### PR TITLE
clean up batch endpoint (remove extra batch in path)

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/BatchEntityTagsController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/BatchEntityTagsController.java
@@ -37,7 +37,7 @@ public class BatchEntityTagsController {
     this.taskService = taskService;
   }
 
-  @RequestMapping(value = "/batch", method = RequestMethod.POST)
+  @RequestMapping(method = RequestMethod.POST)
   @ResponseStatus(value = HttpStatus.ACCEPTED)
   public Map batchUpdate(@RequestBody List<Map> entityTags) {
     Map<String, Object> job = new HashMap<>();


### PR DESCRIPTION
`/batch/tags/batch` is a little redundant