### PR TITLE
do not override instance details when generating insight link context

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
@@ -45,7 +45,7 @@ class InstanceService {
         return it.value instanceof String ? [it.key, it.value] : [it.key, ""]
       } as Map<String, String>
 
-      def context = instanceContext + getContext(account, region, instanceId)
+      def context = getContext(account, region, instanceId) + instanceContext
       return instanceDetails + [
           "insightActions": insightConfiguration.instance.findResults { it.applyContext(context) }
       ]


### PR DESCRIPTION
We have an unfortunate context issue in Titus which results in `instanceId` getting overwritten in the `context` map by the `id`.