### PR TITLE
allow users to send additional notifications when triggering pipelines

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -104,6 +104,7 @@ class PipelineController {
                                   @RequestBody(required = false) Map trigger) {
     trigger = trigger ?: [:]
     trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
+    trigger.notifications = trigger.notifications ?: [];
 
     try {
       def body = pipelineService.trigger(application, pipelineNameOrId, trigger)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -62,6 +62,13 @@ class PipelineService {
       throw new PipelineConfigNotFoundException()
     }
     pipelineConfig.trigger = trigger
+    if (trigger.notifications) {
+      if (pipelineConfig.notifications) {
+        ((List) pipelineConfig.notifications).addAll(trigger.notifications)
+      } else {
+        pipelineConfig.notifications = trigger.notifications;
+      }
+    }
     orcaService.startPipeline(pipelineConfig, trigger.user?.toString())
   }
 


### PR DESCRIPTION
When I'm starting a pipeline, I often want to get a notification when it completes or fails. Other users have requested the same thing.

This is the first step in that process. In the UI, we can just include a checkbox if they're authenticated to send an email or text message (if configured).

@spinnaker/netflix-reviewers WDYT?