### PR TITLE
Adds check for Fiat in user roles provider conditional

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/github/GithubTeamsUserRolesProvider.groovy
@@ -19,11 +19,10 @@ package com.netflix.spinnaker.gate.security.rolesprovider.github
 import com.netflix.spinnaker.gate.config.GitHubProperties
 import com.netflix.spinnaker.gate.security.rolesprovider.UserRolesProvider
 import com.netflix.spinnaker.gate.security.rolesprovider.github.client.GitHubMaster
-
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.stereotype.Component
 import org.springframework.util.Assert
 import retrofit.RetrofitError
@@ -31,7 +30,7 @@ import retrofit.client.Response
 
 @Slf4j
 @Component
-@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "github")
+@ConditionalOnExpression('!${services.fiat.enabled:false} and "github".equalsIgnoreCase("${auth.groupMembership.service:}")')
 class GithubTeamsUserRolesProvider implements UserRolesProvider, InitializingBean {
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/google/GoogleDirectoryUserRolesProvider.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/rolesprovider/google/GoogleDirectoryUserRolesProvider.groovy
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.gate.security.rolesprovider.UserRolesProvider
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
@@ -40,7 +40,7 @@ import org.springframework.util.Assert
 
 @Slf4j
 @Component
-@ConditionalOnProperty(value = "auth.groupMembership.service", havingValue = "google")
+@ConditionalOnExpression('!${services.fiat.enabled:false} and "google".equalsIgnoreCase("${auth.groupMembership.service:}")')
 class GoogleDirectoryUserRolesProvider implements UserRolesProvider, InitializingBean {
 
   @Autowired


### PR DESCRIPTION
This allows someone to add the `auth` block to `spinnaker-local.yml` if they so chose, and it will only be picked up by Gate if Fiat is disabled.

@duftler @jtk54 PTAL
/cc: @gbougeard 

Fixes https://github.com/spinnaker/fiat/issues/83