### PR TITLE
Anonymous users will be granted `anonymous.allowedAccounts` (not enab…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAuto
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.embedded.ServletRegistrationBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.context.web.SpringBootServletInitializer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -31,6 +32,7 @@ import org.springframework.scheduling.annotation.EnableAsync
 
 @EnableAsync
 @Configuration
+@EnableConfigurationProperties
 @ComponentScan(["com.netflix.spinnaker.gate", "com.netflix.spinnaker.config"])
 @EnableAutoConfiguration(exclude = [SecurityAutoConfiguration, GroovyTemplateAutoConfiguration])
 class Main extends SpringBootServletInitializer {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousSecurityConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousSecurityConfig.groovy
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.gate.security.anonymous
+
+import com.netflix.spinnaker.gate.security.WebSecurityAugmentor
+import com.netflix.spinnaker.security.User
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AnonymousAuthenticationProvider
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter
+
+@ConditionalOnExpression('${anonymous.enabled:false}')
+@Configuration
+@ConfigurationProperties(prefix = "anonymous")
+class AnonymousSecurityConfig implements WebSecurityAugmentor {
+  String key = "spinnaker-anonymous"
+  Collection<String> allowedAccounts = []
+
+  @Override
+  void configure(HttpSecurity http,
+                 UserDetailsService userDetailsService,
+                 AuthenticationManager authenticationManager) {
+    def filter = new AnonymousAuthenticationFilter(
+      key, new User("anonymous", null, null, ["anonymous"], allowedAccounts), [new SimpleGrantedAuthority("anonymous")]
+    )
+    http.addFilter(filter)
+    http.csrf().disable()
+  }
+
+  @Override
+  void configure(AuthenticationManagerBuilder auth) {
+    auth.authenticationProvider(new AnonymousAuthenticationProvider(key))
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationProvider.groovy
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.gate.security.x509
 
+import com.netflix.spinnaker.gate.security.anonymous.AnonymousSecurityConfig
 import com.netflix.spinnaker.security.User
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.core.Authentication
@@ -22,6 +23,12 @@ class X509AuthenticationProvider implements AuthenticationProvider {
   */
   private static final String RFC822_NAME_ID = "1"
 
+  private final Collection<String> anonymousAllowedAccounts
+
+  X509AuthenticationProvider(Collection<String> anonymousAllowedAccounts) {
+    this.anonymousAllowedAccounts = anonymousAllowedAccounts ?: []
+  }
+
   @Override
   Authentication authenticate(Authentication authentication) throws AuthenticationException {
     def x509 = (X509Certificate) authentication.credentials
@@ -30,7 +37,7 @@ class X509AuthenticationProvider implements AuthenticationProvider {
     }?.get(1) ?: authentication.principal
 
     return new PreAuthenticatedAuthenticationToken(
-      new User(rfc822Name as String, null, null, [], []),
+      new User(rfc822Name as String, null, null, [], anonymousAllowedAccounts),
       authentication.credentials)
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509SecurityConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509SecurityConfig.groovy
@@ -1,8 +1,9 @@
 package com.netflix.spinnaker.gate.security.x509
 
 import com.netflix.spinnaker.gate.security.WebSecurityAugmentor
+import com.netflix.spinnaker.gate.security.anonymous.AnonymousSecurityConfig
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -12,8 +13,10 @@ import org.springframework.security.web.authentication.preauth.x509.X509Authenti
 
 @ConditionalOnExpression('${x509.enabled:false}')
 @Configuration
-@EnableConfigurationProperties
 class X509SecurityConfig implements WebSecurityAugmentor {
+  @Autowired(required = false)
+  AnonymousSecurityConfig anonymousSecurityConfig
+
   @Override
   void configure(HttpSecurity http,
                  UserDetailsService userDetailsService,
@@ -27,6 +30,6 @@ class X509SecurityConfig implements WebSecurityAugmentor {
 
   @Override
   void configure(AuthenticationManagerBuilder auth) {
-    auth.authenticationProvider(new X509AuthenticationProvider())
+    auth.authenticationProvider(new X509AuthenticationProvider(anonymousSecurityConfig?.allowedAccounts))
   }
 }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/OneLoginSecurityConfigSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/OneLoginSecurityConfigSpec.groovy
@@ -2,8 +2,10 @@ package com.netflix.spinnaker.gate.config
 
 import com.netflix.spinnaker.gate.security.onelogin.saml.Response
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class OneLoginSecurityConfigSpec extends Specification {
+  @Unroll
   void "should parse LDAP CN's into roles"() {
     given:
     def oneLoginSecurityConfig = new OneLoginSecurityConfig.OneLoginSecurityConfigProperties(
@@ -13,19 +15,25 @@ class OneLoginSecurityConfigSpec extends Specification {
     def response = Mock(Response) {
       1 * getAttributes() >> { [memberOf: [commonNames]] }
       1 * getNameId() >> { "test@netflix.com" }
-      1 * getAttribute("User.FirstName") >> { "FirstName"}
-      1 * getAttribute("User.LastName") >> { "LastName"}
+      1 * getAttribute("User.FirstName") >> { "FirstName" }
+      1 * getAttribute("User.LastName") >> { "LastName" }
       0 * _
     }
 
     when:
-    def user = OneLoginSecurityConfig.OneLoginSecurityController.buildUser(oneLoginSecurityConfig, response)
+    def user = OneLoginSecurityConfig.OneLoginSecurityController.buildUser(oneLoginSecurityConfig, response, allowedAnonymousAccounts)
 
     then:
     user.email == "test@netflix.com"
     user.firstName == "FirstName"
     user.lastName == "LastName"
     user.roles == ["groupa", "groupb"]
-    user.allowedAccounts == ["test"]
+    user.allowedAccounts.sort() == expectedAllowedAccounts
+
+    where:
+    allowedAnonymousAccounts || expectedAllowedAccounts
+    ["anonymous"]            || ["anonymous", "test"]
+    []                       || ["test"]
+    null                     || ["test"]
   }
 }


### PR DESCRIPTION
…led by default)
- Users authenticated via OneLogin will be granted `anonymous.allowedAccounts` + any accounts granted to their specific groups
- Users authenticated via x509 will be granted `anonymous.allowedAccounts`
