### PR TITLE
Adds spring profile templates for Google and Azure OAuth providers.

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -81,13 +81,35 @@ spring:
       SORT_PROPERTIES_ALPHABETICALLY: true
     serialization:
       ORDER_MAP_ENTRIES_BY_KEYS: true
-#  oauth2:
-#      client:
-#        clientId:
-#        clientSecret:
-#        accessTokenUri:
-#        userAuthorizationUri:
-#        scope:
-#          - email
-#      resource:
-#        userInfoUri:
+
+---
+
+spring:
+  profiles: googleOAuth
+  oauth2:
+    client:
+      # Set these values in your own config file (e.g. spinnaker-local.yml or gate-googleOAuth.yml).
+      # clientId:
+      # clientSecret:
+      accessTokenUri: https://www.googleapis.com/oauth2/v4/token
+      userAuthorizationUri: https://accounts.google.com/o/oauth2/v2/auth?access_type=offline
+      scope: "profile email"
+    resource:
+      userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo
+
+
+---
+
+spring:
+  profiles: azureOAuth
+  oauth2:
+    client:
+      # Set these values in your own config file (e.g. spinnaker-local.yml or gate-azureOAuth.yml).
+      # clientId:
+      # clientSecret:
+       accessTokenUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/token
+       userAuthorizationUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/authorize?resource=https://graph.windows.net
+      scope: profile
+      clientAuthenticationScheme: query
+    resource:
+      userInfoUri: https://graph.windows.net/me?api-version=1.6


### PR DESCRIPTION
This PR adds a template with some known values for Google and Azure oauth providers. Users can create `gate-googleOAuth.yml` or `gate-azureOAuth.yml` files in their `~/.spinnaker/` config directories that simply specify the clientID and client secret, like so:

```
spring:
  oauth2:
    client:
      clientId: my-client-id
      clientSecret: my-client-secret
```
To pick up this profile at runtime, invoke  

```
$ ./gradlew -Dspring.profiles.active="local,googleOAuth"
```

@rguthriemsft @scotmoor @spinnaker/google-reviewers 


