### PR TITLE
feat(authN/ldap): Adds userSearchBase and userSearchFilter properties for LDAP

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -70,6 +70,14 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
     if (ldapConfigProps.userDnPattern) {
       ldapConfigurer.userDnPatterns(ldapConfigProps.userDnPattern)
     }
+
+    if (ldapConfigProps.userSearchBase) {
+      ldapConfigurer.userSearchBase(ldapConfigProps.userSearchBase)
+    }
+
+    if (ldapConfigProps.userSearchFilter) {
+      ldapConfigurer.userSearchFilter(ldapConfigProps.userSearchFilter)
+    }
   }
 
   @Override
@@ -115,5 +123,7 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
     String groupSearchBase
 
     String userDnPattern
+    String userSearchBase
+    String userSearchFilter
   }
 }


### PR DESCRIPTION
Exposes additional spring-security fields for the LDAP configuration that allow resolving the user via search instead of a user DN template.

See [here](https://github.com/spinnaker/fiat/issues/30#issuecomment-289835132) for discussion, and a corresponding fiat PR at https://github.com/spinnaker/fiat/pull/169.