### PR TITLE
feat(ratelimit): Adding source IP address to anonymous prinicipal

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiter.java
@@ -74,6 +74,10 @@ public class RedisRateLimiter implements RateLimiter {
   }
 
   private int getCapacity(Jedis jedis, String name) {
+    if (name.startsWith("anonymous")) {
+      name = "anonymous";
+    }
+
     String capacity = jedis.get(getRedisCapacityKey(name));
     if (capacity != null) {
       try {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiterSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimiterSpec.groovy
@@ -128,4 +128,21 @@ class RedisRateLimiterSpec extends Specification {
     cleanup:
     jedis.close()
   }
+
+  def 'should use same capacity override for all anonymous principals'() {
+    given:
+    RedisRateLimiter subject = new RedisRateLimiter((JedisPool) embeddedRedis.pool, 3, 1, [
+      'anonymous': 5
+    ])
+
+    Jedis jedis = embeddedRedis.pool.resource
+
+    expect:
+    subject.getCapacity(jedis, 'foo') == 3
+    subject.getCapacity(jedis, 'anonymous') == 5
+    subject.getCapacity(jedis, 'anonymous-10.10.10.10') == 5
+
+    cleanup:
+    jedis.close()
+  }
 }


### PR DESCRIPTION
Allows the ratelimiter to bucket anonymous principal usage by their source IP, rather than bucketing all anonymous users into the same bucket. Any `capacityByPrinicipal` settings for `anonymous` will still apply to all anonymous principals.

@robfletcher PTAL