### PR TITLE
Explicitly enables FiatClientConfigProperties. Previously we relied o…

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -29,7 +29,7 @@ dependencies {
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency('cglib')
-  compile "com.netflix.spinnaker.fiat:fiat-api:0.12.0"
+  compile "com.netflix.spinnaker.fiat:fiat-api:0.13.0"
 
   compile('com.github.kstyrc:embedded-redis:0.6')
   compile('org.springframework.session:spring-session-data-redis:1.1.1.RELEASE')

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.config
 
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
@@ -40,6 +41,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.embedded.FilterRegistrationBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -70,6 +72,7 @@ import static retrofit.Endpoints.newFixedEndpoint
 @CompileStatic
 @Configuration
 @Slf4j
+@EnableConfigurationProperties(FiatClientConfigurationProperties)
 class GateConfig extends RedisHttpSessionConfiguration {
 
   @Value('${server.session.timeoutInSeconds:3600}')


### PR DESCRIPTION
…n the @Component getting picked up, but this causes duplicate beans to be created.

@jtk54 FYI. Going to cut this release when tests pass