### PR TITLE
fix(insight-links): filter invalid insight links based on cloud provider

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ServerGroupService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ServerGroupService.groovy
@@ -57,7 +57,7 @@ class ServerGroupService {
 
         def context = getContext(applicationName, account, region, serverGroupName) + serverGroupContext
         return serverGroupDetails + [
-          "insightActions": insightConfiguration.serverGroup.collect { it.applyContext(context) }
+          "insightActions": insightConfiguration.serverGroup.findResults { it.applyContext(context) }
         ]
       } catch (RetrofitError e) {
         if (e.response?.status == 404) {


### PR DESCRIPTION
We're already doing the same thing for instance insight links, just failed to do it for server group links, which results in `null` values coming back for unmatched links.