### PR TITLE
Update logrotate file permissions

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -105,6 +105,7 @@ ospackage {
     into('/etc/logrotate.d')
     user = 'root'
     permissionGroup = 'root'
+    fileMode = 0644
     fileType = CONFIG | NOREPLACE
   }
 


### PR DESCRIPTION
This change will fix problems where logrotate ignores
/etc/logrotate/gate due to 'bad file mode.'

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)