### PR TITLE
Adds root controller to redirect to Deck's main page

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RootController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RootController.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+import javax.servlet.http.HttpServletResponse
+
+@RestController
+class RootController {
+
+  @Value('${services.deck.baseUrl}')
+  URL deckBaseUrl
+
+  @RequestMapping("/")
+  void root(HttpServletResponse response) {
+    response.sendRedirect(deckBaseUrl.toString())
+  }
+}


### PR DESCRIPTION
The main use case of this controller is to support the case when a user:

1. logs into his SAML provider
1. Clicks the Spinnaker application
1. SAML provider sends login request to `/saml/SSO`, logging in the user.
1. SAML library sends redirect to gate's root
1. This root controller redirects to Deck.

@jtk54 - PTAL

@ajordens @amanya FYI