### PR TITLE
Exposing GitHub API per_page value to accomodate teams larger than 30

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
@@ -42,5 +42,5 @@ class GitHubProperties {
         String organization
 
         @NotEmpty
-        int paginationValue = 30
+        int paginationValue = 100
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
@@ -41,4 +41,6 @@ class GitHubProperties {
         @NotEmpty
         String organization
 
+        @NotEmpty
+        int paginationValue = 30
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
@@ -78,7 +78,7 @@ class GithubTeamsUserRolesProvider implements UserRolesProvider, InitializingBea
     // Get teams of the current user
     List<GitHubMaster.Team> teams
     try {
-      teams = master.gitHubClient.getOrgTeams(gitHubProperties.organization)
+      teams = master.gitHubClient.getOrgTeams(gitHubProperties.organization, gitHubProperties.paginationValue)
 
     } catch (RetrofitError e) {
       log.error("RetrofitError ${e.response.status} ${e.response.reason} ", e)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubClient.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/client/GitHubClient.groovy
@@ -35,9 +35,10 @@ interface GitHubClient {
   @GET('/user/teams')
   List<GitHubMaster.Team> getUserTeams()
 
-  @GET('/orgs/{org}/teams')
+  @GET('/orgs/{org}/teams?per_page={paginationValue}')
   List<GitHubMaster.Team> getOrgTeams(
-    @Path('org') String org
+    @Path('org') String org,
+    @Path('paginationValue') int paginationValue
   )
 
   @GET('/teams/{idTeam}/memberships/{username}')


### PR DESCRIPTION
Noticed that I was getting sporadic results when querying GitHub for Team AuthZ. I noticed that GitHub by default limits to only 30 teams. My organization at the time had 30. GitHub allows you to increase this upwards to 100.

This pull request is to expose the per_page parameter if people need to make it larger than 30. After speaking to some folks, I set a default value 30 (as per GitHub's standard), but allow to increase through the properties.

Link to relevant documentation from GitHub API: https://developer.github.com/v3/#pagination