### PR TITLE
feat(web): Request-time clouddriver client selection

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -171,8 +171,10 @@ class ApplicationController {
    */
   @Deprecated
   @RequestMapping(value = "/{application}/tasks/{id}/details/{taskDetailsId}", method = RequestMethod.GET)
-  Map getTaskDetails(@PathVariable("id") String id, @PathVariable("taskDetailsId") String taskDetailsId) {
-    taskService.getTaskDetails(taskDetailsId)
+  Map getTaskDetails(@PathVariable("id") String id,
+                     @PathVariable("taskDetailsId") String taskDetailsId,
+                     @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    taskService.getTaskDetails(taskDetailsId, sourceApp)
   }
 
   /**

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CloudMetricController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CloudMetricController.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.gate.services.CloudMetricService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -37,9 +38,10 @@ class CloudMetricController {
   List<Map> findAll(@PathVariable String cloudProvider,
                     @PathVariable String account,
                     @PathVariable String region,
-                    @RequestParam Map<String, String> filters) {
+                    @RequestParam Map<String, String> filters,
+                    @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
 
-    cloudMetricService.findAll(cloudProvider, account, region, filters)
+    cloudMetricService.findAll(cloudProvider, account, region, filters, sourceApp)
   }
 
   @RequestMapping(value = "/{cloudProvider}/{account}/{region}/{metricName}/statistics", method = RequestMethod.GET)
@@ -49,8 +51,9 @@ class CloudMetricController {
                     @PathVariable String metricName,
                     @RequestParam(required = false) Long startTime,
                     @RequestParam(required = false) Long endTime,
-                    @RequestParam Map<String, String> filters) {
+                    @RequestParam Map<String, String> filters,
+                    @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
 
-    cloudMetricService.getStatistics(cloudProvider, account, region, metricName, startTime, endTime, filters)
+    cloudMetricService.getStatistics(cloudProvider, account, region, metricName, startTime, endTime, filters, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ClusterController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ClusterController.groovy
@@ -37,37 +37,44 @@ class ClusterController {
 
   @ApiOperation(value = "Retrieve a list of cluster names for an application, grouped by account")
   @RequestMapping(method = RequestMethod.GET)
-  Map getClusters(@PathVariable("application") String app) {
-    clusterService.getClusters(app)
+  Map getClusters(@PathVariable("application") String app,
+                  @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getClusters(app, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a list of clusters for an account")
   @RequestMapping(value = "/{account}", method = RequestMethod.GET)
-  List<Map> getClusters(@PathVariable("application") String app, @PathVariable("account") String account) {
-    clusterService.getClustersForAccount(app, account)
+  List<Map> getClusters(@PathVariable("application") String app,
+                        @PathVariable("account") String account,
+                        @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getClustersForAccount(app, account, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a cluster's details")
   @RequestMapping(value = "/{account}/{clusterName:.+}", method = RequestMethod.GET)
   Map getClusters(@PathVariable("application") String app,
                   @PathVariable("account") String account,
-                  @PathVariable("clusterName") String clusterName) {
-    clusterService.getCluster(app, account, clusterName)
+                  @PathVariable("clusterName") String clusterName,
+                  @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getCluster(app, account, clusterName, sourceApp)
   }
 
   @RequestMapping(value = "/{account}/{clusterName}/{type}/loadBalancers", method = RequestMethod.GET)
-  List getClusterLoadBalancers(
-      @PathVariable String applicationName,
-      @PathVariable String account, @PathVariable String clusterName, @PathVariable String type) {
-    loadBalancerService.getClusterLoadBalancers(applicationName, account, type, clusterName)
+  List getClusterLoadBalancers(@PathVariable String applicationName,
+                               @PathVariable String account,
+                               @PathVariable String clusterName,
+                               @PathVariable String type,
+                               @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    loadBalancerService.getClusterLoadBalancers(applicationName, account, type, clusterName, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a list of server groups for a cluster")
   @RequestMapping(value = "/{account}/{clusterName}/serverGroups", method = RequestMethod.GET)
   List<Map> getServerGroups(@PathVariable("application") String app,
                             @PathVariable("account") String account,
-                            @PathVariable("clusterName") String clusterName) {
-    clusterService.getClusterServerGroups(app, account, clusterName)
+                            @PathVariable("clusterName") String clusterName,
+                            @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getClusterServerGroups(app, account, clusterName, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a list of scaling activities for a server group")
@@ -77,8 +84,9 @@ class ClusterController {
                                  @PathVariable("clusterName") String clusterName,
                                  @PathVariable("serverGroupName") String serverGroupName,
                                  @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
-                                 @RequestParam(value = "region", required = false) String region) {
-    clusterService.getScalingActivities(app, account, clusterName, serverGroupName, provider, region)
+                                 @RequestParam(value = "region", required = false) String region,
+                                 @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getScalingActivities(app, account, clusterName, serverGroupName, provider, region, sourceApp)
   }
 
   @CompileStatic(TypeCheckingMode.SKIP)
@@ -87,9 +95,10 @@ class ClusterController {
   List<Map> getServerGroups(@PathVariable("application") String app,
                             @PathVariable("account") String account,
                             @PathVariable("clusterName") String clusterName,
-                            @PathVariable("serverGroupName") String serverGroupName) {
+                            @PathVariable("serverGroupName") String serverGroupName,
+                            @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     // TODO this crappy logic needs to be here until the "type" field is removed in Clouddriver
-    clusterService.getClusterServerGroups(app, account, clusterName).findAll {
+    clusterService.getClusterServerGroups(app, account, clusterName, sourceApp).findAll {
       it.name == serverGroupName
     }
   }
@@ -104,7 +113,8 @@ class ClusterController {
                            @PathVariable("scope") String scope,
                            @PathVariable("target") String target,
                            @RequestParam(value = "onlyEnabled", required = false) Boolean onlyEnabled,
-                           @RequestParam(value = "validateOldest", required = false) Boolean validateOldest) {
-    clusterService.getTargetServerGroup(app, account, clusterName, cloudProvider, scope, target, onlyEnabled, validateOldest)
+                           @RequestParam(value = "validateOldest", required = false) Boolean validateOldest,
+                           @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    clusterService.getTargetServerGroup(app, account, clusterName, cloudProvider, scope, target, onlyEnabled, validateOldest, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
@@ -47,7 +48,8 @@ class CredentialsController {
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @ApiOperation(value = "Retrieve an account's details")
   @RequestMapping(value = '/{account:.+}', method = RequestMethod.GET)
-  Map getAccount(@PathVariable("account") String account) {
-    credentialsService.getAccount(account)
+  Map getAccount(@PathVariable("account") String account,
+                 @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    credentialsService.getAccount(account, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ImageController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ImageController.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.gate.services.ImageService
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -37,8 +38,9 @@ class ImageController {
   List<Map> getImageDetails(@PathVariable(value = "account") String account,
                             @PathVariable(value = "region") String region,
                             @PathVariable(value = "imageId") String imageId,
-                            @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider) {
-    imageService.getForAccountAndRegion(provider, account, region, imageId)
+                            @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
+                            @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    imageService.getForAccountAndRegion(provider, account, region, imageId, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a list of images, filtered by cloud provider, region, and account",
@@ -55,13 +57,14 @@ class ImageController {
     }.collectEntries { String parameterName ->
       [parameterName, httpServletRequest.getParameter(parameterName)]
     }
-    imageService.search(provider, query, region, account, count, additionalFilters)
+    imageService.search(provider, query, region, account, count, additionalFilters, httpServletRequest.getHeader("X-RateLimit-Header"))
   }
 
   @RequestMapping(value = "/tags", method = RequestMethod.GET)
   List<String> findTags(@RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
-                       @RequestParam(value = "account", required = true) String account,
-                       @RequestParam(value = "repository", required = true) String repository) {
-    imageService.findTags(provider, account, repository)
+                        @RequestParam(value = "account", required = true) String account,
+                        @RequestParam(value = "repository", required = true) String repository,
+                        @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    imageService.findTags(provider, account, repository, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/InstanceController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/InstanceController.groovy
@@ -22,6 +22,7 @@ import groovy.transform.CompileStatic
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -38,8 +39,9 @@ class InstanceController {
   @RequestMapping(value = "/{account}/{region}/{instanceId:.+}", method = RequestMethod.GET)
   Map getInstanceDetails(@PathVariable(value = "account") String account,
                          @PathVariable(value = "region") String region,
-                         @PathVariable(value = "instanceId") String instanceId) {
-    instanceService.getForAccountAndRegion(account, region, instanceId)
+                         @PathVariable(value = "instanceId") String instanceId,
+                         @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    instanceService.getForAccountAndRegion(account, region, instanceId, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve an instance's console output")
@@ -47,7 +49,8 @@ class InstanceController {
   Map getConsoleOutput(@PathVariable(value = "account") String account,
                        @PathVariable(value = "region") String region,
                        @PathVariable(value = "instanceId") String instanceId,
-                       @RequestParam(value = "provider", required = false, defaultValue = "aws") String provider) {
-    instanceService.getConsoleOutput(account, region, instanceId, provider)
+                       @RequestParam(value = "provider", required = false, defaultValue = "aws") String provider,
+                       @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    instanceService.getConsoleOutput(account, region, instanceId, provider, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/JobController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/JobController.groovy
@@ -19,9 +19,7 @@ package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.services.JobService
 import groovy.transform.CompileStatic
-import groovy.transform.InheritConstructors
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @CompileStatic
@@ -31,15 +29,18 @@ class JobController {
   JobService jobService
 
   @RequestMapping(value = "/applications/{applicationName}/jobs", method = RequestMethod.GET)
-  List getJobs(@PathVariable String applicationName, @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand) {
-    jobService.getForApplication(applicationName, expand)
+  List getJobs(@PathVariable String applicationName,
+               @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand,
+               @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    jobService.getForApplication(applicationName, expand, sourceApp)
   }
 
   @RequestMapping(value = "/applications/{applicationName}/jobs/{account}/{region}/{name}", method = RequestMethod.GET)
   Map getJob(@PathVariable String applicationName, @PathVariable String account,
              @PathVariable String region,
              @PathVariable String name,
-             @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand) {
-    jobService.getForApplicationAndAccountAndRegion(applicationName, account, region, name)
+             @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand,
+             @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    jobService.getForApplicationAndAccountAndRegion(applicationName, account, region, name, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoadBalancerController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoadBalancerController.groovy
@@ -31,15 +31,17 @@ class LoadBalancerController {
 
   @ApiOperation(value = "Retrieve a list of load balancers for a given cloud provider")
   @RequestMapping(value = '/loadBalancers', method = RequestMethod.GET)
-  List getAll(@RequestParam(value = "provider", defaultValue = "aws", required = false) String provider) {
-    loadBalancerService.getAll(provider)
+  List getAll(@RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
+              @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    loadBalancerService.getAll(provider, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a load balancer for a given cloud provider")
   @RequestMapping(value = "/loadBalancers/{name:.+}", method = RequestMethod.GET)
   Map getLoadBalancer(@PathVariable String name,
-                      @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider) {
-    loadBalancerService.get(name, provider)
+                      @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
+                      @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    loadBalancerService.get(name, sourceApp, provider)
   }
 
   @ApiOperation(value = "Retrieve a load balancer's details as a single element list for a given account, region, cloud provider and load balancer name")
@@ -47,13 +49,15 @@ class LoadBalancerController {
   List<Map> getLoadBalancerDetails(@PathVariable String account,
                                    @PathVariable String region,
                                    @PathVariable String name,
-                                   @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider) {
-    loadBalancerService.getDetailsForAccountAndRegion(account, region, name, provider)
+                                   @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
+                                   @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    loadBalancerService.getDetailsForAccountAndRegion(account, region, name, sourceApp, provider)
   }
 
   @ApiOperation(value = "Retrieve a list of load balancers for a given application")
   @RequestMapping(value = '/applications/{application}/loadBalancers', method = RequestMethod.GET)
-  List<Map> getApplicationLoadBalancers(@PathVariable String application) {
-    loadBalancerService.getApplicationLoadBalancers(application)
+  List<Map> getApplicationLoadBalancers(@PathVariable String application,
+                                        @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    loadBalancerService.getApplicationLoadBalancers(application, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NetworkController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NetworkController.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.gate.services.NetworkService
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
@@ -33,13 +34,14 @@ class NetworkController {
 
   @ApiOperation(value = "Retrieve a list of networks, grouped by cloud provider")
   @RequestMapping(method = RequestMethod.GET)
-  Map all() {
-    networkService.getNetworks()
+  Map all(@RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    networkService.getNetworks(sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a list of networks for a given cloud provider")
   @RequestMapping(value = "/{cloudProvider}", method = RequestMethod.GET)
-  List<Map> allByCloudProvider(@PathVariable String cloudProvider) {
-    networkService.getNetworks(cloudProvider)
+  List<Map> allByCloudProvider(@PathVariable String cloudProvider,
+                               @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    networkService.getNetworks(cloudProvider, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.gate.controllers
 import com.netflix.spinnaker.gate.services.SearchService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -36,7 +37,8 @@ class SearchController {
                    @RequestParam(value = "type") String type,
                    @RequestParam(value = "platform", required = false) String platform,
                    @RequestParam(value = "pageSize", defaultValue = "10000", required = false) int pageSize,
-                   @RequestParam(value = "page", defaultValue = "1", required = false) int page) {
-    searchService.search(query, type, platform, pageSize, page)
+                   @RequestParam(value = "page", defaultValue = "1", required = false) int page,
+                   @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    searchService.search(query, type, platform, sourceApp, pageSize, page)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SecurityGroupController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SecurityGroupController.groovy
@@ -32,16 +32,17 @@ class SecurityGroupController {
 
   @ApiOperation(value = "Retrieve a list of security groups, grouped by account, cloud provider, and region")
   @RequestMapping(method = RequestMethod.GET)
-  Map all(@RequestParam(value = "id", required = false) String id) {
+  Map all(@RequestParam(value = "id", required = false) String id,
+          @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     if (id) {
-      def result = securityGroupService.getById(id)
+      def result = securityGroupService.getById(id, sourceApp)
       if (result) {
         result
       } else {
         throw new SecurityGroupNotFoundException(id)
       }
     } else {
-      securityGroupService.all
+      securityGroupService.getAll(sourceApp)
     }
   }
 
@@ -50,8 +51,9 @@ class SecurityGroupController {
   Map allByAccount(
       @PathVariable String account,
       @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
-      @RequestParam(value = "region", required = false) String region) {
-    securityGroupService.getForAccountAndProviderAndRegion(account, provider, region)
+      @RequestParam(value = "region", required = false) String region,
+      @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    securityGroupService.getForAccountAndProviderAndRegion(account, provider, region, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a security group's details")
@@ -61,8 +63,9 @@ class SecurityGroupController {
       @PathVariable String region,
       @PathVariable String name,
       @RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
-      @RequestParam(value = "vpcId", required = false) String vpcId) {
-    securityGroupService.getSecurityGroup(account, provider, name, region, vpcId)
+      @RequestParam(value = "vpcId", required = false) String vpcId,
+      @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    securityGroupService.getSecurityGroup(account, provider, name, region, sourceApp, vpcId)
   }
 
   @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupController.groovy
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -41,8 +42,9 @@ class ServerGroupController {
   List getServerGroups(@PathVariable String applicationName,
                        @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand,
                        @RequestParam(required = false, value = 'cloudProvider') String cloudProvider,
-                       @RequestParam(required = false, value = 'clusters') String clusters) {
-    serverGroupService.getForApplication(applicationName, expand, cloudProvider, clusters)
+                       @RequestParam(required = false, value = 'clusters') String clusters,
+                       @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    serverGroupService.getForApplication(applicationName, expand, cloudProvider, clusters, sourceApp)
   }
 
   @ApiOperation(value = "Retrieve a server group's details")
@@ -50,8 +52,9 @@ class ServerGroupController {
   Map getServerGroupDetails(@PathVariable String applicationName,
                             @PathVariable String account,
                             @PathVariable String region,
-                            @PathVariable String serverGroupName) {
-    def serverGroupDetails = serverGroupService.getForApplicationAndAccountAndRegion(applicationName, account, region, serverGroupName)
+                            @PathVariable String serverGroupName,
+                            @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    def serverGroupDetails = serverGroupService.getForApplicationAndAccountAndRegion(applicationName, account, region, serverGroupName, sourceApp)
     if (!serverGroupDetails) {
       throw new ServerGroupNotFoundException()
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/TaskController.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -59,7 +60,9 @@ class TaskController {
   }
 
   @RequestMapping(value = "/{id}/details/{taskDetailsId}", method = RequestMethod.GET)
-  Map getTaskDetails(@PathVariable("id") String id, @PathVariable("taskDetailsId") String taskDetailsId) {
-    taskService.getTaskDetails(taskDetailsId)
+  Map getTaskDetails(@PathVariable("id") String id,
+                     @PathVariable("taskDetailsId") String taskDetailsId,
+                     @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    taskService.getTaskDetails(taskDetailsId, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Tag;
 import com.netflix.spinnaker.security.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -56,6 +57,8 @@ public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    MDC.put("sourceApp", request.getHeader("X-RateLimit-App"));
+
     if ("deck".equalsIgnoreCase(request.getHeader("X-RateLimit-App"))) {
       // If the API request is being made from deck, just let it through without question.
       // Better than trying to keep tuning the rate limiter based on changes to deck.

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CloudMetricService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CloudMetricService.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -29,18 +29,18 @@ class CloudMetricService {
   private static final String GROUP = "cloudMetrics"
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
-  List<Map> findAll(String cloudProvider, String account, String region, Map<String, String> filters) {
+  List<Map> findAll(String cloudProvider, String account, String region, Map<String, String> filters, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "$GROUP:$account:$region:findAll") {
-      clouddriverService.findAllCloudMetrics(cloudProvider, account, region, filters)
+      clouddriverServiceSelector.select(selectorKey).findAllCloudMetrics(cloudProvider, account, region, filters)
     } execute()
   }
 
   Map getStatistics(String cloudProvider, String account, String region, String metricName,
-                    Long startTime, Long endTime, Map<String, String> filters) {
+                    Long startTime, Long endTime, Map<String, String> filters, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "$GROUP:$account:$region:getStatistics") {
-      clouddriverService.getCloudMetricStatistics(cloudProvider, account, region, metricName, startTime, endTime, filters)
+      clouddriverServiceSelector.select(selectorKey).getCloudMetricStatistics(cloudProvider, account, region, metricName, startTime, endTime, filters)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ClusterService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ClusterService.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.services
 import com.netflix.hystrix.exception.HystrixBadRequestException
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,21 +37,24 @@ class ClusterService {
   ClouddriverService clouddriverService
 
   @Autowired
+  ClouddriverServiceSelector clouddriverServiceSelector
+
+  @Autowired
   ProviderLookupService providerLookupService
 
-  Map getClusters(String app) {
+  Map getClusters(String app, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getClustersForApplication") {
       clouddriverService.getClusters(app)
     } execute()
   }
 
-  List<Map> getClustersForAccount(String app, String account) {
+  List<Map> getClustersForAccount(String app, String account, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getClustersForApplicationInAccount-${providerLookupService.providerForAccount(account)}") {
       clouddriverService.getClustersForAccount(app, account)
     } execute()
   }
 
-  Map getCluster(String app, String account, String clusterName) {
+  Map getCluster(String app, String account, String clusterName, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getCluster-${providerLookupService.providerForAccount(account)}") {
       try {
         clouddriverService.getCluster(app, account, clusterName)?.getAt(0) as Map
@@ -64,17 +68,17 @@ class ClusterService {
     } execute()
   }
 
-  List<Map> getClusterServerGroups(String app, String account, String clusterName) {
-    getCluster(app, account, clusterName).serverGroups as List<Map>
+  List<Map> getClusterServerGroups(String app, String account, String clusterName, String selectorKey) {
+    getCluster(app, account, clusterName, null).serverGroups as List<Map>
   }
 
-  List<Map> getScalingActivities(String app, String account, String clusterName, String serverGroupName, String provider, String region) {
+  List<Map> getScalingActivities(String app, String account, String clusterName, String serverGroupName, String provider, String region, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getScalingActivitiesForCluster-${providerLookupService.providerForAccount(account)}") {
       clouddriverService.getScalingActivities(app, account, clusterName, provider, serverGroupName, region)
     } execute()
   }
 
-  Map getTargetServerGroup(String app, String account, String clusterName, String cloudProviderType, String scope, String target, Boolean onlyEnabled, Boolean validateOldest) {
+  Map getTargetServerGroup(String app, String account, String clusterName, String cloudProviderType, String scope, String target, Boolean onlyEnabled, Boolean validateOldest, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getTargetServerGroup-${providerLookupService.providerForAccount(account)}") {
       try {
         return clouddriverService.getTargetServerGroup(app, account, clusterName, cloudProviderType, scope, target, onlyEnabled, validateOldest)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.services
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
@@ -30,7 +31,7 @@ class CredentialsService {
   AccountLookupService accountLookupService
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   @Autowired
   FiatClientConfigurationProperties fiatConfig
@@ -69,9 +70,9 @@ class CredentialsService {
     } execute()
   }
 
-  Map getAccount(String account) {
+  Map getAccount(String account, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getAccount") {
-      clouddriverService.getAccount(account)
+      clouddriverServiceSelector.select(selectorKey).getAccount(account)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EntityTagsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/EntityTagsService.groovy
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -30,17 +30,17 @@ class EntityTagsService {
   private static final String GROUP = "entityTags"
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
-  List<Map> list(@RequestParam Map<String, Object> allParameters) {
+  List<Map> list(@RequestParam Map<String, Object> allParameters, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "listEntityTags") {
-      clouddriverService.listEntityTags(allParameters)
+      clouddriverServiceSelector.select(selectorKey).listEntityTags(allParameters)
     } execute()
   }
 
-  Map get(String id) {
+  Map get(String id, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getEntityTags") {
-      clouddriverService.getEntityTags(id)
+      clouddriverServiceSelector.select(selectorKey).getEntityTags(id)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ImageService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ImageService.groovy
@@ -34,19 +34,19 @@ class ImageService {
   @Autowired
   ProviderLookupService providerLookupService
 
-  List<Map> getForAccountAndRegion(String provider, String account, String region, String imageId) {
+  List<Map> getForAccountAndRegion(String provider, String account, String region, String imageId, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getImagesForAccountAndRegion-${providerLookupService.providerForAccount(account)}") {
       clouddriverService.getImageDetails(provider, account, region, imageId)
     } execute()
   }
 
-  List<Map> search(String provider, String query, String region, String account, Integer count, Map<String, Object> additionalFilters) {
+  List<Map> search(String provider, String query, String region, String account, Integer count, Map<String, Object> additionalFilters, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "searchImages-${providerLookupService.providerForAccount(account)}") {
       clouddriverService.findImages(provider, query, region, account, count, additionalFilters)
     } execute()
   }
 
-  List<String> findTags(String provider, String account, String repository) {
+  List<String> findTags(String provider, String account, String repository, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getTags-${providerLookupService.providerForAccount(account)}") {
       clouddriverService.findTags(provider, account, repository)
     } execute()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
@@ -38,7 +38,7 @@ class InstanceService {
   @Autowired
   ProviderLookupService providerLookupService
 
-  Map getForAccountAndRegion(String account, String region, String instanceId) {
+  Map getForAccountAndRegion(String account, String region, String instanceId, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getInstancesForAccountAndRegion-${providerLookupService.providerForAccount(account)}") {
       def accountDetails = clouddriverService.getAccount(account)
       def instanceDetails = clouddriverService.getInstanceDetails(account, region, instanceId)
@@ -53,7 +53,7 @@ class InstanceService {
     } execute()
   }
 
-  Map getConsoleOutput(String account, String region, String instanceId, String provider) {
+  Map getConsoleOutput(String account, String region, String instanceId, String provider, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getConsoleOutput-${providerLookupService.providerForAccount(account)}") {
       return  clouddriverService.getConsoleOutput(account, region, instanceId, provider)
     } execute()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
@@ -38,14 +38,14 @@ class JobService {
   @Autowired
   ProviderLookupService providerLookupService
 
-  List getForApplication(String applicationName, String expand) {
+  List getForApplication(String applicationName, String expand, String selectorKey) {
     String commandKey = Boolean.valueOf(expand) ? "getExpandedJobsForApplication" : "getJobsForApplication"
     HystrixFactory.newListCommand(GROUP, commandKey) {
       clouddriverService.getJobs(applicationName, expand)
     } execute()
   }
 
-  Map getForApplicationAndAccountAndRegion(String applicationName, String account, String region, String name) {
+  Map getForApplicationAndAccountAndRegion(String applicationName, String account, String region, String name, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getJobsForApplicationAccountAndRegion-${providerLookupService.providerForAccount(account)}", {
       try {
         def context = getContext(applicationName, account, region, name)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoadBalancerService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoadBalancerService.groovy
@@ -30,32 +30,32 @@ class LoadBalancerService {
   @Autowired
   ClouddriverService clouddriverService
 
-  List<Map> getAll(String provider = "aws") {
+  List<Map> getAll(String provider = "aws", String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getAllLoadBalancersForProvider-$provider") {
       clouddriverService.getLoadBalancers(provider)
     } execute()
   }
 
-  Map get(String name, String provider = "aws") {
+  Map get(String name, String selectorKey, String provider = "aws") {
     HystrixFactory.newMapCommand(GROUP, "getLoadBalancer-$provider") {
       clouddriverService.getLoadBalancer(provider, name)
     } execute()
   }
 
-  List<Map> getDetailsForAccountAndRegion(String account, String region, String name, String provider = "aws") {
+  List<Map> getDetailsForAccountAndRegion(String account, String region, String name, String selectorKey, String provider = "aws") {
     HystrixFactory.newListCommand(GROUP, "getLoadBalancerDetails-$provider") {
       clouddriverService.getLoadBalancerDetails(provider, account, region, name)
     } execute()
   }
 
-  List getClusterLoadBalancers(String appName, String account, String provider, String clusterName) {
+  List getClusterLoadBalancers(String appName, String account, String provider, String clusterName, String selectorKey) {
     HystrixFactory.newListCommand(GROUP,
         "getClusterLoadBalancers-$provider") {
       clouddriverService.getClusterLoadBalancers(appName, account, clusterName, provider)
     } execute()
   }
 
-  List getApplicationLoadBalancers(String appName) {
+  List getApplicationLoadBalancers(String appName, String selectorKey) {
     HystrixFactory.newListCommand(GROUP,
       "getApplicationLoadBalancers") {
       clouddriverService.getApplicationLoadBalancers(appName)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NetworkService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NetworkService.groovy
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.gate.services
 
-import java.util.concurrent.Callable
 import com.netflix.hystrix.HystrixCommand
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import java.util.concurrent.Callable
 
 @CompileStatic
 @Component
@@ -31,7 +32,7 @@ class NetworkService {
   private static final String GROUP = "networks"
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   private static HystrixCommand<List> listCommand(String type, Callable<List> work) {
     HystrixFactory.newListCommand(GROUP, type, work)
@@ -41,15 +42,15 @@ class NetworkService {
     HystrixFactory.newMapCommand(GROUP, type, work)
   }
 
-  Map getNetworks() {
+  Map getNetworks(String selectorKey) {
     mapCommand("networks") {
-      clouddriverService.getNetworks()
+      clouddriverServiceSelector.select(selectorKey).getNetworks()
     } execute()
   }
 
-  List<Map> getNetworks(String cloudProvider) {
+  List<Map> getNetworks(String cloudProvider, String selectorKey) {
     listCommand("networks-$cloudProvider") {
-      clouddriverService.getNetworks(cloudProvider)
+      clouddriverServiceSelector.select(selectorKey).getNetworks(cloudProvider)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import groovy.transform.CompileStatic
@@ -39,7 +39,7 @@ class ProjectService {
   OrcaService orcaService
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   List<Map> getAll() {
     HystrixFactory.newListCommand(GROUP, "getAll") {
@@ -59,9 +59,9 @@ class ProjectService {
     } execute()
   }
 
-  List getClusters(String projectId) {
+  List getClusters(String projectId, String selectorKey) {
     HystrixFactory.newListCommand(GROUP, "getClusters") {
-      return clouddriverService.getProjectClusters(projectId)
+      return clouddriverServiceSelector.select(selectorKey).getProjectClusters(projectId)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SearchService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SearchService.groovy
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -29,11 +29,11 @@ class SearchService {
   private static final String GROUP = "searches"
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
-  List<Map> search(String query, String type, String platform, int pageSize = 10000, int page = 1) {
+  List<Map> search(String query, String type, String platform, String selectorKey, int pageSize = 10000, int page = 1) {
     HystrixFactory.newListCommand(GROUP, "search-${type}") {
-      return clouddriverService.search(query, type, platform, pageSize, page)
+      return clouddriverServiceSelector.select(selectorKey).search(query, type, platform, pageSize, page)
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,7 +32,7 @@ class TaskService {
   OrcaService orcaService
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   Map create(Map body) {
     orcaService.doOperation(body)
@@ -59,9 +59,9 @@ class TaskService {
     } execute()
   }
 
-  Map getTaskDetails(String taskDetailsId) {
+  Map getTaskDetails(String taskDetailsId, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getTaskDetails") {
-      clouddriverService.getTaskDetails(taskDetailsId)
+      clouddriverServiceSelector.select(selectorKey).getTaskDetails(taskDetailsId)
     } execute()
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/aws/InfrastructureService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/aws/InfrastructureService.groovy
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.gate.services.aws
 
-import java.util.concurrent.Callable
 import com.netflix.hystrix.HystrixCommand
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+
+import java.util.concurrent.Callable
 
 @CompileStatic
 @Component
@@ -31,35 +32,35 @@ class InfrastructureService {
   private static final String GROUP = "infrastructure"
 
   @Autowired
-  ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   private static HystrixCommand<List> command(String type, Callable<List> work) {
     (HystrixCommand<List>)HystrixFactory.newListCommand(GROUP, type, work)
   }
 
-  List<Map> getInstanceTypes() {
+  List<Map> getInstanceTypes(String selectorKey = null) {
     command("instanceTypes") {
-      clouddriverService.instanceTypes
+      clouddriverServiceSelector.select(selectorKey).instanceTypes
     } execute()
   }
 
-  List<Map> getKeyPairs() {
+  List<Map> getKeyPairs(String selectorKey = null) {
     command("keyPairs") {
-      clouddriverService.keyPairs
+      clouddriverServiceSelector.select(selectorKey).keyPairs
     } execute()
   }
 
   @Deprecated
-  List<Map> getSubnets() {
+  List<Map> getSubnets(String selectorKey = null) {
     command("subnets") {
-      clouddriverService.getSubnets('aws')
+      clouddriverServiceSelector.select(selectorKey).getSubnets('aws')
     } execute()
   }
 
   @Deprecated
-  List<Map> getVpcs() {
+  List<Map> getVpcs(String selectorKey = null) {
     command("vpcs") {
-      clouddriverService.getNetworks('aws')
+      clouddriverServiceSelector.select(selectorKey).getNetworks('aws')
     } execute()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverServiceSelector.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverServiceSelector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.services.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClouddriverServiceSelector {
+
+  private ClouddriverService defaultService;
+  private Map<String, ClouddriverService> services;
+
+  public ClouddriverServiceSelector(ClouddriverService defaultService) {
+    this(defaultService, new HashMap<>());
+  }
+
+  public ClouddriverServiceSelector(ClouddriverService defaultService, Map<String, ClouddriverService> services) {
+    this.defaultService = defaultService;
+    this.services = services;
+  }
+
+  public ClouddriverService select(String key) {
+    return (key == null) ? defaultService :  services.getOrDefault(key, defaultService);
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.gate.services.PipelineService
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.commands.ThrottledRequestException
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import org.springframework.boot.SpringApplication
@@ -55,6 +56,7 @@ class FunctionalSpec extends Specification {
   static ExecutorService executorService
   static Front50Service front50Service
   static ClouddriverService clouddriverService
+  static ClouddriverServiceSelector clouddriverServiceSelector
   static TaskService taskService
   static OrcaService orcaService
   static CredentialsService credentialsService
@@ -70,6 +72,7 @@ class FunctionalSpec extends Specification {
     executorService = Mock(ExecutorService)
     taskService = Mock(TaskService)
     clouddriverService = Mock(ClouddriverService)
+    clouddriverServiceSelector = new ClouddriverServiceSelector(clouddriverService)
     orcaService = Mock(OrcaService)
     credentialsService = Mock(CredentialsService)
     accountLookupService = Mock(AccountLookupService)
@@ -181,6 +184,11 @@ class FunctionalSpec extends Specification {
   @EnableAutoConfiguration(exclude = [SecurityAutoConfiguration, GroovyTemplateAutoConfiguration])
   @Configuration
   static class FunctionalConfiguration {
+
+    @Bean
+    ClouddriverServiceSelector clouddriverSelector() {
+      clouddriverServiceSelector
+    }
 
     @Bean
     ClouddriverService clouddriverService() {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerTest.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.CredentialsService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.squareup.okhttp.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
@@ -36,6 +37,7 @@ class CredentialsControllerTest extends Specification {
 
   MockMvc mockMvc
   ClouddriverService clouddriverService
+  ClouddriverServiceSelector clouddriverServiceSelector
 
   def server = new MockWebServer()
 
@@ -50,10 +52,11 @@ class CredentialsControllerTest extends Specification {
     FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
 
     clouddriverService = Mock(ClouddriverService)
+    clouddriverServiceSelector = Mock(ClouddriverServiceSelector)
 
     @Subject
     CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
-      clouddriverService: clouddriverService,
+      clouddriverServiceSelector: clouddriverServiceSelector,
       fiatConfig: fiatConfig)
 
     server.start()
@@ -63,6 +66,7 @@ class CredentialsControllerTest extends Specification {
   @Unroll
   def "should accept account names with dots"() {
     given:
+    1 * clouddriverServiceSelector.select(_) >> clouddriverService
     1 * clouddriverService.getAccount(account) >> ["accountName": account]
 
     when:

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
@@ -105,7 +105,7 @@ class RateLimitingInterceptorSpec extends Specification {
 
     then:
     noExceptionThrown()
-    1 * request.getHeader("X-RateLimit-App") >> { return "deck" }
+    2 * request.getHeader("X-RateLimit-App") >> { return "deck" }
     0 * _
   }
 }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/InstanceServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/InstanceServiceSpec.groovy
@@ -38,7 +38,7 @@ class InstanceServiceSpec extends Specification {
     )
 
     expect:
-    service.getForAccountAndRegion("account", "region", "instanceId").insightActions*.url == [
+    service.getForAccountAndRegion("account", "region", "instanceId", null).insightActions*.url == [
         "account-prod-region-instanceId-{DNE}-10.0.0.1"
     ]
   }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/ServerGroupServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/ServerGroupServiceSpec.groovy
@@ -19,14 +19,19 @@ package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.config.InsightConfiguration
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import spock.lang.Specification
 
 class ServerGroupServiceSpec extends Specification {
   void "should include relevant insight actions for server group"() {
     given:
     def service = new ServerGroupService(
-        clouddriverService: Mock(ClouddriverService) {
-          1 * getServerGroupDetails(_, _, _, _) >> { return [cloudProvider: "aws"] }
+        clouddriverServiceSelector: Mock(ClouddriverServiceSelector) {
+          1 * select(_) >> {
+            Mock(ClouddriverService) {
+              1 * getServerGroupDetails(_, _, _, _) >> { return [cloudProvider: "aws"] }
+            }
+          }
         },
         providerLookupService: Stub(ProviderLookupService) {
           providerForAccount(_) >> "test"
@@ -39,7 +44,7 @@ class ServerGroupServiceSpec extends Specification {
     )
 
     expect:
-    service.getForApplicationAndAccountAndRegion("application", "account", "region", "serverGroup").insightActions*.url == [
+    service.getForApplicationAndAccountAndRegion("application", "account", "region", "serverGroup", null).insightActions*.url == [
         "application-account-region-serverGroup-aws-{DNE}"
     ]
   }


### PR DESCRIPTION
Adds support for named clouddriver clients, where each client has a different base URL. The clients are selected based on the presence (or not) of the `X-RateLimit-App` header and a matching value. In our case, a `X-RateLimit-App: deck` would be able to route us to a `clouddriver-readonly` stack specifically dedicated to servicing UI traffic.

Explicit callsite changes was a much cleaner and easier to understand path than trying to get a Retrofit interceptor or similar wired together w/ Hystrix.

```yaml
# gate.yml
services: 
  clouddriver:
    baseUrl: https://clouddriver-${netflix.stack}-readonly.example.com
    config:
      dynamicEndpoints:
        deck: https://clouddriver-${netflix.stack}-readonly-deck.example.com
```

@spinnaker/netflix-reviewers PTAL
