### PR TITLE
set maxInactiveIntervalInSeconds via setter

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -61,7 +61,9 @@ import static retrofit.Endpoints.newFixedEndpoint
 class GateConfig extends RedisHttpSessionConfiguration {
 
   @Value('${server.session.timeoutInSeconds:3600}')
-  int maxInactiveIntervalInSeconds
+  void setSessionTimeout(int maxInactiveIntervalInSeconds) {
+    super.setMaxInactiveIntervalInSeconds(maxInactiveIntervalInSeconds)
+  }
 
   @Value('${retrofit.logLevel:BASIC}')
   String retrofitLogLevel


### PR DESCRIPTION
Since this field is referenced directly in the superclass, setting a private field on the subclass doesn't do anything.