### PR TITLE
Re-enable X509 authentication

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/UserController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/UserController.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.security.SpinnakerUser
 import com.netflix.spinnaker.security.User
-import org.springframework.security.web.bind.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationProvider.groovy
@@ -58,7 +58,8 @@ class X509AuthenticationProvider implements AuthenticationProvider {
 
     return new PreAuthenticatedAuthenticationToken(
       new User(rfc822Name as String, null, null, [], anonymousAccountsService.allowedAccounts),
-      authentication.credentials)
+      authentication.credentials,
+      [])
   }
 
   @Override


### PR DESCRIPTION
@jtk54 @rwinch PTAL.

I haven't looked, but hopefully Boot 1.3 adds in the ability to override a few hard coded classes in the `http.x509` configurer. 