### PR TITLE
feat(ratelimit): Parity of static & redis configs

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.config
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.gate.interceptors.RequestLoggingInterceptor
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter
+import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider
 import com.netflix.spinnaker.gate.ratelimit.RateLimitingInterceptor
 import com.netflix.spinnaker.gate.retrofit.UpstreamBadRequest
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
@@ -46,7 +47,7 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
   Registry registry
 
   @Autowired(required = false)
-  RateLimiterConfiguration rateLimiterConfiguration
+  RateLimitPrincipalProvider rateLimiterPrincipalProvider
 
   @Autowired(required = false)
   RateLimiter rateLimiter
@@ -73,7 +74,7 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
     }
 
     if (rateLimiter != null) {
-      registry.addInterceptor(new RateLimitingInterceptor(rateLimiter, spectatorRegistry, rateLimiterConfiguration))
+      registry.addInterceptor(new RateLimitingInterceptor(rateLimiter, spectatorRegistry, rateLimiterPrincipalProvider))
     }
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
@@ -16,9 +16,13 @@
 package com.netflix.spinnaker.gate.config;
 
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter;
+import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider;
+import com.netflix.spinnaker.gate.ratelimit.RedisRateLimitPrincipalProvider;
 import com.netflix.spinnaker.gate.ratelimit.RedisRateLimiter;
+import com.netflix.spinnaker.gate.ratelimit.StaticRateLimitPrincipalProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
@@ -33,11 +37,18 @@ public class RateLimiterConfig {
   @Bean
   @ConditionalOnExpression("${rateLimit.redis.enabled:false}")
   RateLimiter redisRateLimiter(JedisPool jedisPool) {
-    return new RedisRateLimiter(
-      jedisPool,
-      rateLimiterConfiguration.capacity,
-      rateLimiterConfiguration.rateSeconds,
-      rateLimiterConfiguration.capacityByPrincipal
-    );
+    return new RedisRateLimiter(jedisPool);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${rateLimit.redis.enabled:false}")
+  RateLimitPrincipalProvider redisRateLimiterPrincipalProvider(JedisPool jedisPool) {
+    return new RedisRateLimitPrincipalProvider(jedisPool, rateLimiterConfiguration);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(RateLimitPrincipalProvider.class)
+  RateLimitPrincipalProvider staticRateLimiterPrincipalProvider() {
+    return new StaticRateLimitPrincipalProvider(rateLimiterConfiguration);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
@@ -19,9 +19,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Component
 @ConfigurationProperties("rateLimit")
@@ -50,7 +48,12 @@ public class RateLimiterConfiguration {
    * you want to give a specific principal more or less capacity per
    * rateSeconds than the default.
    */
-  Map<String, Integer> capacityByPrincipal = new HashMap<>();
+  List<PrincipalOverride> capacityByPrincipal = new ArrayList<>();
+
+  /**
+   * A principal-specific rate override map.
+   */
+  List<PrincipalOverride> rateSecondsByPrincipal = new ArrayList<>();
 
   /**
    * A list of principals whose capacities are being enforced. This
@@ -67,6 +70,22 @@ public class RateLimiterConfiguration {
    */
   List<String> ignoring = new ArrayList<>();
 
+  public int getCapacity() {
+    return capacity;
+  }
+
+  public int getRateSeconds() {
+    return rateSeconds;
+  }
+
+  public List<PrincipalOverride> getCapacityByPrincipal() {
+    return capacityByPrincipal;
+  }
+
+  public List<PrincipalOverride> getRateSecondsByPrincipal() {
+    return rateSecondsByPrincipal;
+  }
+
   public boolean isLearning() {
     return learning;
   }
@@ -77,5 +96,19 @@ public class RateLimiterConfiguration {
 
   public List<String> getIgnoring() {
     return ignoring;
+  }
+
+  // Spring doesn't enjoy principals that have dots in their name, so it can't be a map.
+  public static class PrincipalOverride {
+    String principal;
+    Integer override;
+
+    public String getPrincipal() {
+      return principal;
+    }
+
+    public Integer getOverride() {
+      return override;
+    }
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/AbstractRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/AbstractRateLimitPrincipalProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import com.netflix.spinnaker.gate.config.RateLimiterConfiguration.PrincipalOverride;
+
+import java.util.List;
+
+abstract public class AbstractRateLimitPrincipalProvider implements RateLimitPrincipalProvider {
+
+  boolean isLearning(String name, List<String> enforcing, List<String> ignoring, boolean globalLearningFlag) {
+    return !enforcing.contains(name) && (ignoring.contains(name) || globalLearningFlag);
+  }
+
+  Integer overrideOrDefault(String principal, List<PrincipalOverride> overrides, Integer defaultValue) {
+    return overrides.stream()
+      .filter(o -> principal.equals(o.getPrincipal()))
+      .map(PrincipalOverride::getOverride)
+      .findFirst()
+      .orElse(defaultValue);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipal.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipal.java
@@ -15,7 +15,33 @@
  */
 package com.netflix.spinnaker.gate.ratelimit;
 
-public interface RateLimiter {
+public class RateLimitPrincipal {
 
-  Rate incrementAndGetRate(RateLimitPrincipal principal);
+  private final String name;
+  private final int rateSeconds;
+  private final int capacity;
+  private final boolean learning;
+
+  public RateLimitPrincipal(String name, int rateSeconds, int capacity, boolean learning) {
+    this.name = name;
+    this.rateSeconds = rateSeconds;
+    this.capacity = capacity;
+    this.learning = learning;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getRateSeconds() {
+    return rateSeconds;
+  }
+
+  public int getCapacity() {
+    return capacity;
+  }
+
+  public boolean isLearning() {
+    return learning;
+  }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipalProvider.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.gate.ratelimit;
 
-public interface RateLimiter {
+public interface RateLimitPrincipalProvider {
 
-  Rate incrementAndGetRate(RateLimitPrincipal principal);
+  RateLimitPrincipal getPrincipal(String name);
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import com.netflix.spinnaker.gate.config.RateLimiterConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalProvider {
+
+  private final static Logger log = LoggerFactory.getLogger(RedisRateLimitPrincipalProvider.class);
+
+  private JedisPool jedisPool;
+  private RateLimiterConfiguration rateLimiterConfiguration;
+
+  public RedisRateLimitPrincipalProvider(JedisPool jedisPool, RateLimiterConfiguration rateLimiterConfiguration) {
+    this.jedisPool = jedisPool;
+    this.rateLimiterConfiguration = rateLimiterConfiguration;
+  }
+
+  @Override
+  public RateLimitPrincipal getPrincipal(String name) {
+    String configName = normalizeAnonymousNameForConfig(name);
+    try (Jedis jedis = jedisPool.getResource()) {
+      int capacity = getCapacity(jedis, configName);
+      int rateSeconds = getRateSeconds(jedis, configName);
+      boolean learning = getLearningFlag(jedis, configName);
+
+      return new RateLimitPrincipal(
+        name,
+        rateSeconds,
+        capacity,
+        learning
+      );
+    } catch (JedisException e) {
+      log.error("failed getting rate limit principal, disabling for request", e);
+      return new RateLimitPrincipal(
+        name,
+        rateLimiterConfiguration.getRateSeconds(),
+        rateLimiterConfiguration.getCapacity(),
+        true
+      );
+    }
+  }
+
+  private int getCapacity(Jedis jedis, String name) {
+    String capacity = jedis.get(getCapacityKey(name));
+    if (capacity != null) {
+      try {
+        return Integer.parseInt(capacity);
+      } catch (NumberFormatException e) {
+        log.error("invalid principal capacity value, expected integer (principal: {}, value: {})", name, capacity);
+      }
+    }
+    return overrideOrDefault(name, rateLimiterConfiguration.getCapacityByPrincipal(), rateLimiterConfiguration.getCapacity());
+  }
+
+  private int getRateSeconds(Jedis jedis, String name) {
+    String rateSeconds = jedis.get(getRateSecondsKey(name));
+    if (rateSeconds != null) {
+      try {
+        return Integer.parseInt(rateSeconds);
+      } catch (NumberFormatException e) {
+        log.error("invalid principal rateSeconds value, expected integer (principal: {}, value: {})", name, rateSeconds);
+      }
+    }
+    return overrideOrDefault(name, rateLimiterConfiguration.getRateSecondsByPrincipal(), rateLimiterConfiguration.getRateSeconds());
+  }
+
+  private boolean getLearningFlag(Jedis jedis, String name) {
+    List<String> enforcing = new ArrayList<>(jedis.smembers(getEnforcingKey()));
+    List<String> ignoring = new ArrayList<>(jedis.smembers(getIgnoringKey()));
+
+    if (enforcing.contains(name) && ignoring.contains(name)) {
+      log.warn("principal is configured to be enforced AND ignored in Redis, ENFORCING for request (principal: {})", name);
+      return false;
+    }
+
+    if (!enforcing.contains(name) && !ignoring.contains(name)) {
+      enforcing = rateLimiterConfiguration.getEnforcing();
+      ignoring = rateLimiterConfiguration.getIgnoring();
+
+      if (enforcing.contains(name) && ignoring.contains(name)) {
+        log.warn("principal is configured to be enforced AND ignored in static config, ENFORCING for request (principal: {})", name);
+        return false;
+      }
+    }
+
+    String redisLearning = jedis.get(getLearningKey());
+    boolean learning = redisLearning == null ? rateLimiterConfiguration.isLearning() : Boolean.parseBoolean(redisLearning);
+
+    return isLearning(name, enforcing, ignoring, learning);
+  }
+
+  private static String getCapacityKey(String name) {
+    return "rateLimit:capacity:" + name;
+  }
+
+  private static String getRateSecondsKey(String name) {
+    return "rateLimit:rateSeconds:" + name;
+  }
+
+  private static String getEnforcingKey() {
+    return "rateLimit:enforcing";
+  }
+
+  private static String getIgnoringKey() {
+    return "rateLimit:ignoring";
+  }
+
+  private static String getLearningKey() {
+    return "rateLimit:learning";
+  }
+
+  private static String normalizeAnonymousNameForConfig(String name) {
+    if (name.startsWith("anonymous")) {
+      return "anonymous";
+    }
+    return name;
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit;
+
+import com.netflix.spinnaker.gate.config.RateLimiterConfiguration;
+
+public class StaticRateLimitPrincipalProvider extends AbstractRateLimitPrincipalProvider {
+
+  private RateLimiterConfiguration rateLimiterConfiguration;
+
+  public StaticRateLimitPrincipalProvider(RateLimiterConfiguration rateLimiterConfiguration) {
+    this.rateLimiterConfiguration = rateLimiterConfiguration;
+  }
+
+  @Override
+  public RateLimitPrincipal getPrincipal(String name) {
+    return new RateLimitPrincipal(
+      name,
+      overrideOrDefault(name, rateLimiterConfiguration.getRateSecondsByPrincipal(), rateLimiterConfiguration.getRateSeconds()),
+      overrideOrDefault(name, rateLimiterConfiguration.getCapacityByPrincipal(), rateLimiterConfiguration.getCapacity()),
+      isLearning(name, rateLimiterConfiguration.getEnforcing(), rateLimiterConfiguration.getIgnoring(), rateLimiterConfiguration.isLearning())
+    );
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
@@ -59,7 +59,7 @@ class RateLimitingInterceptorSpec extends Specification {
       it.ignoring = ['bar@example.com']
       return it
     }
-    def subject = new RateLimitingInterceptor(rateLimiter, registry, config)
+    def subject = new RateLimitingInterceptor(rateLimiter, registry, new StaticRateLimitPrincipalProvider(config))
 
     and:
     def request = Mock(HttpServletRequest)

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProviderSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProviderSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit
+
+import com.netflix.spinnaker.gate.config.RateLimiterConfiguration
+import com.netflix.spinnaker.gate.config.RateLimiterConfiguration.PrincipalOverride
+import com.netflix.spinnaker.gate.redis.EmbeddedRedis
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class RedisRateLimitPrincipalProviderSpec extends Specification {
+
+  static int port
+
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedis
+
+  def setupSpec() {
+    embeddedRedis = EmbeddedRedis.embed()
+    embeddedRedis.jedis.flushDB()
+    port = embeddedRedis.port
+  }
+
+  def cleanup() {
+    embeddedRedis.jedis.flushDB()
+  }
+
+  @Unroll("#principalName should have capacity=#expectedCapacity, rateSeconds=#expectedRateSeconds, learning=#expectedLearning")
+  def 'should allow static and dynamic overrides'() {
+    given:
+    RedisRateLimitPrincipalProvider subject = new RedisRateLimitPrincipalProvider(
+      (JedisPool) embeddedRedis.pool,
+      new RateLimiterConfiguration(
+        capacity: 60,
+        capacityByPrincipal: [
+          new PrincipalOverride(principal: 'anonymous', override: 5),
+          new PrincipalOverride(principal: 'static-override', override: 20)
+        ],
+        rateSecondsByPrincipal: [
+          new PrincipalOverride(principal: 'anonymous', override: 5),
+          new PrincipalOverride(principal: 'static-override', override: 20)
+        ],
+        learning: true
+      )
+    )
+
+    and:
+    Jedis jedis
+    try {
+      jedis = embeddedRedis.pool.resource
+      jedis.sadd("rateLimit:enforcing", 'redis-enforced', 'redis-conflict')
+      jedis.sadd("rateLimit:ignoring", 'redis-ignored', 'redis-conflict')
+      jedis.set('rateLimit:capacity:redis-override', '15')
+      jedis.set('rateLimit:rateSeconds:redis-override', '15')
+    } finally {
+      jedis?.close()
+    }
+
+    when:
+    def principal = subject.getPrincipal(principalName)
+
+    then:
+    principal.capacity == expectedCapacity
+    principal.rateSeconds == expectedRateSeconds
+    principal.learning == expectedLearning
+
+    where:
+    principalName           || expectedCapacity | expectedRateSeconds | expectedLearning
+    'anonymous-10.10.10.10' || 5                | 5                   | true
+    'redis-enforced'        || 60               | 10                  | false
+    'redis-ignored'         || 60               | 10                  | true
+    'redis-conflict'        || 60               | 10                  | false
+    'static-override'       || 20               | 20                  | true
+    'redis-override'        || 15               | 15                  | true
+  }
+}


### PR DESCRIPTION
Refactored how configurations are used in the rate limiter so that there's complete parity between static & dynamic configuration values. As part of this work, I also discovered Spring doesn't play nice with email address keys, so I altered the format of the principal overrides.

@spinnaker/netflix-reviewers PTAL