### PR TITLE
Adding X509UserIdentifierExtractor interface

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -54,9 +54,7 @@ import org.springframework.session.data.redis.config.ConfigureRedisAction
 import org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
-import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
-import redis.clients.util.Pool
 import retrofit.Endpoint
 import retrofit.RequestInterceptor
 import retrofit.RestAdapter

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509UserIdentifierExtractor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509UserIdentifierExtractor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.security.x509;
+
+import java.security.cert.X509Certificate;
+
+public interface X509UserIdentifierExtractor {
+
+  /**
+   * Extracts the user identifier (email, application name, instance id, etc)
+   * from the X509 certificate.
+   */
+  String fromCertificate(X509Certificate cert);
+}


### PR DESCRIPTION
This can be used to decorate additional information into a user's identity for non-human users (e.g. an application X509 in AWS could look like: `{app}-{accountId}-{instanceId}` for example).

@spinnaker/netflix-reviewers PTAL