### PR TITLE
fix(tls) - disable TLS client renegotiation, update kork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.68.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.85.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -38,6 +38,10 @@ import org.springframework.scheduling.annotation.EnableAsync
 @ComponentScan(["com.netflix.spinnaker.gate", "com.netflix.spinnaker.config"])
 @EnableAutoConfiguration(exclude = [SecurityAutoConfiguration, GroovyTemplateAutoConfiguration])
 class Main extends SpringBootServletInitializer {
+  static {
+    System.setProperty("jdk.tls.rejectClientInitiatedRenegotiation", System.getProperty("jdk.tls.rejectClientInitiatedRenegotiation", "true"))
+  }
+
   static final Map<String, String> DEFAULT_PROPS = [
           'netflix.environment': 'test',
           'netflix.account': '${netflix.environment}',


### PR DESCRIPTION
mitigates a potential DDoS attack of repeatedly renegotiating TLS
picks up latest kork version for TLS config updates

requires release of https://github.com/spinnaker/kork/pull/75 and 
https://github.com/spinnaker/spinnaker-dependencies/issues/77