### PR TITLE
feat(applications): allow clusters to be skipped when application details

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -57,8 +57,8 @@ class ApplicationController {
   }
 
   @RequestMapping(value = "/{application:.+}", method = RequestMethod.GET)
-  Map getApplication(@PathVariable("application") String application) {
-    def result = applicationService.getApplication(application)
+  Map getApplication(@PathVariable("application") String application, @RequestParam(value = "expand", defaultValue = "true") boolean expand) {
+    def result = applicationService.getApplication(application, expand)
     if (!result) {
       log.warn("Application ${application} not found")
       throw new ApplicationNotFoundException("Application ${application} not found")

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -112,7 +112,7 @@ class FunctionalSpec extends Specification {
       api.getApplication(name)
 
     then:
-      1 * applicationService.getApplication(name) >> [name: name]
+      1 * applicationService.getApplication(name, true) >> [name: name]
 
     where:
       name = "foo"
@@ -123,7 +123,7 @@ class FunctionalSpec extends Specification {
       api.getApplication(name)
 
     then:
-      1 * applicationService.getApplication(name) >> null
+      1 * applicationService.getApplication(name, true) >> null
 
       RetrofitError exception = thrown()
       exception.response.status == 404


### PR DESCRIPTION
This allows cluster details to be turned off when requesting details from the application view as getting a list of clusters can be expensive. i.e, `http://localhost:7002/applications/titustestapp?clusters=false`. 