### PR TITLE
Add new SubnetController with allByCloudProvider() entry-point.

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -199,6 +199,9 @@ interface ClouddriverService {
   @GET('/subnets')
   List<Map> getSubnets()
 
+  @GET('/subnets/{cloudProvider}')
+  List<Map> getSubnets(@Path("cloudProvider") String cloudProvider)
+
   @GET('/networks')
   Map getNetworks()
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/subnets")
+class SubnetController {
+
+  @Autowired
+  ClouddriverService clouddriverService
+
+  @RequestMapping(value = "/{cloudProvider}", method = RequestMethod.GET)
+  List<Map> allByCloudProvider(@PathVariable String cloudProvider) {
+    clouddriverService.getSubnets(cloudProvider)
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/aws/InfrastructureService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/aws/InfrastructureService.groovy
@@ -48,9 +48,10 @@ class InfrastructureService {
     } execute()
   }
 
+  @Deprecated
   List<Map> getSubnets() {
     command("subnets") {
-      clouddriverService.subnets
+      clouddriverService.getSubnets('aws')
     } execute()
   }
 


### PR DESCRIPTION
Deprecate existing getSubnets() entry-point in aws.InfrastructureService and have it delegate to allByCloudProvider('aws').
Should be no breaking changes for any caller.