### PR TITLE
fix(credentials): allow account names with dots

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -46,7 +46,7 @@ class CredentialsController {
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @ApiOperation(value = "Retrieve an account's details")
-  @RequestMapping(value = '/{account}', method = RequestMethod.GET)
+  @RequestMapping(value = '/{account:.+}', method = RequestMethod.GET)
   Map getAccount(@PathVariable("account") String account) {
     credentialsService.getAccount(account)
   }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Schibsted ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.gate.services.AccountLookupService
+import com.netflix.spinnaker.gate.services.CredentialsService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.squareup.okhttp.mockwebserver.MockWebServer
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+class CredentialsControllerTest extends Specification {
+
+  MockMvc mockMvc
+  ClouddriverService clouddriverService
+
+  def server = new MockWebServer()
+
+  void cleanup() {
+    server.shutdown()
+  }
+
+  void setup() {
+    AccountLookupService  accountLookupService = Mock(AccountLookupService) {
+      getAccounts() >> ["test", "test.com"]
+    }
+    FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
+
+    clouddriverService = Mock(ClouddriverService)
+
+    @Subject
+    CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
+      clouddriverService: clouddriverService,
+      fiatConfig: fiatConfig)
+
+    server.start()
+    mockMvc = MockMvcBuilders.standaloneSetup(new CredentialsController(credentialsService: credentialsService)).build()
+  }
+
+  @Unroll
+  def "should accept account names with dots"() {
+    given:
+    1 * clouddriverService.getAccount(account) >> ["accountName": account]
+
+    when:
+    MockHttpServletResponse response = mockMvc.perform(get("/credentials/${account}")
+      .accept(MediaType.APPLICATION_JSON)).andReturn().response
+
+    then:
+    response.status == 200
+    response.contentAsString == "{\"accountName\":\"${expectedAccount}\"}"
+
+    where:
+    account    || expectedAccount
+    "test"     || "test"
+    "test.com" || "test.com"
+  }
+}


### PR DESCRIPTION
We have a docker registry account named like `registry.company.domain` and it is resolved as `registry.company`.

Changing the `RequestMapping` parameter to a regex like `.+` solves the issue.