### PR TITLE
Quick and dirty fix for anon auth not returning credentials

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AccountsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AccountsService.groovy
@@ -23,12 +23,8 @@ import org.springframework.stereotype.Component
 @Component
 class AccountsService {
 
-  private final ClouddriverService clouddriverService
-
   @Autowired
-  AccountsService(ClouddriverService clouddriverService) {
-    this.clouddriverService = clouddriverService
-  }
+  ClouddriverService clouddriverService
 
   /**
    * Returns all account names that a user with the specified list of userRoles has access to.

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -33,7 +33,8 @@ class CredentialsService {
     HystrixFactory.newListCommand(GROUP, "getAccounts") {
       def allAccounts = clouddriverService.accounts
 
-      if (!AuthenticatedRequest.getSpinnakerUser().present) {
+      if (!AuthenticatedRequest.getSpinnakerUser().present ||
+          !AuthenticatedRequest.getSpinnakerAccounts().present) {
         // if the request is unauthenticated, return only anonymously accessible accounts (no group membership required)
         return allAccounts.findAll { !it.requiredGroupMembership }
       }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/AccountsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/AccountsServiceSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class AccountsServiceSpec extends Specification {
+
+
+  @Unroll
+  def "should return allowed account names"() {
+    setup:
+      ClouddriverService clouddriverService = Mock(ClouddriverService) {
+        getAccounts() >> accounts
+      }
+      @Subject AccountsService accountsService = new AccountsService(clouddriverService: clouddriverService)
+
+    when:
+      def allowedAccounts = accountsService.getAllowedAccounts(roles)
+
+    then:
+      allowedAccounts == expectedAccounts
+
+    where:
+      roles              | accounts                       || expectedAccounts
+      ["roleA"]          | [acnt("acntA")]                || ["acntA"]
+      ["roleA"]          | [acnt("acntB")]                || ["acntB"]
+      ["roleA", "roleB"] | [acnt("acntA"), acnt("acntB")] || ["acntA", "acntB"]
+      ["roleA"]          | [acnt("acntA", "roleA")]       || ["acntA"]
+      ["ROLEA"]          | [acnt("acntA", "rolea")]       || ["acntA"]
+      ["roleA"]          | [acnt("acntA", "roleB")]       || []
+      []                 | []                             || []
+      [null]             | []                             || []
+      null               | []                             || []
+  }
+
+  static ClouddriverService.Account acnt(String name, String... reqGroupMembership) {
+    new ClouddriverService.Account(name: name, requiredGroupMembership: reqGroupMembership)
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -53,7 +53,7 @@ class CredentialsServiceSpec extends Specification {
     ["account2"]                         || [accounts[1]]
     ["account1", "account2"]             || accounts
     ["account1", "account2", "account3"] || accounts
-    []                                   || []
-    null                                 || []
+    []                                   || accounts
+    null                                 || accounts
   }
 }


### PR DESCRIPTION
@lwander PTAL, @duftler FYI

Warning: this is a hack. Before my auth changes went in, `AuthenticatedRequest.getSpinnakerUser()` returned null, so requests to the `CredentialsService` would always return all accounts without required group membership.

After the auth changes, `AuthenticatedRequest.getSpinnakerUser()` returned a Kork User that represented an anonymous user with `allowedAccounts: []`. This basically caused the credentials endpoint to become useless for anonymous users. 

This PR adds tests for the AccountsService that was added a while ago and wasn't tested.

Tested with anonymous config and confirmed an instance could be deleted (aka mutating calls work).