### PR TITLE
fix(oauth): Fix UnsatifiedDependencyException

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -126,6 +126,7 @@ class OAuth2SsoConfig {
    * preEstablishedRedirectUri, if set, where the SSL is terminated outside of this server.
    */
   @Component
+  @ConditionalOnExpression(''''${spring.oauth2.client.clientId:}'!=""''')
   static class ExternalSslAwareEntryPoint extends LoginUrlAuthenticationEntryPoint {
 
     @Autowired


### PR DESCRIPTION
It looks like the ExternalSslAwareEntryPoint component is being created even though the outer class has a ConditionalOnExpression which returns false. I guess as it is a different class found by spring on startup and it doesn't consider it related to the outer class.

So i've simply duplicated the ConditionalOnExpression from the outer class to ExternalSslAwareEntryPoint.

I'm not 100% convinced this is the correct fix - but i thought i'd take a shot at it :)