### PR TITLE
refactor(applications): ignore front50 account entries on applications

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -206,7 +206,7 @@ class ApplicationService {
           String accounts = (app.clusters as Map)?.keySet()?.join(',') ?:
             (app.clusterNames as Map)?.keySet()?.join(',')
 
-          mergedApp.attributes.accounts = mergeAccounts(accounts, mergedApp.attributes.accounts)
+          mergedApp.attributes.accounts = accounts
 
           (app["attributes"] as Map).entrySet().each {
             if (it.value && !(mergedApp.attributes as Map)[it.key]) {
@@ -217,9 +217,7 @@ class ApplicationService {
         } else {
           Map attributes = app.attributes ?: app
           attributes.entrySet().each {
-            if (it.key == 'accounts') {
-              mergedApp.attributes.accounts = mergeAccounts(mergedApp.attributes.accounts, it.value)
-            } else if (it.value != null) {
+            if (it.value != null) {
               (mergedApp.attributes as Map)[it.key] = it.value
             }
           }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -65,7 +65,7 @@ class ApplicationServiceSpec extends Specification {
     providerType = "aws"
   }
 
-  void "should include accounts from front50 and from clouddriver clusters"() {
+  void "should ignore accounts from front50 and only include those from clouddriver clusters"() {
     setup:
     HystrixRequestContext.initializeContext()
 
@@ -90,7 +90,7 @@ class ApplicationServiceSpec extends Specification {
     1 * clouddriver.getApplication(name) >> clouddriverApp
     1 * front50.getApplication(name) >> front50App
 
-    app == [name: name, attributes: (clouddriverApp.attributes + front50App + [accounts: [clouddriverAccount, front50Account].toSet().sort().join(',')]), clusters: clouddriverApp.clusters]
+    app == [name: name, attributes: (clouddriverApp.attributes + front50App + [accounts: [clouddriverAccount].toSet().sort().join(',')]), clusters: clouddriverApp.clusters]
 
     where:
     name = "foo"


### PR DESCRIPTION
As we no longer care about the accounts in Front50 (and we're no longer collecting them), we should not merge them/include them in the application results - instead, we'll rely entirely on cluster data from Clouddriver.