### PR TITLE
core: Implemented a controller for getting snapshots from front50

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SnapshotController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SnapshotController.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.services.SnapshotService
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Slf4j
+@CompileStatic
+@RestController
+@RequestMapping("/applications")
+class SnapshotController {
+
+  @Autowired
+  SnapshotService snapshotService
+
+  @RequestMapping(value = "/{application}/snapshots/{account}", method = RequestMethod.GET)
+  Map getCurrentSnapshot(@PathVariable("application") String application,
+                         @PathVariable("account") String account) {
+    snapshotService.getCurrent(application, account)
+  }
+
+  @RequestMapping(value = "/{application}/snapshots/{account}/history", method = RequestMethod.GET)
+  List<Map> getSnapshotHistory(@PathVariable("application") String application,
+                               @PathVariable("account") String account,
+                               @RequestParam(value = "limit", defaultValue= "20") int limit) {
+    snapshotService.getHistory(application, account, limit)
+  }
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SnapshotService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SnapshotService.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.gate.services.internal.Front50Service
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@CompileStatic
+@Component
+@Slf4j
+class SnapshotService {
+
+  @Autowired(required = false)
+  Front50Service front50Service
+
+  Map getCurrent(String application, String account) {
+    front50Service.getCurrentSnapshot("$application-$account")
+  }
+
+  List<Map> getHistory(String application, String account, int limit) {
+    front50Service.getSnapshotHistory("$application-$account", limit)
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -101,6 +101,15 @@ interface Front50Service {
   @GET('/v2/projects/{projectId}')
   Map getProject(@Path('projectId') String projectId)
 
+  //
+  // Snapshot-related
+  //
+  @GET('/snapshots/{id}')
+  Map getCurrentSnapshot(@Path('id') String id)
+
+  @GET('/snapshots/{id}/history')
+  List<Map> getSnapshotHistory(@Path("id") String id, @Query("limit") int limit)
+
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class HalList {
     @JsonProperty("_embedded")


### PR DESCRIPTION
Added functionality to get the current snapshot and the snapshot history from front50. This will be used to surface snapshots that are available for the user in deck. PTAL @lwander @duftler @danielpeach 