### PR TITLE
Add Spring Cloud Config Server as optional source of properties

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -44,6 +44,8 @@ dependencies {
     exclude group: 'org.springframework.boot'
     exclude group: 'org.springframework.security'
   }
+  compile("org.springframework.cloud:spring-cloud-starter-config:1.0.6.RELEASE")
+  compile("org.springframework.cloud:spring-cloud-config-server:1.0.4.RELEASE")
 
   compile 'com.squareup.retrofit:converter-simplexml:1.9.0'
   testCompile "com.squareup.okhttp:mockwebserver:${spinnaker.version('okHttp')}"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SpringCloudConfigServerConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SpringCloudConfigServerConfig.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.cloud.config.server.EnableConfigServer
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Create an embedded config server.
+ *
+ * NOTE: It's opt-in via spring.cloud.config.server.bootstrap=true
+ */
+@Configuration
+@ConditionalOnProperty('spring.cloud.config.server.bootstrap')
+class SpringCloudConfigServerConfig {
+
+	@EnableConfigServer
+	static class SpringCloudEmbeddedConfigServer {}
+
+}

--- a/gate-web/src/main/resources/bootstrap.yml
+++ b/gate-web/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: gate # Embedded config server needs this setting sooner than can be reached via DEFAULT_PROPS
+  cloud:
+    config:
+      server:
+        bootstrap: false # Disabled by default
+        prefix: /config


### PR DESCRIPTION
* By default, config server is disabled. Enable with spring.cloud.config.server.enabled=true
* Gate will run the embedded config server to handle both CORS policy impacts as well as not expanding the footprint of Spinnaker
* It defaults to being served underneath /config