### PR TITLE
adds a flag to the onelogin config to requireAuthentication

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/OneLoginSecurityConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/OneLoginSecurityConfig.groovy
@@ -35,7 +35,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
-import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.RememberMeServices
@@ -60,15 +59,27 @@ class OneLoginSecurityConfig extends WebSecurityConfigurerAdapter {
   @ConfigurationProperties("onelogin")
   static class OneLoginSecurityConfigProperties {
     Boolean enabled
+    Boolean requireAuthentication
     String url
     String certificate
     String redirectBase
     String requiredRole
   }
 
+  @Autowired
+  OneLoginSecurityConfigProperties oneLoginSecurityConfigProperties
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-    http.csrf().disable().rememberMe().rememberMeServices(rememberMeServices())
+
+    http.csrf().disable()
+       .rememberMe().rememberMeServices(rememberMeServices())
+    if (oneLoginSecurityConfigProperties.requireAuthentication) {
+      http.authorizeRequests()
+              .antMatchers('/auth/**').permitAll()
+              .antMatchers('/**').authenticated()
+          .and()
+    }
   }
 
   @Bean


### PR DESCRIPTION
if present, all requests aside from the /auth endpoint require and authenticated session.

effectively disables access from the api client for scripting, but supports a browser only mode

we can add a different supported auth mechanism for scripting clients to authenticate in the future and
make this a non optional flag
