### PR TITLE
Restrict cross origin requests.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/CorsFilter.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/CorsFilter.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters
+
+import com.netflix.spinnaker.gate.config.Headers
+
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class CorsFilter implements Filter {
+
+  private final OriginValidator originValidator
+
+  CorsFilter(OriginValidator originValidator) {
+    this.originValidator = originValidator
+  }
+
+  @Override
+  void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletResponse response = (HttpServletResponse) res
+    HttpServletRequest request = (HttpServletRequest) req
+    String origin = request.getHeader("Origin")
+    if (!originValidator.isValidOrigin(origin)) {
+      origin = '*'
+    }
+    response.setHeader("Access-Control-Allow-Credentials", "true")
+    response.setHeader("Access-Control-Allow-Origin", origin)
+    response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH")
+    response.setHeader("Access-Control-Max-Age", "3600")
+    response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type, authorization")
+    response.setHeader("Access-Control-Expose-Headers", [Headers.AUTHENTICATION_REDIRECT_HEADER_NAME].join(", "))
+    chain.doFilter(req, res)
+  }
+
+  @Override
+  void init(FilterConfig filterConfig) {}
+
+  @Override
+  void destroy() {}
+
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/GateOriginValidator.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/GateOriginValidator.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters
+
+import java.util.regex.Pattern
+
+class GateOriginValidator implements OriginValidator {
+  private final URI deckUri
+  private final Pattern redirectHosts
+  private final Pattern allowedOrigins
+
+  GateOriginValidator(String deckUri, String redirectHostsPattern, String allowedOriginsPattern) {
+    this.deckUri = deckUri ? deckUri.toURI() : null
+    this.redirectHosts = redirectHostsPattern ? Pattern.compile(redirectHostsPattern) : null
+    this.allowedOrigins = allowedOriginsPattern ? Pattern.compile(allowedOriginsPattern) : null
+  }
+
+  @Override
+  boolean isValidOrigin(String origin) {
+    if (!origin) {
+      return false
+    }
+
+    try {
+      def uri = URI.create(origin)
+      if (!(uri.scheme && uri.host)) {
+        return false
+      }
+
+      if (allowedOrigins) {
+        return allowedOrigins.matcher(origin).matches()
+      }
+
+      if (redirectHosts) {
+        return redirectHosts.matcher(uri.host).matches()
+      }
+
+      if (!deckUri) {
+        return false
+      }
+
+      return deckUri.scheme == uri.scheme && deckUri.host == uri.host && deckUri.port == uri.port
+    } catch (URISyntaxException) {
+      return false
+    }
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/OriginValidator.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/OriginValidator.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters
+
+interface OriginValidator {
+
+  boolean isValidOrigin(String origin)
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/filters/GateOriginValidatorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/filters/GateOriginValidatorSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters
+
+import spock.lang.Specification
+
+/**
+ * GateOriginValidatorSpec.
+ */
+class GateOriginValidatorSpec extends Specification {
+
+  void "#desc isValidOrigin #expected"() {
+    given:
+    def validator = new GateOriginValidator('http://localhost:9000', null, null)
+
+    expect:
+    validator.isValidOrigin(origin) == expected
+
+    where:
+    origin                  | expected | desc
+    null                    | false    | 'null origin'
+    ''                      | false    | 'empty origin'
+    '/foo'                  | false    | 'not absolute URI'
+    'file:/bar'             | false    | 'no host component'
+    'http://localhost:9000' | true     | 'match for configured deckUri'
+  }
+
+  void "uses allowedOrigins if configured #desc"() {
+    given:
+    def validator = new GateOriginValidator('http://localhost:9000', 'evil.com', /^http(s)?:\/\/good.com:7777(\/)?$/)
+
+    expect:
+    validator.isValidOrigin(origin) == expected
+
+    where:
+    origin                   | expected | desc
+    'http://localhost:9000'  | false    | 'deckUri'
+    'http://evil.com'        | false    | 'redirectHosts'
+    'http://good.com:7777'   | true     | 'optional path'
+    'http://good.com:7777/'  | true     | 'with path'
+    'https://good.com:7777/' | true     | 'with https'
+    'http://good.com:666'    | false    | 'port mismatch'
+  }
+
+  void "wildcard domain example"() {
+    given:
+    def validator = new GateOriginValidator("http://foo", null, /^https?:\/\/(?:localhost|[^\/]+\.example\.com)(?::[1-9]\d*)?\/?/)
+
+    expect:
+    validator.isValidOrigin(origin) == expected
+
+    where:
+    origin                                                                    | expected
+    'http://localhost:9000'                                                   | true
+    'http://www.example.com'                                                  | true
+    'http://www.example.com:80/'                                              | true
+    'https://www.example.com'                                                 | true
+    'https://www.example.com:443/'                                            | true
+    'https://www.example.com:/'                                               | false
+    'https://www.example.com:0/'                                              | false
+    'https://www.example.com:08/'                                             | false
+    'https://www.evil.com' + URLEncoder.encode('/', 'UTF-8') + '.example.com' | false
+    'https://www.evil.com/.example.com/'                                      | false
+  }
+}


### PR DESCRIPTION
*Note:* this is a breaking change for anyone that is currently relying on the cors filter to allow any requesting domain with authentication, and is hitting the spinnaker API directly from other browser based web apps besides deck.

Adds a new `cors.allowedOriginsPattern` configuration property that takes a regex to match against the request origin. If successful, the request origin is returned as the `Access-Control-Allow-Origin` header. If unsuccessful, `*` is returned and the browser will then not supply cookies.

If not configured, then falls back to checking the hosts configured in the `services.deck.redirectHostPattern` property. Finally falls back to matching `services.deck.baseUrl`.

A reasonable example value for `cors.allowedOriginsPattern` would be:

````yaml
cors:
  allowedOriginsPattern: '^https?://(?:localhost|[^/]+\.example\.com)(?::[1-9]\d*)?/?$'
````

This would match any `http` or `https` request from `localhost` or `*.example.com` with or without a port supplied.