### PR TITLE
Execution endpoints now support `statuses` and `limit` query parameters

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -70,16 +70,19 @@ class ApplicationController {
   }
 
   @RequestMapping(value = "/{application}/tasks", method = RequestMethod.GET)
-  List getTasks(@PathVariable("application") String application) {
-    executionHistoryService.getTasks(application)
+  List getTasks(@PathVariable("application") String application,
+                @RequestParam(value = "limit", required = false) Integer limit,
+                @RequestParam(value = "statuses", required = false) String statuses) {
+    executionHistoryService.getTasks(application, limit, statuses)
   }
 
   @RequestMapping(value = "/{application}/pipelines", method = RequestMethod.GET)
   List getPipelines(@PathVariable("application") String application,
-                    @RequestParam(value = "limit", required = false) Integer limit) {
+                    @RequestParam(value = "limit", required = false) Integer limit,
+                    @RequestParam(value = "statuses", required = false) String statuses) {
     def listLimit = limit ?: environment.getProperty(PIPELINE_EXECUTION_LIMIT, Integer, 10)
     log.info("execution fetch limit: ${listLimit}")
-    executionHistoryService.getPipelines(application, listLimit)
+    executionHistoryService.getPipelines(application, listLimit, statuses)
   }
 
   /**

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
@@ -53,8 +53,9 @@ class ProjectController {
 
   @RequestMapping(value = "/{id:.+}/pipelines", method = RequestMethod.GET)
   List<Map> allPipelinesForProject(@PathVariable("id") String projectId,
-                                   @RequestParam(value = "limit", defaultValue = "5") int limit) {
-    return projectService.getAllPipelines(projectId, limit)
+                                   @RequestParam(value = "limit", defaultValue = "5") int limit,
+                                   @RequestParam(value = "statuses", required = false) String statuses) {
+    return projectService.getAllPipelines(projectId, limit, statuses)
   }
 
   @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.gate.services
 
 import com.google.common.base.Preconditions
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.commands.ThrottledRequestException
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -33,19 +32,19 @@ class ExecutionHistoryService {
   @Autowired
   OrcaService orcaService
 
-  List getTasks(String app) {
+  List getTasks(String app, Integer limit, String statuses) {
     Preconditions.checkNotNull(app)
 
     def command = HystrixFactory.newListCommand("taskExecutionHistory", "getTasksForApp") {
-      orcaService.getTasks(app)
+      orcaService.getTasks(app, limit, statuses)
     }
     return command.execute()
   }
 
-  List getPipelines(String app, int limit) {
+  List getPipelines(String app, Integer limit, String statuses) {
     Preconditions.checkNotNull(app)
     def command = HystrixFactory.newListCommand("pipelineExecutionHistory", "getPipelinesForApp") {
-      orcaService.getPipelinesV2(app, limit)
+      orcaService.getPipelines(app, limit, statuses)
     }
     return command.execute()
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -49,9 +49,9 @@ class ProjectService {
     } execute()
   }
 
-  List<Map> getAllPipelines(String projectId, int limit) {
+  List<Map> getAllPipelines(String projectId, int limit, String statuses) {
     HystrixFactory.newListCommand(GROUP, "getAllPipelines") {
-      return orcaService.getPipelinesForProject(projectId, limit)
+      return orcaService.getPipelinesForProject(projectId, limit, statuses)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -26,15 +26,15 @@ interface OrcaService {
 
   @Headers("Accept: application/json")
   @GET("/applications/{application}/tasks")
-  List getTasks(@Path("application") String app)
+  List getTasks(@Path("application") String app, @Query("limit") Integer limit, @Query("statuses") String statuses)
 
   @Headers("Accept: application/json")
   @GET("/v2/applications/{application}/pipelines")
-  List getPipelinesV2(@Path("application") String app, @Query("limit") int limit)
+  List getPipelines(@Path("application") String app, @Query("limit") Integer limit, @Query("statuses") String statuses)
 
   @Headers("Accept: application/json")
   @GET("/projects/{projectId}/pipelines")
-  List<Map> getPipelinesForProject(@Path("projectId") String projectId, @Query("limit") int limit)
+  List<Map> getPipelinesForProject(@Path("projectId") String projectId, @Query("limit") Integer limit, @Query("statuses") String statuses)
 
   @Headers("Accept: application/json")
   @GET("/tasks/{id}")

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/Api.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/Api.groovy
@@ -27,7 +27,7 @@ interface Api {
   Map getApplication(@Path("name") String name)
 
   @GET("/applications/{name}/tasks")
-  List getTasks(@Path("name") String name)
+  List getTasks(@Path("name") String name, @Query("limit") Integer limit, @Query("statuses") String statuses)
 
   @POST("/applications/{name}/tasks")
   Map createTask(@Path("name") String name, @Body Map body)

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -136,10 +136,10 @@ class FunctionalSpec extends Specification {
 
   void "should call ApplicationService for an application's tasks"() {
     when:
-      api.getTasks(name)
+      api.getTasks(name, null, "RUNNING,TERMINAL")
 
     then:
-      1 * orcaService.getTasks(name) >> []
+      1 * orcaService.getTasks(name, null, "RUNNING,TERMINAL") >> []
 
     where:
       name = "foo"
@@ -159,24 +159,24 @@ class FunctionalSpec extends Specification {
 
   void "should throw ThrottledRequestException if result served from hystrix fallback"() {
     when:
-    def tasks = executionHistoryService.getTasks("app")
+    def tasks = executionHistoryService.getTasks("app", 5, null)
 
     then:
-    1 * orcaService.getTasks("app") >> { return ["1"] }
+    1 * orcaService.getTasks("app", 5, null) >> { return ["1"] }
     tasks == ["1"]
 
     when:
-      executionHistoryService.getTasks("app")
+      executionHistoryService.getTasks("app", 10, "RUNNING")
 
     then:
-      1 * orcaService.getTasks("app") >> { throw new IllegalStateException() }
+      1 * orcaService.getTasks("app", 10, "RUNNING") >> { throw new IllegalStateException() }
       thrown(ThrottledRequestException)
 
     when:
-    executionHistoryService.getPipelines("app", 5)
+    executionHistoryService.getPipelines("app", 5, "TERMINAL")
 
     then:
-    1 * orcaService.getPipelinesV2("app", 5) >> { throw new IllegalStateException() }
+    1 * orcaService.getPipelines("app", 5, "TERMINAL") >> { throw new IllegalStateException() }
     thrown(ThrottledRequestException)
   }
 


### PR DESCRIPTION
- Passed straight through the orca
- `statuses` is a comma-separated list of execution statuses
