### PR TITLE
guard against no projects present

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -43,7 +43,7 @@ class ProjectService {
 
   List<Map> getAll() {
     HystrixFactory.newListCommand(GROUP, "getAll") {
-      return front50Service.getAllProjects().embedded.projects ?: []
+      return front50Service.getAllProjects().embedded?.projects ?: []
     } execute()
   }
 


### PR DESCRIPTION
If there are no projects configured, there won't be an `embedded` property, so we end up with a NPE.

It might be fixing this on the producer (front 50) - couple of ways to do that are outlined here: http://stackoverflow.com/questions/30286795/how-to-force-spring-hateoas-resources-to-render-an-empty-embedded-array