### PR TITLE
feat(web): Adding request logging interceptor

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.gate.interceptors.RequestLoggingInterceptor
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter
 import com.netflix.spinnaker.gate.ratelimit.RateLimitingInterceptor
 import com.netflix.spinnaker.gate.retrofit.UpstreamBadRequest
@@ -56,6 +57,9 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
   @Value('${rateLimit.learning:true}')
   Boolean rateLimitLearningMode
 
+  @Value('${requestLogging.enabled:false}')
+  Boolean requestLogging
+
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(
@@ -63,6 +67,10 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
         this.registry, "controller.invocations", ["account", "region"], ["BasicErrorController"]
       )
     )
+
+    if (requestLogging) {
+      registry.addInterceptor(new RequestLoggingInterceptor());
+    }
 
     if (rateLimiter != null) {
       registry.addInterceptor(new RateLimitingInterceptor(rateLimiter, spectatorRegistry, rateLimiterConfiguration))

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.interceptors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class RequestLoggingInterceptor extends HandlerInterceptorAdapter {
+
+  private Logger log = LoggerFactory.getLogger(getClass());
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+    // 127.0.0.1 "GET /limecat.jpg HTTP/1.0" 200 2326
+    log.debug(String.format(
+      "%s \"%s %s %s\" %d %d",
+      sourceIpAddress(request),
+      request.getMethod(),
+      getRequestEndpoint(request),
+      request.getProtocol(),
+      response.getStatus(),
+      getResponseSize(response)
+    ));
+  }
+
+  private static String sourceIpAddress(HttpServletRequest request) {
+    String ip = request.getHeader("X-FORWARDED-FOR");
+    if (ip == null) {
+      return request.getRemoteAddr();
+    }
+    return ip;
+  }
+
+  private static String getRequestEndpoint(HttpServletRequest request) {
+    String endpoint = request.getRequestURI();
+    if (request.getQueryString() != null) {
+      return endpoint + "?" + request.getQueryString();
+    }
+    return endpoint;
+  }
+
+  private static int getResponseSize(HttpServletResponse response) {
+    if (response instanceof ContentCachingResponseWrapper) {
+      return ((ContentCachingResponseWrapper) response).getContentAsByteArray().length;
+    }
+    return -1;
+  }
+
+}


### PR DESCRIPTION
Basic request logging interceptor, which we need to help identify API client behaviors while evaluating rate limit capacities. Since we don't proxy gate with Apache or anything else, it's hard to determine what clients are actually doing when they're being rate limited.

@spinnaker/netflix-reviewers PTAL