### PR TITLE
Enable Basic Auth in order to support spectator sidecar adaptor

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
@@ -62,6 +62,8 @@ class AuthConfig {
   void configure(HttpSecurity http) throws Exception {
     // @formatter:off
     http
+      .httpBasic()
+        .and()
       .authorizeRequests()
         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
         .antMatchers(PermissionRevokingLogoutSuccessHandler.LOGGED_OUT_URL).permitAll()


### PR DESCRIPTION
@cfieber @ewiseblatt @gardleopard FYI