### PR TITLE
fix notification merging

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -64,7 +64,7 @@ class PipelineService {
     pipelineConfig.trigger = trigger
     if (trigger.notifications) {
       if (pipelineConfig.notifications) {
-        ((List) pipelineConfig.notifications).addAll(trigger.notifications)
+        pipelineConfig.notifications = (List) pipelineConfig.notifications + (List) trigger.notifications
       } else {
         pipelineConfig.notifications = trigger.notifications;
       }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/PipelineServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/PipelineServiceSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.gate.services.internal.OrcaService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PipelineServiceSpec extends Specification {
+
+  void 'startPipeline should add notifications to existing notifications'() {
+    given:
+    OrcaService orcaService = Mock(OrcaService)
+    def service = new PipelineService(
+      applicationService: Mock(ApplicationService) {
+        1 * getPipelineConfigForApplication('app', 'p-id') >> [
+          notifications: [[type: 'email']]
+        ]
+      },
+      orcaService: orcaService
+    )
+    when:
+    service.trigger('app', 'p-id', [notifications: [[type: 'sms']]])
+
+    then:
+    1 * orcaService.startPipeline({ p -> p.notifications.type == ['email', 'sms'] }, _)
+  }
+
+  @Unroll
+  void 'startPipeline should set notifications to those on trigger'() {
+    given:
+    OrcaService orcaService = Mock(OrcaService)
+    def service = new PipelineService(
+      applicationService: Mock(ApplicationService) {
+        1 * getPipelineConfigForApplication('app', 'p-id') >> [
+          notifications: config
+        ]
+      },
+      orcaService: orcaService
+    )
+    when:
+    service.trigger('app', 'p-id', [notifications: trigger])
+
+    then:
+    1 * orcaService.startPipeline({ p -> p.notifications == expected }, _)
+
+    where:
+    config                     | trigger                    || expected
+    null                       | null                       || null
+    null                       | []                         || null
+    []                         | null                       || []
+    []                         | []                         || []
+    null                       | [[type: 'a']]              || [[type: 'a']]
+    null                       | [[type: 'a'], [type: 'b']] || [[type: 'a'], [type: 'b']]
+    null                       | [[type: 'a'], [type: 'b']] || [[type: 'a'], [type: 'b']]
+    [[type: 'a']]              | null                       || [[type: 'a']]
+    [[type: 'a'], [type: 'b']] | null                       || [[type: 'a'], [type: 'b']]
+    [[type: 'a'], [type: 'b']] | [[type: 'c']]              || [[type: 'a'], [type: 'b'], [type: 'c']]
+  }
+}


### PR DESCRIPTION
Shame on me for not writing a test. It turns out that, when calling `addAll` like this, Groovy just appends the argument into the caller, so you have a List with the original items plus the other collection.