### PR TITLE
Added on-demand endpoint to refresh granted user roles.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
@@ -17,11 +17,14 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.security.SpinnakerUser
+import com.netflix.spinnaker.gate.security.rolesprovider.UserRolesSyncer
 import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
 import org.apache.commons.lang.exception.ExceptionUtils
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -44,6 +47,9 @@ class AuthController {
       "Hodor.",
   ]
 
+  @Autowired
+  UserRolesSyncer userRolesSyncer
+
   @Value('${services.deck.baseUrl}')
   URL deckBaseUrl
 
@@ -57,6 +63,15 @@ class AuthController {
   @RequestMapping("/loggedOut")
   String loggedOut() {
     return LOGOUT_MESSAGES[r.nextInt(LOGOUT_MESSAGES.size()+1)]
+  }
+
+  /**
+   * On-demand endpoint to sync the user roles, in case
+   * waiting for the periodic refresh won't work.
+   */
+  @RequestMapping(value = "/roles/sync", method = RequestMethod.POST)
+  void sync() {
+    userRolesSyncer.sync()
   }
 
   @RequestMapping("/redirect")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncer.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncer.groovy
@@ -40,11 +40,11 @@ class UserRolesSyncer {
   UserRolesProvider userRolesProvider
 
   /**
-   * Check all sessions to see whether the session user's groups have changed. If so, delete the session.
+   * Check all sessions to see whether the session user's roles have changed. If so, delete the session.
    * Repeat every 10 minutes, after an initial delay.
    */
   @Scheduled(initialDelay = 10000L, fixedRate = 600000L)
-  public void syncUserGroups() {
+  public void sync() {
     Map<String, String> emailSessionIdMap = [:]
     Map<String, Collection<String>> emailCurrentGroupsMap = [:]
     Set<String> sessionKeys = sessionRedisTemplate.keys('*session:sessions*')

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/rolesprovider/UserRolesSyncerSpec.groovy
@@ -117,7 +117,7 @@ class UserRolesSyncerSpec extends Specification {
     userRolesSyncer.userRolesProvider = rolesProvider
 
     when: "we sync the groups"
-    userRolesSyncer.syncUserGroups()
+    userRolesSyncer.sync()
 
     then: "no sessions should be present"
     repository.getSession(sessionId) == null
@@ -141,7 +141,7 @@ class UserRolesSyncerSpec extends Specification {
     userRolesSyncer.userRolesProvider = rolesProvider
 
     when: "we sync the groups"
-    userRolesSyncer.syncUserGroups()
+    userRolesSyncer.sync()
 
     then: "our session should be present"
     repository.getSession(sessionId) != null
@@ -169,7 +169,7 @@ class UserRolesSyncerSpec extends Specification {
     userRolesSyncer.userRolesProvider = rolesProvider
 
     when: "we sync the groups"
-    userRolesSyncer.syncUserGroups()
+    userRolesSyncer.sync()
 
     then: "our session should be present"
     repository.getSession(goodSessionId) != null


### PR DESCRIPTION
Added on-demand endpoint to refresh granted user roles. Also renamed the sync function as well. Seemed weirdto export 'syncUserGroups' from a 'UserRolesSyncer'. @ttomsu PTAL.