### PR TITLE
Caching `globalAccounts` from Front50 allows us to withstand a comple…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -62,6 +62,7 @@ class ApplicationService {
   ExecutorService executorService
 
   private AtomicReference<List<Map>> allApplicationsCache = new AtomicReference<>([])
+  private AtomicReference<List<String>> globalAccountsCache = new AtomicReference<>([])
 
   @PostConstruct
   void startMonitoring() {
@@ -187,8 +188,9 @@ class ApplicationService {
 
   private Collection<String> fetchGlobalAccounts() {
     HystrixFactory.newListCommand(GROUP, "fetchGlobalAccounts", {
-      front50Service.credentials.findAll { it.global == true }.collect { it.name }
-    }, { [] }).execute()
+      globalAccountsCache.set(front50Service.credentials.findAll { it.global == true }.collect { it.name } as List<String>)
+      return globalAccountsCache.get()
+    }, { globalAccountsCache.get() }).execute()
   }
 
   @CompileDynamic


### PR DESCRIPTION
…te Front50 outage and still serve complete application metadata

- Accounts change very seldom so caching for the purpose of a fallback should have no impact whatsoever