### PR TITLE
Adding endpoint to expose Orca task execution status metrics

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ExecutionsController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ExecutionsController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.TaskService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RequestMapping("/executions")
+@RestController
+public class ExecutionsController {
+
+  private TaskService taskService;
+
+  @Autowired
+  public ExecutionsController(TaskService taskService) {
+    this.taskService = taskService;
+  }
+
+  @RequestMapping(value = "/activeByInstance", method = RequestMethod.GET)
+  Map getActiveExecutionsByInstance() {
+    return taskService.getActiveExecutionsByInstance();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
@@ -62,5 +62,4 @@ class TaskController {
   Map getTaskDetails(@PathVariable("id") String id, @PathVariable("taskDetailsId") String taskDetailsId) {
     taskService.getTaskDetails(taskDetailsId)
   }
-
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -77,6 +77,12 @@ class TaskService {
     } execute()
   }
 
+  Map getActiveExecutionsByInstance() {
+    HystrixFactory.newMapCommand(GROUP, "getActiveExecutionsByInstance") {
+      orcaService.getActiveExecutionsByInstance()
+    } execute()
+  }
+
   /**
    * @deprecated  This pipeline operation does not belong here.
    */

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -57,6 +57,10 @@ interface OrcaService {
   Map cancelTasks(@Body List<String> taskIds)
 
   @Headers("Accept: application/json")
+  @GET("/executions/activeByInstance")
+  Map getActiveExecutionsByInstance()
+
+  @Headers("Accept: application/json")
   @GET("/pipelines/{id}")
   Map getPipeline(@Path("id") String id)
 


### PR DESCRIPTION
Not sure if this is the direction we'd like to go - exposing a generic endpoint like this?

```
{
  "runningExecutions": {
    "i-1234": 9000,
    "i-5678": 0,
    ...
  }
}
```

@robfletcher 