### PR TITLE
(core) allow pipeline triggering by id or name

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -98,20 +98,20 @@ class PipelineController {
     pipelineService.startPipeline(map, authenticatedUser)
   }
 
-  @RequestMapping(value = "/{application}/{pipelineName:.+}", method = RequestMethod.POST)
+  @RequestMapping(value = "/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
   HttpEntity invokePipelineConfig(@PathVariable("application") String application,
-                                  @PathVariable("pipelineName") String pipelineName,
+                                  @PathVariable("pipelineNameOrId") String pipelineNameOrId,
                                   @RequestBody(required = false) Map trigger) {
     trigger = trigger ?: [:]
     trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
 
     try {
-      def body = pipelineService.trigger(application, pipelineName, trigger)
+      def body = pipelineService.trigger(application, pipelineNameOrId, trigger)
       new ResponseEntity(body, HttpStatus.ACCEPTED)
     } catch (PipelineConfigNotFoundException e) {
       throw e
     } catch (e) {
-      log.error("Unable to trigger pipeline (application: ${application}, pipelineName: ${pipelineName})", e)
+      log.error("Unable to trigger pipeline (application: ${application}, pipelineName: ${pipelineNameOrId})", e)
       new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
     }
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -135,9 +135,9 @@ class ApplicationService {
     } execute()
   }
 
-  Map getPipelineConfigForApplication(String app, String pipelineName) {
+  Map getPipelineConfigForApplication(String app, String pipelineNameOrId) {
     HystrixFactory.newMapCommand(GROUP, "getPipelineConfig") {
-      front50Service.getPipelineConfigsForApplication(app).find { it.name == pipelineName }
+      front50Service.getPipelineConfigsForApplication(app).find { it.name == pipelineNameOrId || it.id == pipelineNameOrId }
     } execute()
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -56,8 +56,8 @@ class PipelineService {
     front50Service.movePipelineConfig(moveCommand)
   }
 
-  Map trigger(String application, String pipelineName, Map trigger) {
-    def pipelineConfig = applicationService.getPipelineConfigForApplication(application, pipelineName)
+  Map trigger(String application, String pipelineNameOrId, Map trigger) {
+    def pipelineConfig = applicationService.getPipelineConfigForApplication(application, pipelineNameOrId)
     if (!pipelineConfig) {
       throw new PipelineConfigNotFoundException()
     }


### PR DESCRIPTION
Makes scripting a little more durable, as users can trigger pipelines by ID without worrying about them being renamed.

@ajordens WDYT?