### PR TITLE
Adding regex support for oauth2 user info requirements

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
@@ -41,6 +41,16 @@ class SpinnakerUserInfoTokenServicesSpec extends Specification {
       !tokenServices.hasAllUserInfoRequirements(["bar": "foo.com"])
       !tokenServices.hasAllUserInfoRequirements(["bar": "bar.com"])
 
+    when: 'domain restricted by regex expression'
+      userInfoRequirements.hd = "/foo\\.com|bar\\.com/"
+
+    then:
+      !tokenServices.hasAllUserInfoRequirements([:])
+      tokenServices.hasAllUserInfoRequirements(['hd': 'foo.com'])
+      tokenServices.hasAllUserInfoRequirements(['hd': 'bar.com'])
+      !tokenServices.hasAllUserInfoRequirements(['hd': 'baz.com'])
+      !tokenServices.hasAllUserInfoRequirements(['bar': 'foo.com'])
+
     when: "multiple restriction values"
       userInfoRequirements.bar = "bar.com"
 


### PR DESCRIPTION
Low-hanging fruit to support regex expressions in oauth2 user info requirements. Requires values to have a `/expr/` format.

Fixes https://github.com/spinnaker/fiat/issues/124

@ttomsu @msloes