### PR TITLE
Passes 'X-Hub-Signature' through on webhook calls

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
@@ -29,7 +29,14 @@ class EventController {
   EventService eventService
 
   @RequestMapping(value = "/webhooks/{type}/{source}", method = RequestMethod.POST)
-  void webhooks(@PathVariable("type") String type, @PathVariable("source") String source, @RequestBody Map event) {
-    eventService.webhooks(type, source, event)
+  void webhooks(@PathVariable("type") String type,
+                @PathVariable("source") String source,
+                @RequestBody Map event,
+                @RequestHeader(value = "X-Hub-Signature", required = false) String gitHubSignature) {
+    if (gitHubSignature) {
+      eventService.webhooks(type, source, event, gitHubSignature)
+    } else {
+      eventService.webhooks(type, source, event)
+    }
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
@@ -60,11 +60,13 @@ class AuthConfig {
   }
 
   void configure(HttpSecurity http) throws Exception {
+    // @formatter:off
     http
       .authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-        .antMatchers('/auth/user').permitAll()
         .antMatchers(PermissionRevokingLogoutSuccessHandler.LOGGED_OUT_URL).permitAll()
+        .antMatchers('/auth/user').permitAll()
+        .antMatchers(HttpMethod.POST, '/webhooks/**').permitAll()
         .antMatchers('/health').permitAll()
         .antMatchers('/**').authenticated()
         .and()
@@ -75,6 +77,7 @@ class AuthConfig {
         .and()
       .csrf()
         .disable()
+    // @formatter:on
   }
 
   @Component

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.services
 import com.netflix.spinnaker.gate.services.internal.EchoService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 
 @CompileStatic
@@ -33,4 +34,7 @@ class EventService {
     echoService.webhooks(type, source, event)
   }
 
+  void webhooks(String type, String source, Map event, String signature) {
+    echoService.webhooks(type, source, event, signature)
+  }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
+import com.netflix.spinnaker.gate.controllers.EventController
 import retrofit.http.*
 import retrofit.client.Response
 
@@ -23,7 +24,16 @@ interface EchoService {
 
   @Headers("Accept: application/json")
   @POST("/webhooks/{type}/{source}")
-  Response webhooks(@Path('type') String type, @Path('source') String source, @Body Map event)
+  Response webhooks(@Path('type') String type,
+                    @Path('source') String source,
+                    @Body Map event)
+
+  @Headers("Accept: application/json")
+  @POST("/webhooks/{type}/{source}")
+  Response webhooks(@Path('type') String type,
+                    @Path('source') String source,
+                    @Body Map event,
+                    @Header("X-Hub-Signature") String signature)
 
   @GET("/validateCronExpression")
   Map validateCronExpression(@Query("cronExpression") String cronExpression)


### PR DESCRIPTION
Extracts and forwards the GitHub signature header, if present.

Additionally, POST calls to `/webhooks/**` need to have auth requirements opened up, which is also included in this PR.

@duftler @jtk54 @cfieber @ajordens. 

tag: https://github.com/spinnaker/fiat/issues/134