### PR TITLE
Multi-auth with SAML, NFLX user role extraction from the assertion.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfigurer.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfigurer.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.saml
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+
+/**
+ * Allows the use of additional authentication mechanisms to be tried before the SAML login.
+ */
+interface SamlSsoConfigurer {
+
+  void configure(HttpSecurity http) throws Exception
+}


### PR DESCRIPTION
Finished up the TODO items in https://github.com/spinnaker/gate/pull/208, specifically:

* Hooks in the roles/groupsMemberships that were previously being extracted
* Adds in user roles provider support
* Multi-auth support (aka SAML + X509)

This should mean that only small configuration changes are necessary for any existing installation (including NFLX)

@spinnaker/google-reviewers FYI