### PR TITLE
Auth: added check to invalidate session if user groups change.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
@@ -34,6 +34,11 @@ class AuthConfig {
   UserRolesProvider defaultUserRolesProvider() {
     return new UserRolesProvider() {
       @Override
+      Map<String, Collection<String>> multiLoadRoles(Collection<String> userEmails) {
+        return [:]
+      }
+
+      @Override
       Collection<String> loadRoles(String userEmail) {
         return []
       }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesProvider.groovy
@@ -17,5 +17,21 @@
 package com.netflix.spinnaker.gate.security.rolesprovider
 
 public interface UserRolesProvider {
+
+  /**
+   * Load the roles assigned to the {@link com.netflix.spinnaker.security.User User}.
+   *
+   * @param userEmail
+   * @return Roles assigned to the {@link com.netflix.spinnaker.security.User User} with the given userEmail.
+   */
   public Collection<String> loadRoles(String userEmail)
+
+  /**
+   * Load the roles assigned to each {@link com.netflix.spinnaker.security.User User's} email in userEmails.
+   *
+   * @param userEmails
+   * @return Map whose keys are the {@link com.netflix.spinnaker.security.User User's} email and values are their
+   * assigned roles.
+   */
+  public Map<String, Collection<String>> multiLoadRoles(Collection<String> userEmails)
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncer.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncer.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.rolesprovider
+
+import com.netflix.spinnaker.security.User
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.session.ExpiringSession
+
+@Slf4j
+@Configuration
+class UserRolesSyncer {
+
+  @Autowired
+  RedisTemplate<String, ExpiringSession> redisTemplate
+
+  @Autowired
+  UserRolesProvider userRolesProvider
+
+  /**
+   Check if a user's groups have changed across _ALL_ sessions every 10 minutes, after an initial delay.
+   Invalidate the user's session if his groups have changed.
+   */
+  @Scheduled(initialDelay = 10000L, fixedRate = 600000L)
+  public void syncUserGroups() {
+    log.info("Syncing user groups in sessions")
+    Set<String> sessionKeys = redisTemplate.keys('*session:sessions*')
+    sessionKeys.each { String key ->
+      println key
+      def secCtx = redisTemplate.opsForHash().get(key, "sessionAttr:SPRING_SECURITY_CONTEXT") as SecurityContext
+      println secCtx.toString()
+      def principal = secCtx?.authentication?.principal
+      if (principal && principal instanceof User) {
+        def newRoles = userRolesProvider.loadRoles(principal.email)
+        if (newRoles != principal.roles) {
+          redisTemplate.delete(key)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Added periodic check to invalidate session if user groups change. Invalidating the session will cause the user to re-auth and re-sync the groups, which is much safer and cleaner than updating the groups for a few reasons:

* Updating groups could allow the user to have unnecessary permissions for approximately a session.
* There is a different `Authentication` object for each of {OAuth2, x509, SAML}, updating which results in a lot of unnecessary duplicated code for something that is not incredibly secure.
* Since we now prompt to re-auth from Deck if the session is expired, invalidating the session does not cause the UX to suffer.

Should we reduce the period of when the re-auth checks happen in Deck? As it stands currently, a user might have up to 10 min of unsaved work with no session in Gate from this PR. If the period of the re-auth check were shorter, this would be mitigated significantly. Thoughts on this?

@ttomsu @cberry PTAL.