### PR TITLE
remove stash docs

### DIFF
--- a/gate-manual/src/asciidoc/index.adoc
+++ b/gate-manual/src/asciidoc/index.adoc
@@ -16,10 +16,9 @@ Spinnaker's Gateway API service exposes a RESTful HTTP API, where orchestrated s
 
 == Spinnaker Java Client
 
-Spinnaker provides a zero-dependency Java client for developers to be able to write applications against the platform.
+Spinnaker will provide a zero-dependency Java client for developers to be able to write applications against the platform.
 
 - - -
-include::client.adoc[]
 - - -
 
 == Orchestrated Operations


### PR DESCRIPTION
It is debatable whether the client docs should be in this project at all. Since it is a separate library javadoc seems more appropriate.
I left the placeholder here and the original documentation for reference. This is just to keep new users from finding it until it is ready.
