### PR TITLE
Disables SAML discovery in order to use SSO flow

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -35,7 +35,7 @@ dependencies {
   compile("com.google.api-client:google-api-client:1.21.0")
   compile("com.google.apis:google-api-services-admin-directory:directory_v1-rev65-1.21.0")
   compile("org.springframework.security.extensions:spring-security-saml2-core:1.0.2.RELEASE")
-  compile("org.springframework.security.extensions:spring-security-saml-dsl:1.0.0.M1") {
+  compile("org.springframework.security.extensions:spring-security-saml-dsl:1.0.0.M2") {
     exclude group: 'org.springframework.boot'
     exclude group: 'org.springframework.security'
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -107,6 +107,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           .userDetailsService(samlUserDetailsService)
           .identityProvider()
             .metadataFilePath(samlSecurityConfigProperties.metadataUrl)
+            .discoveryEnabled(false)
             .and()
           .serviceProvider()
             .entityId(samlSecurityConfigProperties.issuerId)


### PR DESCRIPTION
Pulls in M2 release of SAML DSL library where I've added the switch to disable discovery.

@jtk54 PTAL.

@riltsken - Please take this PR for a spin to see if it gets around the issues you were hitting.