### PR TITLE
GitHub Teams UserRoles provider

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -41,6 +41,7 @@ dependencies {
     exclude group: 'org.springframework.security'
   }
 
+  compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
   testCompile "com.squareup.okhttp:mockwebserver:${spinnaker.version('okHttp')}"
 
   //this brings in the jetty GzipFilter which boot will autoconfigure

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubConfig.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config
+
+import com.netflix.spinnaker.gate.security.rolesprovider.github.client.GitHubClient
+import com.netflix.spinnaker.gate.security.rolesprovider.github.client.GitHubMaster
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
+
+import javax.validation.Valid
+
+/**
+ * Converts the list of GitHub Configuration properties a collection of clients to access the GitHub hosts
+ */
+@Configuration
+@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "github")
+@Slf4j
+@CompileStatic
+class GitHubConfig {
+
+    @Bean
+    GitHubMaster gitHubMasters(@Valid GitHubProperties gitHubProperties) {
+        log.info "bootstrapping ${gitHubProperties.baseUrl} as github"
+        new GitHubMaster(gitHubClient: gitHubClient(gitHubProperties.baseUrl, gitHubProperties.accessToken),
+                         baseUrl: gitHubProperties.baseUrl)
+    }
+
+    GitHubClient gitHubClient(String address, String accessToken) {
+        new RestAdapter.Builder()
+            .setEndpoint(Endpoints.newFixedEndpoint(address))
+            .setRequestInterceptor(new BasicAuthRequestInterceptor(accessToken))
+            .setClient(new OkClient())
+            .setConverter(new JacksonConverter())
+            .build()
+            .create(GitHubClient)
+
+    }
+
+    static class BasicAuthRequestInterceptor implements RequestInterceptor {
+
+        private final String accessToken
+
+        BasicAuthRequestInterceptor(String accessToken) {
+            this.accessToken = accessToken
+        }
+
+        @Override
+        void intercept(RequestInterceptor.RequestFacade request) {
+            request.addQueryParam("access_token", accessToken)
+        }
+    }
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config
+
+import groovy.transform.CompileStatic
+import org.hibernate.validator.constraints.NotEmpty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+import javax.validation.constraints.NotNull
+
+/**
+ * Helper class to map masters in properties file into a validated property map
+ */
+@Configuration
+@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "github")
+@CompileStatic
+@ConfigurationProperties(prefix = "auth.groupMembership.github")
+class GitHubProperties {
+        @NotEmpty
+        String baseUrl
+
+        @NotEmpty
+        String accessToken
+
+        @NotEmpty
+        String organization
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.rolesprovider.github
+
+import com.netflix.spinnaker.gate.config.GitHubProperties
+import com.netflix.spinnaker.gate.security.rolesprovider.UserRolesProvider
+import com.netflix.spinnaker.gate.security.rolesprovider.github.client.GitHubMaster
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.util.Assert
+import retrofit.RetrofitError
+import retrofit.client.Response
+
+@Slf4j
+@Component
+@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "github")
+class GithubTeamsUserRolesProvider implements UserRolesProvider, InitializingBean {
+
+  @Autowired
+  GitHubMaster master
+
+  @Autowired
+  GitHubProperties gitHubProperties
+
+  @Override
+  Collection<String> loadRoles(String userName) {
+    if (!userName || !gitHubProperties.organization) {
+      return []
+    }
+    // check organization if set.
+    // If organization is unset, all GitHub users can login and have full access
+    // If an organization is set, add it to roles to restrict users to this organization
+    // If organization is set AND requiredGroupMembership set, organization members will have RO access
+    // and requiredGroupMembership members RW access
+    Boolean isMemberOfOrg = false
+
+    try {
+      Response response = master.gitHubClient.isMemberOfOrganization(gitHubProperties.organization, userName)
+      isMemberOfOrg = (response.status == 204)
+    } catch (RetrofitError e) {
+      if (e.getKind() == RetrofitError.Kind.NETWORK) {
+        log.error("Could not find the server ${master.baseUrl}", e)
+        return []
+      } else if (e.response.status == 404) {
+        log.error("Could not find the GitHub organization ${gitHubProperties.organization}", e)
+        return []
+      } else if (e.response.status == 401) {
+        log.error("Cannot get GitHub organization ${gitHubProperties.organization} informations: Not authorized.", e)
+        return []
+      }
+    }
+
+    if (!isMemberOfOrg) {
+      return []
+    }
+
+    List result = []
+    result.add(gitHubProperties.organization)
+
+    // Get teams of the current user
+    List<GitHubMaster.Team> teams
+    try {
+      teams = master.gitHubClient.getOrgTeams(gitHubProperties.organization)
+
+    } catch (RetrofitError e) {
+      log.error("RetrofitError ${e.response.status} ${e.response.reason} ", e)
+      if (e.getKind() == RetrofitError.Kind.NETWORK) {
+        log.error("Could not find the server ${master.baseUrl}", e)
+      } else if (e.response.status == 404) {
+        log.error(" 404 when getting teams")
+        return result
+      } else if (e.response.status == 401) {
+        log.error("Cannot get GitHub organization ${gitHubProperties.organization} teams: Not authorized.", e)
+        return result
+      }
+    }
+    if (teams) {
+      teams.each { GitHubMaster.Team t -> if (isMemberOfTeam(t, userName)) result.add(t.slug) }
+    }
+
+    return result
+  }
+
+
+  boolean isMemberOfTeam(GitHubMaster.Team t, String userName) {
+    String ACTIVE = "active"
+    try {
+      GitHubMaster.TeamMembership response = master.gitHubClient.isMemberOfTeam(t.id, userName)
+      return (response.state == ACTIVE)
+    } catch (RetrofitError e) {
+      if (e.getKind() == RetrofitError.Kind.NETWORK) {
+        log.error("Could not find the server ${master.baseUrl}")
+        return false
+      } else if (e.response.status == 404) {
+        return false
+      } else if (e.response.status == 401) {
+        log.error("Cannot check if $userName is member of ${t.name} teams: Not authorized.", e)
+        return false
+      }
+    }
+  }
+
+  @Override
+  void afterPropertiesSet() throws Exception {
+    Assert.state(gitHubProperties.organization != null, "Supply an organization")
+  }
+
+  @Override
+  Map<String, Collection<String>> multiLoadRoles(Collection<String> userEmails) {
+    if (!userEmails) {
+      return [:]
+    }
+    def emailGroupsMap = [:]
+    userEmails.each { String email ->
+      emailGroupsMap.put(email, loadRoles(email))
+    }
+    emailGroupsMap
+  }
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubClient.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubClient.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.rolesprovider.github.client
+
+
+import retrofit.client.Response
+import retrofit.http.GET
+import retrofit.http.Path
+
+/**
+ * Interface for interacting with a GitHub REST API
+ */
+interface GitHubClient {
+
+  @GET('/orgs/{org}/members/{username}')
+  Response isMemberOfOrganization(
+    @Path('org') String org,
+    @Path('username') String username)
+
+   // This one should use the Current User credentials
+  @GET('/user/teams')
+  List<GitHubMaster.Team> getUserTeams()
+
+  @GET('/orgs/{org}/teams')
+  List<GitHubMaster.Team> getOrgTeams(
+    @Path('org') String org
+  )
+
+  @GET('/teams/{idTeam}/memberships/{username}')
+  GitHubMaster.TeamMembership isMemberOfTeam(
+    @Path('idTeam') Long idTeam,
+    @Path('username') String username
+  )
+}
+

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubMaster.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubMaster.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.rolesprovider.github.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.netflix.spinnaker.gate.config.GitHubProperties
+import org.springframework.context.annotation.Bean
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.OkClient
+import retrofit.converter.SimpleXMLConverter
+
+import javax.validation.Valid
+
+/**
+ * Wrapper class for a collection of GitHub clients
+ */
+class GitHubMaster {
+    GitHubClient gitHubClient
+    String baseUrl
+
+    @Bean
+    GitHubMaster gitHubMasters(@Valid GitHubProperties gitHubProperties) {
+        new GitHubMaster(gitHubClient : gitHubClient(gitHubProperties.baseUrl, gitHubProperties.accessToken), baseUrl: gitHubProperties.baseUrl)
+    }
+
+
+    GitHubClient gitHubClient(String address, String username, String password) {
+        new RestAdapter.Builder()
+            .setEndpoint(Endpoints.newFixedEndpoint(address))
+            .setRequestInterceptor(new BasicAuthRequestInterceptor(accessToken))
+            .setClient(new OkClient())
+            .setConverter(new SimpleXMLConverter())
+            .build()
+            .create(GitHubClient(address:address))
+
+    }
+
+    static class BasicAuthRequestInterceptor implements RequestInterceptor {
+
+        private final String accessToken
+
+        BasicAuthRequestInterceptor(String accessToken) {
+            this.accessToken = accessToken
+        }
+
+        @Override
+        void intercept(RequestInterceptor.RequestFacade request) {
+            request.addQueryParam("access_token", accessToken)
+        }
+    }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class TeamMembership {
+    String role
+    String state
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class Team {
+    Long id
+    String name
+    String slug
+  }
+}


### PR DESCRIPTION
Use GitHub teams to provide UserRoles.
To restrict to a whole organization : set requiredGroupMembership as the
organization.
To restrict to teams : set requiredGroupMembership as the teams slug.
The `access_token` configured needs the `org:read` grant.

@ttomsu @jtk54 PTAL. Currently the team membership is done by many calls to GitHub API and it could be replaced by a single call to https://developer.github.com/v3/orgs/teams/#list-user-teams but it needs the `access_token` of the current authenticated user.

EDIT: if `loadRoles` is a batch call to `loadRole` the call using the current authenticated user `access_token` cannot be used. So this implementation might be the final one.