### PR TITLE
OAuth load roles from username

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -107,16 +107,16 @@ class OAuth2SsoConfig extends OAuth2SsoConfigurerAdapter {
         OAuth2Authentication oAuth2Authentication = userInfoTokenServices.loadAuthentication(accessToken)
 
         Map details = oAuth2Authentication.userAuthentication.details as Map
-        def email = details[userInfoMapping.email] as String
-        def roles = userRolesProvider.loadRoles(email)
+        def username = details[userInfoMapping.username] as String
+        def roles = userRolesProvider.loadRoles(username)
 
         User spinnakerUser = new User(
-            email: email,
+            email: details[userInfoMapping.email] as String,
             firstName: details[userInfoMapping.firstName] as String,
             lastName: details[userInfoMapping.lastName] as String,
             allowedAccounts: accountsService.getAllowedAccounts(roles),
             roles: roles,
-            username: details[userInfoMapping.username] as String)
+            username: username)
 
         PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
             spinnakerUser,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesProvider.groovy
@@ -21,17 +21,17 @@ public interface UserRolesProvider {
   /**
    * Load the roles assigned to the {@link com.netflix.spinnaker.security.User User}.
    *
-   * @param userEmail
+   * @param userId identify a user. Can be email or username.
    * @return Roles assigned to the {@link com.netflix.spinnaker.security.User User} with the given userEmail.
    */
-  public Collection<String> loadRoles(String userEmail)
+  public Collection<String> loadRoles(String userId)
 
   /**
    * Load the roles assigned to each {@link com.netflix.spinnaker.security.User User's} email in userEmails.
    *
-   * @param userEmails
+   * @param userIds
    * @return Map whose keys are the {@link com.netflix.spinnaker.security.User User's} email and values are their
    * assigned roles.
    */
-  public Map<String, Collection<String>> multiLoadRoles(Collection<String> userEmails)
+  public Map<String, Collection<String>> multiLoadRoles(Collection<String> userIds)
 }


### PR DESCRIPTION
Generify the parameter name of `UserRolesProvider.loadRoles` to `userId` .
OAuth provider should use `username` as `userId` but other Authent systems still use `email`.
OAuth provider user mapping should define `username` : Google use `email` but Github OAuth use `login` because it' the input to get the memberships for a user.

@ttomsu PTAL .

I plan to do another PR to create a `GitHubTeamsUserRolesProvider` based on `GoogleDirectoryUserRolesProvider` 