### PR TITLE
Fixes XSS vulnerability with default Spring error attributes

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -19,12 +19,16 @@ package com.netflix.spinnaker.gate.config
 import com.netflix.spectator.api.ExtendedRegistry
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes
+import org.springframework.boot.autoconfigure.web.ErrorAttributes
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.context.request.RequestAttributes
 import org.springframework.web.filter.ShallowEtagHeaderFilter
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+
 import javax.servlet.Filter
 
 @Configuration
@@ -45,5 +49,27 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
   @Bean
   Filter eTagFilter() {
     new ShallowEtagHeaderFilter()
+  }
+
+  @Bean
+  ErrorAttributes errorAttributes() {
+    return new ErrorAttributes() {
+
+      DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes()
+
+      @Override
+      Map<String, Object> getErrorAttributes(RequestAttributes attrs, boolean includeStackTrace) {
+        Map<String, Object> errorAttributes = defaultErrorAttributes.getErrorAttributes(attrs, includeStackTrace)
+        // By default, Spring echoes back the user's requested path. This opens up a potential XSS vulnerability where a
+        // user, for example, requests "GET /<script>alert('Hi')</script> HTTP/1.1".
+        errorAttributes.remove("path")
+        return errorAttributes
+      }
+
+      @Override
+      Throwable getError(RequestAttributes requestAttributes) {
+        return defaultErrorAttributes.getError(requestAttributes)
+      }
+    }
   }
 }


### PR DESCRIPTION
Migrates same fix from https://github.com/spinnaker/orca/pull/588 to Gate

@ajordens , @anotherchrisberry - I looked across Deck, and nothing looks to explicitly use the 'path' element. Do you know of any internal users who script against Gate that, for whatever reason, _expect_ 404 errors?

@duftler FYI 
