### PR TITLE
Prepping for Front50 Project API refactor

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -41,9 +41,17 @@ class ProjectService {
   @Autowired
   ClouddriverService clouddriverService
 
+  //TODO: (jeyrs)Remove the try catch to handle the new format when front50 is updated & in prod
   List<Map> getAll() {
+    // Prepping to start using List<Map> instead of HalList from Front50
     HystrixFactory.newListCommand(GROUP, "getAll") {
-      return front50Service.getAllProjects().embedded?.projects ?: []
+      try {
+        return front50Service.legacyGetAllProjects().embedded?.projects ?: []
+      } catch (retrofit.converter.ConversionException e) {
+        log.info("Falling back on new return type {}", e.getMessage())
+        return front50Service.getAllProjects() ?: []
+      }
+
     } execute()
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -96,7 +96,10 @@ interface Front50Service {
   // Project-related
   //
   @GET('/v2/projects')
-  HalList getAllProjects()
+  HalList legacyGetAllProjects() //TODO: remove this when front50 is updated to return a list of POJO Projects
+
+  @GET('/v2/projects')
+  List<Map> getAllProjects()
 
   @GET('/v2/projects/{projectId}')
   Map getProject(@Path('projectId') String projectId)


### PR DESCRIPTION
- Updated call to front50 project's api to handle both the old & the new return type.
Front50 will use Set<Projects> projects instead of Resources<ProjectResource> project (HAL)