### PR TITLE
chore(fiat): Bumps Fiat API, dropping autoConfig property

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -37,7 +37,6 @@ services:
     enabled: false
   fiat:
     enabled: false
-    autoConfig: false
   flapjack:
     enabled: false
   igor:

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -29,7 +29,7 @@ dependencies {
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency("frigga")
   compile spinnaker.dependency('cglib')
-  compile "com.netflix.spinnaker.fiat:fiat-api:0.21.0"
+  compile "com.netflix.spinnaker.fiat:fiat-api:0.22.0"
 
   compile('com.github.kstyrc:embedded-redis:0.6')
   compile('org.springframework.session:spring-session-data-redis:1.1.1.RELEASE')

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.gate.config
 
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import org.springframework.beans.factory.annotation.Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -16,9 +16,9 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Role
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.gate.retrofit.UpstreamBadRequest
 import com.netflix.spinnaker.gate.security.SpinnakerUser

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.gate
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.controllers.ApplicationController
 import com.netflix.spinnaker.gate.controllers.PipelineController
@@ -27,23 +27,23 @@ import com.netflix.spinnaker.gate.services.ExecutionHistoryService
 import com.netflix.spinnaker.gate.services.PipelineService
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.commands.ThrottledRequestException
-import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaService
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.context.ConfigurableApplicationContext
-import retrofit.RetrofitError
-
-import java.util.concurrent.ExecutorService
-import org.springframework.boot.SpringApplication
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit.RestAdapter
+import retrofit.RetrofitError
 import retrofit.client.OkClient
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.util.concurrent.ExecutorService
 
 class FunctionalSpec extends Specification {
 

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.netflix.spinnaker.config.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import spock.lang.Specification
 import spock.lang.Subject


### PR DESCRIPTION
Gate is the special snowflake of why the `services.fiat.autoConfig` property was added. https://github.com/spinnaker/fiat/pull/154 addressed the problem that `autoConfig` wasn't really supposed to be a user-configurable flag - instead it was more supposed to be a component-specific attribute. 

@cfieber @jtk54 - this is a non-`@EnableFiatAutoConfig` component (the only one). PTAL.

Tests won't pass until https://github.com/spinnaker/fiat/pull/154 is submitted and released.