### PR TITLE
add full context to server group insight actions

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/ServerGroupServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/ServerGroupServiceSpec.groovy
@@ -26,19 +26,21 @@ class ServerGroupServiceSpec extends Specification {
     given:
     def service = new ServerGroupService(
         clouddriverService: Mock(ClouddriverService) {
-          1 * getServerGroupDetails(_, _, _, _) >> { return [:] }
+          1 * getServerGroupDetails(_, _, _, _) >> { return [cloudProvider: "aws"] }
         },
         providerLookupService: Stub(ProviderLookupService) {
           providerForAccount(_) >> "test"
         },
         insightConfiguration: new InsightConfiguration(
-            serverGroup: [new InsightConfiguration.Link(url: '${application}-${account}-${region}-${serverGroup}-{DNE}')]
+            serverGroup: [new InsightConfiguration.Link(
+              url: '${application}-${account}-${region}-${serverGroup}-${cloudProvider}-{DNE}'
+            )]
         )
     )
 
     expect:
     service.getForApplicationAndAccountAndRegion("application", "account", "region", "serverGroup").insightActions*.url == [
-        "application-account-region-serverGroup-{DNE}"
+        "application-account-region-serverGroup-aws-{DNE}"
     ]
   }
 


### PR DESCRIPTION
@anotherchrisberry or @cfieber please review.

It's currently not possible to have provider specific insight actions for server groups, since the context never includes `cloudProvider`. This just follows the pattern used in the instance service.