### PR TITLE
Add /webhooks/{type} into the gate URL mappers.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
@@ -32,4 +32,9 @@ class EventController {
   void webhooks(@PathVariable("type") String type, @PathVariable("source") String source, @RequestBody Map event) {
     eventService.webhooks(type, source, event)
   }
+
+  @RequestMapping(value = "/webhooks/{type}", method = RequestMethod.POST)
+  void webhooks(@PathVariable("type") String type, @RequestBody Map event) {
+    eventService.webhooks(type, event)
+  }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
@@ -33,4 +33,8 @@ class EventService {
     echoService.webhooks(type, source, event)
   }
 
+  void webhooks(String type, Map event) {
+    echoService.webhooks(type, event)
+  }
+
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -25,6 +25,10 @@ interface EchoService {
   @POST("/webhooks/{type}/{source}")
   Response webhooks(@Path('type') String type, @Path('source') String source, @Body Map event)
 
+  @Headers("Accept: application/json")
+  @POST("/webhooks/{type}")
+  Response webhooks(@Path('type') String type, @Body Map event)
+
   @GET("/validateCronExpression")
   Map validateCronExpression(@Query("cronExpression") String cronExpression)
 


### PR DESCRIPTION
Adds the `/webhooks/{type}` URL in echo into the URL space in gate.

Initially, I thought we could use `/webhooks/{type}/{source}` but with an empty `{source}`
However, the mapper in gate would not resolve it and return a 404.

Ultimately with this change, allows https://github.com/spinnaker/echo/pull/85 to work via gate rather than directly at echo.