### PR TITLE
supports front50 service config to filter apps by account

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/ServiceConfiguration.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/ServiceConfiguration.groovy
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
 @ConfigurationProperties
 class ServiceConfiguration {
   List<String> discoveryHosts
-  Map<String, Service> services
+  Map<String, Service> services = [:]
 
   @Autowired
   ApplicationContext ctx


### PR DESCRIPTION
- adds oort cluster accounts to account application names
- if includedAccounts is provided as a comma separated list in service configuration, 
  only apps matching an includedAccount are returned in the application list
