### PR TITLE
Hystrix properties can now be overridden in `hystrix.properties`

### DIFF
--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -22,6 +22,6 @@ dependencies {
   compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency("groovy")
   compile 'org.springframework.security.oauth:spring-security-oauth2:2.0.7.RELEASE'
-  compile 'com.netflix.hystrix:hystrix-core:1.4.0-RC5'
-  compile 'com.netflix.hystrix:hystrix-metrics-event-stream:1.4.0-RC5'
+  compile 'com.netflix.hystrix:hystrix-core:1.4.20'
+  compile 'com.netflix.hystrix:hystrix-metrics-event-stream:1.4.20'
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/AbstractHystrixCommand.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/AbstractHystrixCommand.groovy
@@ -40,8 +40,7 @@ abstract class AbstractHystrixCommand<T> extends HystrixCommand<T> {
                                 Closure fallback) {
     super(HystrixCommand.Setter.withGroupKey(toGroupKey(groupKey))
         .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey))
-        .andCommandPropertiesDefaults(createHystrixCommandPropertiesSetter()
-        .withExecutionIsolationThreadTimeoutInMilliseconds(60000)))
+        .andCommandPropertiesDefaults(createHystrixCommandPropertiesSetter()))
     this.groupKey = groupKey
     this.commandKey = commandKey
     this.work = work
@@ -54,7 +53,7 @@ abstract class AbstractHystrixCommand<T> extends HystrixCommand<T> {
   }
 
   protected T getFallback() {
-    return (fallback.call() as T) ?: null
+    return (fallback.call() as T)
   }
 
   @Override

--- a/gate-web/config/hystrix.properties
+++ b/gate-web/config/hystrix.properties
@@ -1,0 +1,5 @@
+## Hystrix Global Defaults
+hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=60000
+
+## Command-specific overrides
+hystrix.command.fetchGlobalAccounts.execution.isolation.thread.timeoutInMilliseconds=2000

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -98,4 +98,8 @@ buildRpm {
   dependsOn installDist
 }
 
+tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
+  classpath configurations.runtime + file('config')
+}
+
 tasks.bootRepackage.enabled = false

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -15,6 +15,8 @@
  */
 
 package com.netflix.spinnaker.gate
+
+import com.netflix.config.ConfigurationManager
 import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorConfig
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -46,6 +48,10 @@ class Main extends SpringBootServletInitializer {
           'spring.config.name': 'spinnaker,${spring.application.name}',
           'spring.profiles.active': '${netflix.environment},local'
   ]
+
+  static {
+    ConfigurationManager.loadCascadedPropertiesFromResources("hystrix")
+  }
 
   static void main(String... args) {
     new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)


### PR DESCRIPTION
- Removed the hardcoded 60s default timeout (similarly replaced in hystrix.properties)
- Bumped hystrix to 1.4.20
- Added specific hystrix wrappers around Cloud Driver and Front50 in ApplicationService (should be more resilient around failures to only one of CD or F50)