### PR TITLE
fix(auth): (Re)add auth protection for Spring management endpoints

### DIFF
--- a/gate-web/src/main/resources/gate.properties
+++ b/gate-web/src/main/resources/gate.properties
@@ -1,4 +1,0 @@
-#security configuration
-security.basic.enabled=false
-management.security.enabled=false
-


### PR DESCRIPTION
Spring endpoints (such as /env and /resolvedEnv) are currently overexposed. This PR removes the settings that expose them.

This means that an admin will need to know the HTTP Basic username/password in order to hit those endpoints when some form of authentication is turned on (OAuth, SAML, etc).

@cfieber @jtk54 PTAL
@skim1420 @lwander FYI