### PR TITLE
Use the temporary account cache to supply the account list for credentials service.

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/AccountLookupService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/AccountLookupService.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+
+interface AccountLookupService {
+  List<ClouddriverService.Account> getAccounts()
+}

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupService.groovy
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit
  * DefaultProviderLookupService.
  */
 @Component("providerLookupService")
-class DefaultProviderLookupService implements ProviderLookupService {
+class DefaultProviderLookupService implements ProviderLookupService, AccountLookupService {
 
   private static final String FALLBACK = "unknown"
   private static final String ACCOUNTS_KEY = "all"
@@ -41,7 +41,7 @@ class DefaultProviderLookupService implements ProviderLookupService {
   private final LoadingCache<String, List<ClouddriverService.Account>> accountsCache = CacheBuilder.newBuilder()
     .initialCapacity(1)
     .maximumSize(1)
-    .refreshAfterWrite(5, TimeUnit.SECONDS)
+    .refreshAfterWrite(2, TimeUnit.SECONDS)
     .build(new CacheLoader<String, List<ClouddriverService.Account>>() {
         @Override
         List<ClouddriverService.Account> load(String key) throws Exception {
@@ -54,6 +54,7 @@ class DefaultProviderLookupService implements ProviderLookupService {
     this.clouddriverService = clouddriverService
   }
 
+  @Override
   public String providerForAccount(String account) {
     try {
       return accountsCache.get(ACCOUNTS_KEY)?.find { it.name == account }?.type ?: FALLBACK
@@ -62,4 +63,8 @@ class DefaultProviderLookupService implements ProviderLookupService {
     }
   }
 
+  @Override
+  public List<ClouddriverService.Account> getAccounts() {
+    return accountsCache.get(ACCOUNTS_KEY)
+  }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -27,6 +27,9 @@ class CredentialsService {
   private static final String GROUP = "credentials"
 
   @Autowired
+  AccountLookupService accountLookupService
+
+  @Autowired
   ClouddriverService clouddriverService
 
   @Autowired
@@ -49,7 +52,7 @@ class CredentialsService {
    */
   List<ClouddriverService.Account> getAccounts(Collection<String> userRoles) {
     HystrixFactory.newListCommand(GROUP, "getAccounts") {
-      return clouddriverService.accounts.findAll { ClouddriverService.Account account ->
+      return accountLookupService.accounts.findAll { ClouddriverService.Account account ->
         if (fiatConfig.enabled) {
           return true // Returned list is filtered later.
         }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.config.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.controllers.ApplicationController
 import com.netflix.spinnaker.gate.controllers.PipelineController
+import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.CredentialsService
 import com.netflix.spinnaker.gate.services.ExecutionHistoryService
@@ -59,6 +60,7 @@ class FunctionalSpec extends Specification {
   static CredentialsService credentialsService
   static PipelineService pipelineService
   static ServiceConfiguration serviceConfiguration
+  static AccountLookupService accountLookupService
 
   ConfigurableApplicationContext ctx
 
@@ -70,6 +72,7 @@ class FunctionalSpec extends Specification {
     clouddriverService = Mock(ClouddriverService)
     orcaService = Mock(OrcaService)
     credentialsService = Mock(CredentialsService)
+    accountLookupService = Mock(AccountLookupService)
     pipelineService = Mock(PipelineService)
     serviceConfiguration = new ServiceConfiguration()
 
@@ -227,6 +230,11 @@ class FunctionalSpec extends Specification {
     @Bean
     ServiceConfiguration serviceConfiguration() {
       serviceConfiguration
+    }
+
+    @Bean
+    AccountLookupService accountLookupService() {
+      accountLookupService
     }
 
     @Bean

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -27,13 +27,13 @@ class CredentialsServiceSpec extends Specification {
   @Unroll
   def "should return allowed account names"() {
     setup:
-      ClouddriverService clouddriverService = Mock(ClouddriverService) {
+      AccountLookupService accountLookupService = Mock(AccountLookupService) {
         getAccounts() >> accounts
       }
       FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
 
       @Subject
-      CredentialsService credentialsService = new CredentialsService(clouddriverService: clouddriverService,
+      CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
                                                                      fiatConfig: fiatConfig)
 
     when:


### PR DESCRIPTION
The accounts are checked every request to augment authentication details, this saves a round trip call to clouddriver in every request (instead at most every 2 seconds as the entry expires out of the loading cache)

@robzienert PTAL