### PR TITLE
feat(web): Adding rate limit headers to all 429 errors

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
@@ -19,9 +19,10 @@ import javax.servlet.http.HttpServletResponse;
 
 public class Rate {
 
-  private static final String CAPACITY_HEADER = "X-RateLimit-Capacity";
-  private static final String REMAINING_HEADER = "X-RateLimit-Remaining";
-  private static final String RESET_HEADER = "X-RateLimit-Reset";
+  static final String CAPACITY_HEADER = "X-RateLimit-Capacity";
+  static final String REMAINING_HEADER = "X-RateLimit-Remaining";
+  static final String RESET_HEADER = "X-RateLimit-Reset";
+  static final String LEARNING_HEADER = "X-RateLimit-Learning";
 
   Integer capacity;
   Integer rateSeconds;
@@ -33,9 +34,10 @@ public class Rate {
     return throttled;
   }
 
-  public void assignHttpHeaders(HttpServletResponse response) {
+  public void assignHttpHeaders(HttpServletResponse response, Boolean learning) {
     response.setIntHeader(CAPACITY_HEADER, capacity);
     response.setIntHeader(REMAINING_HEADER, remaining);
     response.setDateHeader(RESET_HEADER, reset);
+    response.setHeader(LEARNING_HEADER, learning.toString());
   }
 }


### PR DESCRIPTION
Some small improvements to rate limiting:

* Added `X-RateLimit-Learning` bool header. 
* Send rate limit headers in learning mode.
* Intercepting all 429 errors to verify the rate limit headers are added (Hystrix circuit-breaking, for example, wasn't returning rate limit errors). If the reset header is undefined, the date is set to five seconds in the future.
* Consistency between learning/enforcing log messages

@spinnaker/reviewers PTAL