### PR TITLE
Adding interface to pull user roles from X509 certificates

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509RolesExtractor.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509RolesExtractor.groovy
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.gate.security.x509
+
+import java.security.cert.X509Certificate
+
+interface X509RolesExtractor {
+
+  /**
+   * Loads the roles assigned to the {@link com.netflix.spinnaker.security.User User},
+   * extracted from the X509 certificate.
+   *
+   * @param cert
+   * @return Roles assigned to the {@link com.netflix.spinnaker.security.User User}
+   */
+  Collection<String> fromCertificate(X509Certificate cert)
+}


### PR DESCRIPTION
Allows extensions to define strategies of providing roles from X509 certificates.

PTAL @ttomsu @ajordens 