### PR TITLE
Make SAML service provider protocol and basepath configurable

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -67,8 +67,10 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
     // SAML DSL uses a metadata URL instead of hard coding a certificate/issuerId/redirectBase into the config.
     String metadataUrl
-    // The hostname of this server passed to the SAML IdP.
+    // The parts of this endpoint passed to/used by the SAML IdP.
+    String redirectProtocol = "https"
     String redirectHostname
+    String redirectBasePath = "/"
     // The application identifier given to the IdP for this app.
     String issuerId
 
@@ -112,9 +114,9 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
             .and()
           .serviceProvider()
             .entityId(samlSecurityConfigProperties.issuerId)
-            .protocol(serverProperties?.ssl?.enabled ? "https" : "http")
+            .protocol(samlSecurityConfigProperties.redirectProtocol)
             .hostname(samlSecurityConfigProperties.redirectHostname ?: serverProperties?.address?.hostName)
-            .basePath("/")
+            .basePath(samlSecurityConfigProperties.redirectBasePath)
             .keyStore()
               .storeFilePath(samlSecurityConfigProperties.keyStore)
               .password(samlSecurityConfigProperties.keyStorePassword)


### PR DESCRIPTION
Thanks to @johntheodore for bringing up this issue.

This PR allows a SAML user to use an external proxy to terminate SSL connections while running Gate in HTTP mode. The jist is you have to override `redirectHostname` and `redirectBasePath` to get the exact URL the IDP will use when contacting Gate. In the case of Google's click to deploy image, this Gate URL is `https://localhost:9000/gate/saml/SSO`, so the SAML config would include:
```
saml:
  redirectHostname: localhost:9000
  redirectBasePath: /gate
```
I included the protocol in the changes because someone may want that in the future and we might as well do it now too.

@cfieber @ajordens @jtk54 @duftler PTAL