### PR TITLE
Removed @NotEmpty annotation on paginationValue

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GitHubProperties.groovy
@@ -41,6 +41,5 @@ class GitHubProperties {
         @NotEmpty
         String organization
 
-        @NotEmpty
         int paginationValue = 100
 }


### PR DESCRIPTION
The previous merge request #272 has caused some issues; namely that we required an int to be `@NotEmpty` which is a typo/bug and we also talked about not making this a mandatory value so removing the annotation all together.