### PR TITLE
Load properties straight into Spring Boot

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -15,10 +15,8 @@
  */
 
 package com.netflix.spinnaker.gate
-
 import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorConfig
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
@@ -48,23 +46,13 @@ class Main extends SpringBootServletInitializer {
           'spring.profiles.active': "${System.getProperty('netflix.environment', 'test')},local"
   ]
 
-  static {
-    applyDefaults()
-  }
-
-  static void applyDefaults() {
-    DEFAULT_PROPS.each { k, v ->
-      System.setProperty(k, System.getProperty(k, v))
-    }
-  }
-
   static void main(String... args) {
-    SpringApplication.run this, args
+    new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)
   }
 
   @Override
   SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-    builder.sources(Main)
+    builder.properties(DEFAULT_PROPS).sources(Main)
   }
 
   @Bean


### PR DESCRIPTION
The current mechanism of writing default propeties straight into the environment breaks the Spring property lifecycle, making it impossible to override certain settings. This path does what's intended, load the default properties into the Spring Boot application builder while still allowing overrides.
