### PR TITLE
filter insight links by provider

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/InsightConfiguration.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/InsightConfiguration.groovy
@@ -39,8 +39,12 @@ class InsightConfiguration {
 
     String url
     String label
+    String cloudProvider
 
     Map applyContext(Map<String, String> context) {
+      if (cloudProvider && cloudProvider != context.cloudProvider) {
+        return null
+      }
       try {
         return [
           url  : template.make(context.withDefault { null }).toString(),

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
@@ -47,7 +47,7 @@ class InstanceService {
 
       def context = instanceContext + getContext(account, region, instanceId)
       return instanceDetails + [
-          "insightActions": insightConfiguration.instance.collect { it.applyContext(context) }
+          "insightActions": insightConfiguration.instance.findResults { it.applyContext(context) }
       ]
     } execute()
   }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/InsightConfigurationSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/InsightConfigurationSpec.groovy
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.internal.config
+package com.netflix.spinnaker.gate.config
 
-import com.netflix.spinnaker.gate.config.InsightConfiguration
 import spock.lang.Specification
 
 class InsightConfigurationSpec extends Specification {
@@ -47,5 +46,15 @@ class InsightConfigurationSpec extends Specification {
     new InsightConfiguration.Link(
       url: 'http://${if (publicDnsName) publicDnsName else ""}${if (!publicDnsName) privateDnsName else ""}'
     ).applyContext([privateDnsName: "foobar"]).url == 'http://foobar'
+  }
+
+  void "should filter on cloudProvider"() {
+    setup:
+    def link = new InsightConfiguration.Link(url: 'http://providerLink', cloudProvider: 'aws')
+
+    expect:
+    link.applyContext([:]) == null
+    link.applyContext([cloudProvider: 'titus']) == null
+    link.applyContext([cloudProvider: 'aws']).url == 'http://providerLink'
   }
 }


### PR DESCRIPTION
Allows insight links to be specific to particular providers based on `cloudProvider` field.

depends on https://github.com/spinnaker/clouddriver/pull/1268