### PR TITLE
feat(serviceAccounts): Allows login by registered service accounts

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -90,6 +90,7 @@ class OAuth2SsoConfig {
     String firstName = "given_name"
     String lastName = "family_name"
     String username = "email"
+    String serviceAccountEmail = "email"
   }
 
   @Component

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount
 import retrofit.client.Response
 import retrofit.http.*
 
@@ -123,4 +124,7 @@ interface Front50Service {
 
   @GET('/snapshots/{id}/history')
   List<Map> getSnapshotHistory(@Path("id") String id, @Query("limit") int limit)
+
+  @GET('/serviceAccounts')
+  List<Map> getServiceAccounts()
 }


### PR DESCRIPTION
This PR takes the concepts of a cloud provider service account, and merges it with a Spinnaker/Fiat service account. By allowing provider service accounts the ability to login, we open up another option for script access (beyond X509 certs)

