### PR TITLE
Optionally check the health of downstream services

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/ServiceConfiguration.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/ServiceConfiguration.groovy
@@ -18,19 +18,31 @@ package com.netflix.spinnaker.gate.config
 
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
 
 @CompileStatic
 @Component
 @ConfigurationProperties
 class ServiceConfiguration {
+  List<String> healthCheckableServices
   List<String> discoveryHosts
   Map<String, Service> services = [:]
 
   @Autowired
   ApplicationContext ctx
+
+  @PostConstruct
+  void postConstruct() {
+    // this check is done in a @PostConstruct to avoid Spring's list merging in @ConfigurationProperties (vs. overriding)
+    healthCheckableServices = healthCheckableServices ?: [
+      "orca", "clouddriver", "echo", "igor", "flex", "front50", "mahe", "mine"
+    ]
+  }
 
   Service getService(String name) {
     services[name]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/health/DownstreamServicesHealthIndicator.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/health/DownstreamServicesHealthIndicator.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.gate.health
+
+import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import com.netflix.spinnaker.gate.config.GateConfig
+import com.netflix.spinnaker.gate.config.Service
+import com.netflix.spinnaker.gate.config.ServiceConfiguration
+import com.netflix.spinnaker.gate.services.internal.HealthCheckableService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.actuate.health.AbstractHealthIndicator
+import org.springframework.boot.actuate.health.Health
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import retrofit.RestAdapter
+import retrofit.RetrofitError
+import retrofit.client.OkClient
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+import static retrofit.Endpoints.newFixedEndpoint
+
+@Component
+class DownstreamServicesHealthIndicator extends AbstractHealthIndicator {
+  final Map<String, HealthCheckableService> healthCheckableServices
+
+  AtomicReference<Map<String, String>> failuresByService = new AtomicReference<>([:])
+  AtomicBoolean skipDownstreamServiceChecks = new AtomicBoolean(false)
+
+  @Autowired
+  DownstreamServicesHealthIndicator(OkHttpClientConfiguration okHttpClientConfiguration,
+                                    ServiceConfiguration serviceConfiguration) {
+    this(
+      serviceConfiguration.services.findResults { String name, Service service ->
+        if (!service.enabled || !serviceConfiguration.healthCheckableServices.contains(name)) {
+          return null
+        }
+
+        return [
+          name, new RestAdapter.Builder()
+          .setEndpoint(newFixedEndpoint(service.baseUrl))
+          .setClient(new OkClient(okHttpClientConfiguration.create()))
+          .build()
+          .create(HealthCheckableService)
+        ]
+      }.collectEntries()
+    )
+  }
+
+  DownstreamServicesHealthIndicator(Map<String, HealthCheckableService> healthCheckableServices) {
+    this.healthCheckableServices = healthCheckableServices
+  }
+
+  @Override
+  protected void doHealthCheck(Health.Builder builder) throws Exception {
+    def httpServletRequest = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest()
+
+    if (Boolean.valueOf(httpServletRequest.getParameter("checkDownstreamServices") ?: "false")) {
+      // force a re-check of downstream services
+      skipDownstreamServiceChecks.set(false)
+    }
+
+    if (!Boolean.valueOf(httpServletRequest.getParameter("downstreamServices") ?: "false")) {
+      // do not consider downstream service health (will result in UNKNOWN)
+      return
+    }
+
+    failuresByService.get().isEmpty() ? builder.up() : builder.down().withDetail("errors", failuresByService.get())
+  }
+
+  @Scheduled(fixedDelay = 30000L)
+  void checkDownstreamServiceHealth() {
+    if (skipDownstreamServiceChecks.get()) {
+      return
+    }
+
+    def serviceHealths = [:]
+    healthCheckableServices.each { String name, HealthCheckableService service ->
+      try {
+        service.health()
+      } catch (RetrofitError e) {
+        serviceHealths[name] = "${e.message} (url: ${e.url})".toString()
+      }
+    }
+
+    if (!serviceHealths) {
+      // do not continue checking downstream services once successful
+      skipDownstreamServiceChecks.set(true)
+    }
+
+    failuresByService.set(serviceHealths)
+  }
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/HealthCheckableService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/HealthCheckableService.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.gate.services.internal
+
+import retrofit.http.GET
+import retrofit.http.Headers
+
+interface HealthCheckableService {
+  @Headers("Accept: application/json")
+  @GET("/health")
+  Map health()
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/health/DownstreamServicesHealthIndicatorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/health/DownstreamServicesHealthIndicatorSpec.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.netflix.spinnaker.gate.health
+
+import com.netflix.spinnaker.gate.services.internal.HealthCheckableService
+import org.springframework.boot.actuate.health.Health
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletWebRequest
+import retrofit.RetrofitError
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest
+
+class DownstreamServicesHealthIndicatorSpec extends Specification {
+  def healthCheckableService = Mock(HealthCheckableService)
+
+  def "should check downstream health only once if successful"() {
+    given:
+    def healthIndicator = new DownstreamServicesHealthIndicator(["test": healthCheckableService])
+
+    when:
+    healthIndicator.checkDownstreamServiceHealth()
+
+    then:
+    1 * healthCheckableService.health() >> { [:] }
+    healthIndicator.skipDownstreamServiceChecks.get()
+
+    when:
+    healthIndicator.checkDownstreamServiceHealth()
+
+    then:
+    0 * healthCheckableService.health()
+
+  }
+
+  def "should record failures if health check unsuccessful"() {
+    given:
+    def healthIndicator = new DownstreamServicesHealthIndicator(["test": healthCheckableService])
+
+    when:
+    healthIndicator.checkDownstreamServiceHealth()
+
+    then:
+    1 * healthCheckableService.health() >> {
+      throw new RetrofitError("Unable to connect", "http://localhost", null, null, null, null, null)
+    }
+
+    healthIndicator.failuresByService.get() == [
+      "test": "Unable to connect (url: http://localhost)"
+    ]
+    !healthIndicator.skipDownstreamServiceChecks.get()
+  }
+
+  @Unroll
+  def "should only include downstream service check results if `checkDownstreamServices` == true"() {
+    given:
+    def healthIndicator = new DownstreamServicesHealthIndicator(["test": healthCheckableService])
+    def healthBuilder = Mock(Health.Builder)
+    def httpServletRequest = Mock(HttpServletRequest)
+
+    and:
+    RequestContextHolder.setRequestAttributes(
+      new ServletWebRequest(httpServletRequest)
+    )
+
+    1 * httpServletRequest.getParameter("checkDownstreamServices") >> { checkDownstreamServices }
+    1 * httpServletRequest.getParameter("downstreamServices") >> { downstreamServices }
+    healthIndicator.skipDownstreamServiceChecks.set(true)
+
+    when:
+    healthIndicator.doHealthCheck(healthBuilder)
+
+    then:
+    upInvocations * healthBuilder.up()
+
+    healthIndicator.skipDownstreamServiceChecks.get() == expectedSkipDownstreamServiceChecks
+
+    where:
+    checkDownstreamServices | downstreamServices || upInvocations || expectedSkipDownstreamServiceChecks
+    "true"                  | "true"             || 1             || false
+    "false"                 | "true"             || 1             || true
+    "false"                 | "false"            || 0             || true
+    null                    | null               || 0             || true
+  }
+
+  def "should include error details if `checkDownstreamServices` == true and failures are present"() {
+    given:
+    def healthIndicator = new DownstreamServicesHealthIndicator(["test": healthCheckableService])
+    def healthBuilder = Mock(Health.Builder)
+    def httpServletRequest = Mock(HttpServletRequest)
+
+    and:
+    RequestContextHolder.setRequestAttributes(
+      new ServletWebRequest(httpServletRequest)
+    )
+
+    1 * httpServletRequest.getParameter("checkDownstreamServices") >> { true }
+    1 * httpServletRequest.getParameter("downstreamServices") >> { true }
+    healthIndicator.failuresByService.set(["test": "Unable to connect (url: http://localhost)"])
+
+    when:
+    healthIndicator.doHealthCheck(healthBuilder)
+
+    then:
+    1 * healthBuilder.down() >> { healthBuilder }
+    1 * healthBuilder.withDetail("errors", ["test": "Unable to connect (url: http://localhost)"])
+  }
+}


### PR DESCRIPTION
- Uses request parameters to determine whether to check downstream services
- Downstream services are checked asynchronously (and only until success occurs)