### PR TITLE
Only check host and port when validating deck redirect

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
@@ -75,8 +75,7 @@ class AuthController {
       return false
     }
 
-    return toURL.protocol == deckBaseUrl.protocol &&
-        toURL.host == deckBaseUrl.host &&
+    return toURL.host == deckBaseUrl.host &&
         toURL.port == deckBaseUrl.port
   }
 }


### PR DESCRIPTION
- This supports a situation where deck is available under http/https