### PR TITLE
Add BitBucket support

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EventController.groovy
@@ -32,9 +32,11 @@ class EventController {
   void webhooks(@PathVariable("type") String type,
                 @PathVariable("source") String source,
                 @RequestBody Map event,
-                @RequestHeader(value = "X-Hub-Signature", required = false) String gitHubSignature) {
-    if (gitHubSignature) {
-      eventService.webhooks(type, source, event, gitHubSignature)
+                @RequestHeader(value = "X-Hub-Signature", required = false) String gitHubSignature,
+                @RequestHeader(value = "X-Event-Key", required = false) String bitBucketEventType)
+  {
+    if (gitHubSignature || bitBucketEventType) {
+      eventService.webhooks(type, source, event, gitHubSignature, bitBucketEventType)
     } else {
       eventService.webhooks(type, source, event)
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EventService.groovy
@@ -34,7 +34,7 @@ class EventService {
     echoService.webhooks(type, source, event)
   }
 
-  void webhooks(String type, String source, Map event, String signature) {
-    echoService.webhooks(type, source, event, signature)
+  void webhooks(String type, String source, Map event, String gitHubSignature, String bitBucketEventType) {
+    echoService.webhooks(type, source, event, gitHubSignature, bitBucketEventType)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -33,7 +33,8 @@ interface EchoService {
   Response webhooks(@Path('type') String type,
                     @Path('source') String source,
                     @Body Map event,
-                    @Header("X-Hub-Signature") String signature)
+                    @Header("X-Hub-Signature") String gitHubSignature,
+                    @Header("X-Event-Key") String bitBucketEventType)
 
   @GET("/validateCronExpression")
   Map validateCronExpression(@Query("cronExpression") String cronExpression)


### PR DESCRIPTION
PR [#153](https://github.com/spinnaker/igor/pull/153) has been opened against Igor.
PR [#137](https://github.com/spinnaker/echo/pull/137) has been opened against Echo.

A PR is also being opened against Deck.

BitBucket Server (a.k.a. Stash) support already exists. This adds BitBucket Cloud support of pipeline triggers based on BitBucket webhooks and provides Orca the ability to retrieve a list of commits from BitBucket as part of it's GetCommits stage.
