### PR TITLE
fix(instanceService): prevents merge of instance and account details

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
@@ -41,12 +41,12 @@ class InstanceService {
   Map getForAccountAndRegion(String account, String region, String instanceId) {
     HystrixFactory.newMapCommand(GROUP, "getInstancesForAccountAndRegion-${providerLookupService.providerForAccount(account)}") {
       def accountDetails = clouddriverService.getAccount(account)
-      def instanceDetails = clouddriverService.getInstanceDetails(account, region, instanceId) << accountDetails
+      def instanceDetails = clouddriverService.getInstanceDetails(account, region, instanceId)
       def instanceContext = instanceDetails.collectEntries {
         return it.value instanceof String ? [it.key, it.value] : [it.key, ""]
       } as Map<String, String>
 
-      def context = getContext(account, region, instanceId) + instanceContext
+      def context = getContext(account, region, instanceId) + instanceContext + accountDetails
       return instanceDetails + [
           "insightActions": insightConfiguration.instance.findResults { it.applyContext(context) }
       ]


### PR DESCRIPTION
@icfantv or @anotherchrisberry please review.

`instanceDetails` and `accountDetails` shouldn't be merged, since the instance details endpoint returns this merged map. This change still populates the insight action context.