### PR TITLE
feat(webhooks): Support preconfigured webhook stages

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/WebhookController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/WebhookController.groovy
@@ -16,19 +16,24 @@
 
 package com.netflix.spinnaker.gate.controllers
 
-import com.netflix.spinnaker.gate.services.EventService
-import groovy.transform.CompileStatic
+import com.netflix.spinnaker.gate.services.WebhookService
+import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
 
-@CompileStatic
 @RestController
-class EventController {
+@RequestMapping("/webhooks")
+class WebhookController {
 
   @Autowired
-  EventService eventService
+  WebhookService webhookService
 
-  @RequestMapping(value = "/webhooks/{type}/{source}", method = RequestMethod.POST)
+  @RequestMapping(value = "/{type}/{source}", method = RequestMethod.POST)
   void webhooks(@PathVariable("type") String type,
                 @PathVariable("source") String source,
                 @RequestBody Map event,
@@ -36,9 +41,15 @@ class EventController {
                 @RequestHeader(value = "X-Event-Key", required = false) String bitBucketEventType)
   {
     if (gitHubSignature || bitBucketEventType) {
-      eventService.webhooks(type, source, event, gitHubSignature, bitBucketEventType)
+      webhookService.webhooks(type, source, event, gitHubSignature, bitBucketEventType)
     } else {
-      eventService.webhooks(type, source, event)
+      webhookService.webhooks(type, source, event)
     }
+  }
+
+  @ApiOperation(value = "Retrieve a list of preconfigured webhooks in Orca")
+  @RequestMapping(value = "/preconfigured", method = RequestMethod.GET)
+  List preconfiguredWebhooks() {
+    return webhookService.preconfiguredWebhooks()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/WebhookService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/WebhookService.groovy
@@ -17,18 +17,18 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.internal.EchoService
-import groovy.transform.CompileStatic
+import com.netflix.spinnaker.gate.services.internal.OrcaService
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 
-@CompileStatic
 @Component
-class EventService {
-  private static final String GROUP = "events"
+class WebhookService {
 
   @Autowired(required = false)
   EchoService echoService
+
+  @Autowired
+  OrcaService orcaService
 
   void webhooks(String type, String source, Map event) {
     echoService.webhooks(type, source, event)
@@ -36,5 +36,9 @@ class EventService {
 
   void webhooks(String type, String source, Map event, String gitHubSignature, String bitBucketEventType) {
     echoService.webhooks(type, source, event, gitHubSignature, bitBucketEventType)
+  }
+
+  List preconfiguredWebhooks() {
+    return orcaService.preconfiguredWebhooks()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
-import com.netflix.spinnaker.gate.controllers.EventController
 import retrofit.http.*
 import retrofit.client.Response
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -103,4 +103,8 @@ interface OrcaService {
   @Headers("Accept: application/json")
   @GET("/pipelines/{id}/evaluateExpression")
   Map evaluateExpressionForExecution(@Path("id") String executionId, @Query("expression") String pipelineExpression)
+  
+  @Headers("Accept: application/json")
+  @GET("/webhooks/preconfigured")
+  List preconfiguredWebhooks()
 }


### PR DESCRIPTION
This adds support for a new endpoint for preconfigured webhooks in Orca.

I was in doubt where to put this logic. I ended up renaming `Event(Service|Controller)` to `Webhook(Service|Controller)` and putting it there, as some other webhook related functionality already lived there. If this is undesired, please let me know, and I'll fix 👍 

Corresponds with https://github.com/spinnaker/orca/pull/1329.