### PR TITLE
Ensure that gate always returns the application name.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -52,6 +52,9 @@ class ApplicationController {
     def result = applicationService.get(name)
     if (!result) {
       new ApplicationNotFoundException("Application ${name} not found")
+    } else if (!result.name) {
+      // applicationService.get() doesn't set the name unless clusters are found. Deck requires the name.
+      result.name = name
     }
     result
   }


### PR DESCRIPTION
Without this fix, gate only returns the application name if clusters are found.
Deck requires the application name so that a user can create a server group in an empty Application. If the application name is not returned by gate, the user can work all the way through the Create/Clone dialog,
submit the command, and the operation will fail because there is no application specified.
The name is included in the application's attributes, but it would make the code in Deck quite ugly to go looking for it there.
Without this fix, `applicationService.get(name)` return a map with these keys if clusters are found: `[name, attributes, clusters]` and a map with these keys if clusters are not found: `[attributes]`.
