### PR TITLE
GitHub AuthN : change log message when user not a member of org.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
@@ -60,7 +60,7 @@ class GithubTeamsUserRolesProvider implements UserRolesProvider, InitializingBea
         log.error("Could not find the server ${master.baseUrl}", e)
         return []
       } else if (e.response.status == 404) {
-        log.error("Could not find the GitHub organization ${gitHubProperties.organization}", e)
+        log.error("User ${userName} is not a member of GitHub organization ${gitHubProperties.organization}")
         return []
       } else if (e.response.status == 401) {
         log.error("Cannot get GitHub organization ${gitHubProperties.organization} informations: Not authorized.", e)


### PR DESCRIPTION
The exception is not needed. Added the userName in the log message.

@ttomsu PTAL