### PR TITLE
Adding basic API rate limiting

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.config;
+
+import com.netflix.spinnaker.gate.ratelimit.RateLimiter;
+import com.netflix.spinnaker.gate.ratelimit.RedisRateLimiter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPool;
+
+@Configuration
+@ConditionalOnExpression("${rateLimit.enabled:false}")
+public class RateLimiterConfig {
+
+  @Autowired(required = false)
+  RateLimiterConfiguration rateLimiterConfiguration;
+
+  @Bean
+  @ConditionalOnExpression("${rateLimit.redis.enabled:false}")
+  RateLimiter redisRateLimiter(JedisPool jedisPool) {
+    return new RedisRateLimiter(
+      jedisPool,
+      rateLimiterConfiguration.capacity,
+      rateLimiterConfiguration.rateSeconds,
+      rateLimiterConfiguration.capacityByPrincipal
+    );
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@ConfigurationProperties("rateLimit")
+public class RateLimiterConfiguration {
+
+  /**
+   * When learning mode is enabled, principals that go over their
+   * allocated rate limit will not receive a 429, but gate will still
+   * log that they would have been rate limited.
+   */
+  boolean learning = true;
+
+  /**
+   * The number of requests allowed in the given rateSeconds window.
+   */
+  int capacity = 60;
+
+  /**
+   * The number of seconds for each rate limit bucket. Capacity will be
+   * filled at the beginning of each rate interval.
+   */
+  int rateSeconds = 10;
+
+  /**
+   * A principal-specific capacity override map. This can be defined if
+   * you want to give a specific principal more or less capacity per
+   * rateSeconds than the default.
+   */
+  Map<String, Integer> capacityByPrincipal = new HashMap<>();
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class Rate {
+
+  private static final String CAPACITY_HEADER = "X-RateLimit-Capacity";
+  private static final String REMAINING_HEADER = "X-RateLimit-Remaining";
+  private static final String RESET_HEADER = "X-RateLimit-Reset";
+
+  Integer capacity;
+  Integer remaining;
+  Long reset;
+  Boolean throttled;
+
+  public boolean isThrottled() {
+    return throttled;
+  }
+
+  public void assignHttpHeaders(HttpServletResponse response) {
+    response.setIntHeader(CAPACITY_HEADER, capacity);
+    response.setIntHeader(REMAINING_HEADER, remaining);
+    response.setDateHeader(RESET_HEADER, reset);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimiter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimiter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+public interface RateLimiter {
+
+  Rate incrementAndGetRate(String key);
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import com.netflix.spinnaker.security.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
+
+  private static Logger log = LoggerFactory.getLogger(RateLimitingInterceptor.class);
+
+  private static String UNKNOWN_PRINCIPAL = "unknown";
+
+  RateLimiter rateLimiter;
+  boolean learning;
+
+  public RateLimitingInterceptor(RateLimiter rateLimiter, boolean learning) {
+    this.rateLimiter = rateLimiter;
+    this.learning = learning;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    String principal = getPrincipal().toString();
+    if (UNKNOWN_PRINCIPAL.equals(principal)) {
+      // Occurs when Spring decides to dispatch to /error after we send the initial 429.
+      // Pass through so that the JSON error body gets rendered.
+      return true;
+    }
+
+    Rate rate = rateLimiter.incrementAndGetRate(principal);
+
+    if (learning) {
+      if (rate.isThrottled()) {
+        log.warn("Rate limiting principal (principal: {}, learning: true)", principal);
+      }
+      return true;
+    }
+
+    rate.assignHttpHeaders(response);
+
+    if (rate.isThrottled()) {
+      log.warn("Rate limiting principal (principal: {})", principal);
+      response.sendError(429, "Rate capacity exceeded");
+      return false;
+    }
+
+    return true;
+  }
+
+  private Object getPrincipal() {
+    SecurityContext context = SecurityContextHolder.getContext();
+    Authentication authentication = context.getAuthentication();
+
+    if (authentication == null) {
+      return UNKNOWN_PRINCIPAL;
+    }
+
+    if (authentication.getPrincipal() instanceof User) {
+      return ((User) authentication.getPrincipal()).getEmail();
+    }
+
+    log.warn("Unknown principal type, assuming anonymous");
+    return "anonymous";
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiter.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+
+public class RedisRateLimiter implements RateLimiter {
+
+  private final static Logger log = LoggerFactory.getLogger(RedisRateLimiter.class);
+
+  JedisPool jedisPool;
+
+  private final int defaultCapacity;
+  private final int rate;
+  private final Map<String, Integer> principalOverrides;
+
+  public RedisRateLimiter(JedisPool jedisPool, int capacity, int rateSeconds, Map<String, Integer> principalOverrides) {
+    this.jedisPool = jedisPool;
+    this.defaultCapacity = capacity;
+    this.rate = rateSeconds;
+    this.principalOverrides = principalOverrides;
+  }
+
+  @Override
+  public Rate incrementAndGetRate(String name) {
+    String key = getRedisKey(name);
+
+    try (Jedis jedis = jedisPool.getResource()) {
+      int capacity = getCapacity(jedis, name);
+      String count = jedis.get(key);
+
+      Bucket bucket;
+      if (count == null) {
+        bucket = Bucket.buildNew(name, capacity, rate);
+      } else {
+        Long ttl = jedis.pttl(key);
+        bucket = Bucket.buildExisting(name, capacity, rate, Integer.parseInt(count), ttl.intValue());
+      }
+
+      bucket.increment(jedis);
+
+      return bucket.toRate();
+    } catch (JedisException e) {
+      log.error("failed getting rate limit, disabling for request", e);
+      Rate rate = new Rate();
+      rate.throttled = false;
+      rate.capacity = 0;
+      rate.remaining = 0;
+      rate.reset = new Date().getTime();
+      return rate;
+    }
+  }
+
+  private int getCapacity(Jedis jedis, String name) {
+    String capacity = jedis.get(getRedisCapacityKey(name));
+    if (capacity != null) {
+      try {
+        return Integer.parseInt(capacity);
+      } catch (NumberFormatException e) {
+        log.error("invalid principal capacity value, expected integer (principal: {}, value: {})", name, capacity);
+      }
+    }
+    return principalOverrides.getOrDefault(name, defaultCapacity);
+  }
+
+  private static String getRedisCapacityKey(String name) {
+    return "rateLimit:capacity:" + name;
+  }
+
+  private static String getRedisKey(String name) {
+    return "rateLimit:" + name;
+  }
+
+  private static class Bucket {
+    String name;
+    Integer capacity;
+    Integer remaining;
+    Date reset;
+    int rate;
+
+    static Bucket buildNew(String name, Integer capacity, Integer rate) {
+      Bucket bucket = new Bucket();
+      bucket.name = name;
+      bucket.capacity = capacity;
+      bucket.remaining = capacity;
+
+      Calendar calendar = Calendar.getInstance();
+      calendar.add(Calendar.SECOND, rate);
+
+      bucket.reset = calendar.getTime();
+      bucket.rate = rate;
+
+      return bucket;
+    }
+
+    static Bucket buildExisting(String name, Integer capacity, Integer rate, Integer count, Integer ttl) {
+      Bucket bucket = new Bucket();
+      bucket.name = name;
+      bucket.capacity = capacity;
+      bucket.remaining = capacity - Math.min(capacity, count);
+
+      Calendar calendar = Calendar.getInstance();
+      calendar.add(Calendar.MILLISECOND, ttl);
+
+      bucket.reset = calendar.getTime();
+      bucket.rate = rate;
+
+      return bucket;
+    }
+
+    void increment(Jedis jedis) {
+      String key = getKey();
+
+      Long newCount = jedis.incr(key);
+      if (newCount == 1) {
+        remaining = capacity - 1;
+        jedis.pexpire(key, reset.getTime() - new Date().getTime());
+        return;
+      }
+
+      remaining = capacity - newCount.intValue();
+    }
+
+    private String getKey() {
+      return "rateLimit:" + name;
+    }
+
+    Rate toRate() {
+      Rate rate = new Rate();
+      rate.capacity = capacity;
+      rate.remaining = Math.max(remaining, 0);
+      rate.reset = reset.getTime();
+      rate.throttled = remaining < 0;
+      return rate;
+    }
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiterSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiterSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit
+
+import com.netflix.spinnaker.gate.redis.EmbeddedRedis
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class RedisRateLimiterSpec extends Specification {
+
+  static int port
+
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedis
+
+  def setupSpec() {
+    embeddedRedis = EmbeddedRedis.embed()
+    embeddedRedis.jedis.flushDB()
+    port = embeddedRedis.port
+  }
+
+  def cleanup() {
+    embeddedRedis.jedis.flushDB()
+  }
+
+  def 'should create new bucket for unknown principal'() {
+    given:
+    RedisRateLimiter subject = new RedisRateLimiter((JedisPool) embeddedRedis.pool, 10, 10, [:])
+
+    when:
+    Rate rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    noExceptionThrown()
+    rate.capacity == 10
+    rate.remaining == 9
+    rate.reset > new Date().getTime()
+    !rate.isThrottled()
+  }
+
+  def 'should fill bucket after expiry'() {
+    given:
+    RedisRateLimiter subject = new RedisRateLimiter((JedisPool) embeddedRedis.pool, 10, 1, [:])
+
+    when:
+    Rate rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    noExceptionThrown()
+    rate.capacity == 10
+    rate.remaining == 9
+
+    when:
+    rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    rate.capacity == 10
+    rate.remaining == 8
+
+    when:
+    sleep(1000)
+    rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    rate.remaining == 9
+  }
+
+  def 'should throttle after bucket empties'() {
+    given:
+    RedisRateLimiter subject = new RedisRateLimiter((JedisPool) embeddedRedis.pool, 3, 1, [:])
+
+    when:
+    subject.incrementAndGetRate('user@example.com')
+    Rate rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    rate.remaining == 1
+    !rate.throttled
+
+    when:
+    rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    rate.remaining == 0
+    !rate.throttled
+
+    when:
+    rate = subject.incrementAndGetRate('user@example.com')
+
+    then:
+    rate.remaining == 0
+    rate.throttled
+  }
+
+  def 'should allow static and dynamic capacity overrides'() {
+    given:
+    RedisRateLimiter subject = new RedisRateLimiter((JedisPool) embeddedRedis.pool, 3, 1, [
+      'foo': 5
+    ])
+
+    Jedis jedis = embeddedRedis.pool.resource
+    jedis.set("rateLimit:capacity:bar", "8")
+    jedis.set("rateLimit:capacity:invalid", "hello")
+
+    expect:
+    subject.getCapacity(jedis, 'no-override') == 3
+    subject.getCapacity(jedis, 'foo') == 5
+    subject.getCapacity(jedis, 'bar') == 8
+    subject.getCapacity(jedis, 'invalid') == 3
+
+    cleanup:
+    jedis.close()
+  }
+}


### PR DESCRIPTION
I opted for a bucketed approach, rather than a sliding window since it's a lot simpler from a storage perspective. We can avoid horrible, bursty death by making the buckets smaller, which should suffice.

```
rateLimit:
  enabled: true
  learning: true
  redis:
    enabled: true
  capacity: 5
  rateSeconds: 30
  capacityByPrincipal:
    anonymous: 50
```

@spinnaker/netflix-reviewers PTAL