### PR TITLE
Split the orca pipeline/task retrieval out of ApplicationService and …

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/HystrixFactory.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/HystrixFactory.groovy
@@ -29,33 +29,45 @@ class HystrixFactory {
     HystrixCommandGroupKey.Factory.asKey(name)
   }
 
-  public static ListCommand newListCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback,
-                                           Closure<? extends List> work) {
-    new ListCommand(groupKey, commandKey, withLastKnownGoodFallback, propagate(work, false))
+  public static ListCommand newListCommand(String groupKey,
+                                           String commandKey,
+                                           boolean withLastKnownGoodFallback,
+                                           Closure<? extends List> work,
+                                           Closure<? extends List> fallback = { null }) {
+    new ListCommand(groupKey, commandKey, withLastKnownGoodFallback, propagate(work, false), fallback)
   }
 
-  public static ListCommand newListCommand(String groupKey, String commandKey, Closure<? extends List> work) {
-    new ListCommand(groupKey, commandKey, false, propagate(work, false))
+  public static ListCommand newListCommand(String groupKey,
+                                           String commandKey,
+                                           Closure<? extends List> work,
+                                           Closure<? extends List> fallback = { null }) {
+    new ListCommand(groupKey, commandKey, false, propagate(work, false), fallback)
   }
 
-  public static MapCommand newMapCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback,
-                                         Closure<? extends Map> work) {
-    new MapCommand(groupKey, commandKey, withLastKnownGoodFallback, propagate(work, false))
+  public static MapCommand newMapCommand(String groupKey,
+                                         String commandKey,
+                                         boolean withLastKnownGoodFallback,
+                                         Closure<? extends Map> work,
+                                         Closure<? extends Map> fallback = { null }) {
+    new MapCommand(groupKey, commandKey, withLastKnownGoodFallback, propagate(work, false), fallback)
   }
 
-  public static MapCommand newMapCommand(String groupKey, String commandKey, Closure<? extends Map> work) {
-    new MapCommand(groupKey, commandKey, false, propagate(work, false))
+  public static MapCommand newMapCommand(String groupKey,
+                                         String commandKey,
+                                         Closure<? extends Map> work,
+                                         Closure<? extends List> fallback = { null }) {
+    new MapCommand(groupKey, commandKey, false, propagate(work, false), fallback)
   }
 
   private static class ListCommand extends AbstractHystrixCommand<List> {
-    ListCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback, Closure work) {
-      super(groupKey, commandKey, withLastKnownGoodFallback, [], work)
+    ListCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback, Closure work, Closure fallback) {
+      super(groupKey, commandKey, withLastKnownGoodFallback, [], work, fallback)
     }
   }
 
   private static class MapCommand extends AbstractHystrixCommand<Map> {
-    MapCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback, Closure work) {
-      super(groupKey, commandKey, withLastKnownGoodFallback, [:], work)
+    MapCommand(String groupKey, String commandKey, boolean withLastKnownGoodFallback, Closure work, Closure fallback) {
+      super(groupKey, commandKey, withLastKnownGoodFallback, [:], work, fallback)
     }
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.services.ApplicationService
+import com.netflix.spinnaker.gate.services.ExecutionHistoryService
 import com.netflix.spinnaker.gate.services.PipelineService
 import com.netflix.spinnaker.gate.services.TaskService
 import groovy.transform.CompileStatic
@@ -37,6 +38,9 @@ class ApplicationController {
 
   @Autowired
   ApplicationService applicationService
+
+  @Autowired
+  ExecutionHistoryService executionHistoryService
 
   @Autowired
   TaskService taskService
@@ -64,12 +68,12 @@ class ApplicationController {
 
   @RequestMapping(value = "/{name}/tasks", method = RequestMethod.GET)
   List getTasks(@PathVariable("name") String name) {
-    applicationService.getTasks(name)
+    executionHistoryService.getTasks(name)
   }
 
   @RequestMapping(value = "/{name}/pipelines", method = RequestMethod.GET)
   List getPipelines(@PathVariable("name") String name) {
-    applicationService.getPipelines(name)
+    executionHistoryService.getPipelines(name)
   }
 
   /**

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -16,13 +16,11 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.google.common.base.Preconditions
 import com.netflix.spinnaker.gate.config.Service
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OortService
-import com.netflix.spinnaker.gate.services.internal.OrcaService
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -36,6 +34,7 @@ import retrofit.converter.ConversionException
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicReference
 
 @CompileStatic
 @Component
@@ -50,32 +49,34 @@ class ApplicationService {
   OortService oortService
 
   @Autowired
-  OrcaService orcaService
-
-  @Autowired
   Front50Service front50Service
-
-  @Autowired
-  CredentialsService credentialsService
 
   @Autowired
   ExecutorService executorService
 
+  private AtomicReference<List<Map>> allApplicationsCache = new AtomicReference<>([])
+
   List<Map> getAll() {
     def applicationListRetrievers = buildApplicationListRetrievers()
 
-    HystrixFactory.newListCommand(GROUP, "getAll", true) {
+    HystrixFactory.newListCommand(GROUP, "getAll", true, {
       List<Future<List<Map>>> futures = executorService.invokeAll(applicationListRetrievers)
       List<List<Map>> all = futures.collect { it.get() } // spread operator doesn't work here; no clue why.
       List<Map> flat = (List<Map>) all?.flatten()?.toList()
-      mergeApps(flat, serviceConfiguration.getService('front50')).collect { it.attributes }
-    } execute()
+      def mergedApplications = mergeApps(flat, serviceConfiguration.getService('front50')).collect {
+        it.attributes
+      } as List<Map>
+
+      allApplicationsCache.set(mergedApplications)
+
+      return mergedApplications
+    }, { return allApplicationsCache.get() }).execute()
   }
 
   Map get(String name) {
     def applicationRetrievers = buildApplicationRetrievers(name)
 
-    HystrixFactory.newMapCommand(GROUP, "getAppByName", true) {
+    HystrixFactory.newMapCommand(GROUP, "getAppByName", true, {
       try {
         def futures = executorService.invokeAll(applicationRetrievers)
         List<Map> applications = (List<Map>) futures.collect { it.get() }
@@ -86,21 +87,7 @@ class ApplicationService {
         log.error("Unable to retrieve application '${name}'", e)
         throw e
       }
-    } execute()
-  }
-
-  List getTasks(String app) {
-    Preconditions.checkNotNull(app)
-    HystrixFactory.newListCommand(GROUP, "getTasksForApp", true) {
-      orcaService.getTasks(app)
-    } execute()
-  }
-
-  List getPipelines(String app) {
-    Preconditions.checkNotNull(app)
-    HystrixFactory.newListCommand(GROUP, "getPipelinesForApp", true) {
-      orcaService.getPipelines(app)
-    } execute()
+    }, { allApplicationsCache.get().find { it.name.toString().equalsIgnoreCase(name) } }).execute()
   }
 
   List<Map> getPipelineConfigs(String app) {
@@ -124,34 +111,19 @@ class ApplicationService {
 
   private Collection<Callable<List<Map>>> buildApplicationListRetrievers() {
     def globalAccounts = front50Service.credentials.findAll { it.global == true }.collect { it.name } as List<String>
-    if (globalAccounts) {
-      return globalAccounts.collectMany { String globalAccount ->
-        [new ApplicationListRetriever(globalAccount, front50Service), new OortApplicationsRetriever(oortService)]
-      } as Collection<Callable<List<Map>>>
-    }
-
-    return (credentialsService.accounts.collectMany {
-      [new ApplicationListRetriever((String) it.name, front50Service), new OortApplicationsRetriever(oortService)]
-    } as Collection<Callable<List<Map>>>)
+    return globalAccounts.collectMany { String globalAccount ->
+      [new ApplicationListRetriever(globalAccount, front50Service), new OortApplicationsRetriever(oortService)]
+    } as Collection<Callable<List<Map>>>
   }
 
   private Collection<Callable<Map>> buildApplicationRetrievers(String applicationName) {
     def globalAccounts = front50Service.credentials.findAll { it.global == true }.collect { it.name } as List<String>
-    if (globalAccounts) {
-      return globalAccounts.collectMany { String globalAccount ->
-        [
-          new Front50ApplicationRetriever(globalAccount, applicationName, front50Service),
-          new OortApplicationRetriever(applicationName, oortService)
-        ]
-      } as Collection<Callable<Map>>
-    }
-
-    return (credentialsService.accounts.collectMany {
+    return globalAccounts.collectMany { String globalAccount ->
       [
-        new Front50ApplicationRetriever((String) it.name, applicationName, front50Service),
+        new Front50ApplicationRetriever(globalAccount, applicationName, front50Service),
         new OortApplicationRetriever(applicationName, oortService)
       ]
-    } as Collection<Callable<Map>>)
+    } as Collection<Callable<Map>>
   }
 
   @CompileDynamic
@@ -165,7 +137,7 @@ class ApplicationService {
       }
       Map<String, Map<String, Object>> merged = [:]
       for (Map<String, Object> app in applications) {
-        if (!app) continue
+        if (!app || !app.name) continue
         String key = (app.name as String)?.toLowerCase()
         if (key && !merged.containsKey(key)) {
           merged[key] = [name: key, attributes: [:], clusters: [:]] as Map<String, Object>

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.gate.services
+
+import com.google.common.base.Preconditions
+import com.netflix.spinnaker.gate.services.commands.HystrixFactory
+import com.netflix.spinnaker.gate.services.internal.OrcaService
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@CompileStatic
+@Component
+@Slf4j
+class ExecutionHistoryService {
+  private static final String GROUP = "executionHistory"
+
+  @Autowired
+  OrcaService orcaService
+
+  List getTasks(String app) {
+    Preconditions.checkNotNull(app)
+    HystrixFactory.newListCommand(GROUP, "getTasksForApp", true) {
+      orcaService.getTasks(app)
+    } execute()
+  }
+
+  List getPipelines(String app) {
+    Preconditions.checkNotNull(app)
+    HystrixFactory.newListCommand(GROUP, "getPipelinesForApp", true) {
+      orcaService.getPipelines(app)
+    } execute()
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ExecutionHistoryServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ExecutionHistoryServiceSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.gate
+
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext
+import com.netflix.spinnaker.gate.services.ApplicationService
+import com.netflix.spinnaker.gate.services.ExecutionHistoryService
+import com.netflix.spinnaker.gate.services.internal.OrcaService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ExecutionHistoryServiceSpec extends Specification {
+  @Unroll
+  def "should fall back to last known good result if Orca times out getting #list"() {
+    setup:
+    HystrixRequestContext.initializeContext()
+
+    def service = new ExecutionHistoryService()
+    service.orcaService = Mock(OrcaService)
+
+    and:
+    service.orcaService."$methodName"(app) >> [] >> { throw new SocketTimeoutException() }
+
+    expect:
+    service."$methodName"(app) == []
+
+    and:
+    service."$methodName"(app) == []
+
+    where:
+    app = "bivl"
+    list << ["tasks", "pipelines"]
+    methodName = "get" + list.capitalize()
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.controllers.ApplicationController
 import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.CredentialsService
+import com.netflix.spinnaker.gate.services.ExecutionHistoryService
 import com.netflix.spinnaker.internal.services.TagService
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.internal.services.internal.FlapJackService
@@ -49,6 +50,7 @@ class FunctionalSpec extends Specification {
   Api api
 
   static ApplicationService applicationService
+  static ExecutionHistoryService executionHistoryService
   static ExecutorService executorService
   static Front50Service front50Service
   static MortService mortService
@@ -63,6 +65,7 @@ class FunctionalSpec extends Specification {
 
   void setup() {
     applicationService = Mock(ApplicationService)
+    executionHistoryService = Mock(ExecutionHistoryService)
     executorService = Mock(ExecutorService)
     taskService = Mock(TaskService)
     oortService = Mock(OortService)
@@ -133,7 +136,7 @@ class FunctionalSpec extends Specification {
       api.getTasks(name)
 
     then:
-      1 * applicationService.getTasks(name) >> []
+      1 * executionHistoryService.getTasks(name) >> []
 
     where:
       name = "foo"
@@ -183,6 +186,11 @@ class FunctionalSpec extends Specification {
     @Bean
     ApplicationService applicationService() {
       applicationService
+    }
+
+    @Bean
+    ExecutionHistoryService executionHistoryService() {
+      executionHistoryService
     }
 
     @Bean


### PR DESCRIPTION
…into ExecutionHistoryService
- ApplicationService now only considers global application registries
- ApplicationService will use last known good values as it's Hystrix fallback (as refreshed by all())
