### PR TITLE
Periodically refresh `allApplicationsCache` rather than relying on Ap…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -29,10 +29,6 @@ interface OrcaService {
   List getTasks(@Path("application") String app)
 
   @Headers("Accept: application/json")
-  @GET("/applications/{application}/pipelines")
-  List getPipelines(@Path("application") String app)
-
-  @Headers("Accept: application/json")
   @GET("/v2/applications/{application}/pipelines")
   List getPipelinesV2(@Path("application") String app, @Query("limit") int limit)
 

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -230,6 +230,7 @@ class ApplicationServiceSpec extends Specification {
     def front50App = [name: name.toLowerCase(), email: email]
 
     when:
+    service.tick()
     def apps = service.getAll()
 
     then:
@@ -243,6 +244,7 @@ class ApplicationServiceSpec extends Specification {
     apps[0].clusters == null
 
     when: "should return last known good values if an exception is thrown"
+    service.tick()
     def allApps = service.getAll()
     def singleApp = service.get(name)
 


### PR DESCRIPTION
…plicationService.getAll()
- Applications rarely change, so take advantage of the fallback cache rather than paying the expense to constantly query clouddriver
