### PR TITLE
add eTag filter

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -19,10 +19,13 @@ package com.netflix.spinnaker.gate.config
 import com.netflix.spectator.api.ExtendedRegistry
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.ShallowEtagHeaderFilter
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+import javax.servlet.Filter
 
 @Configuration
 @ComponentScan
@@ -37,5 +40,10 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
         extendedRegistry, "controller.invocations", ["account", "region"], ["BasicErrorController"]
       )
     )
+  }
+
+  @Bean
+  Filter eTagFilter() {
+    new ShallowEtagHeaderFilter()
   }
 }


### PR DESCRIPTION
We had this in Oort, Kato, and possibly Orca, and it helped a bit on performance, especially on result sets that do not change frequently.
