### PR TITLE
feat(applications): allow filtering on account from /applications end…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpEntity
@@ -54,8 +55,18 @@ class ApplicationController {
 
   @ApiOperation(value = "Retrieve a list of applications")
   @RequestMapping(method = RequestMethod.GET)
-  List<Map> getAllApplications() {
-    applicationService.getAllApplications()
+  List<Map> getAllApplications(
+    @ApiParam(name = "account", required = false, value = "filters results to only include applications deployed in the specified account")
+    @RequestParam(value = "account", required = false) String account) {
+    List<Map> allApplications = applicationService.getAllApplications()
+    if (account) {
+      String lcAccount = account.toLowerCase()
+      return allApplications.findAll { app ->
+        String[] appAccounts = ((String) app.accounts ?: "").toLowerCase().split(",")
+        appAccounts.contains(lcAccount)
+      }
+    }
+    return allApplications
   }
 
   @ApiOperation(value = "Retrieve an application's details")


### PR DESCRIPTION
…point

Nothing fancy, just allows a user to call, e.g. `/applications?account=test` to get just the applications in the test account.