### PR TITLE
chore(auth): Removes basicAuth.enabled in favor of standard 

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -38,7 +38,7 @@ class CredentialsController {
   @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'READ')")
   @RequestMapping(method = RequestMethod.GET)
   List<ClouddriverService.Account> getAccounts(@SpinnakerUser User user) {
-    credentialsService.getAccounts(user.roles)
+    credentialsService.getAccounts(user?.roles ?: [])
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.security.SecurityProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -45,8 +46,8 @@ class AuthConfig {
   @Autowired
   PermissionRevokingLogoutSuccessHandler permissionRevokingLogoutSuccessHandler
 
-  @Value('${basicAuth.enabled:false}')
-  Boolean basicAuthEnabled
+  @Autowired
+  SecurityProperties securityProperties
 
   @Bean
   @ConditionalOnMissingBean(UserRolesProvider)
@@ -84,10 +85,9 @@ class AuthConfig {
         .disable()
     // @formatter:on
 
-    if (basicAuthEnabled) {
+    if (securityProperties.basic.enabled) {
       result.httpBasic()
     }
-
   }
 
   @Component


### PR DESCRIPTION
`security.basic.enabled`.

@anotherchrisberry - you added the `basicAuth.enabled` in response to a PR I made. There already exists a standard property, which this PR uses instead of that one. It also looks like there is already a `gate.properties` [file](https://github.com/spinnaker/gate/blob/master/gate-web/src/main/resources/gate.properties) that turns this property off by default, but I don't know if you guys deploy with that file (because I don't think you deploy with the internal gate-web/config/gate.yml file).

 Please confirm that this change does not pop up that HTTP Basic browser dialog box.

@jtk54 PTAL, too.

@lwander, @ewiseblatt FYI
