### PR TITLE
Prepping for Front50 Project API refactor

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -47,7 +47,7 @@ class ProjectService {
     HystrixFactory.newListCommand(GROUP, "getAll") {
       try {
         return front50Service.legacyGetAllProjects().embedded?.projects ?: []
-      } catch (retrofit.converter.ConversionException e) {
+      } catch (Exception e) {
         log.info("Falling back on new return type {}", e.getMessage())
         return front50Service.getAllProjects() ?: []
       }


### PR DESCRIPTION
- Replaced retrofit.converter.ConversionException to Exception as the exception wasnt being caught.