### PR TITLE
refactor(web): Pipeline create/update now go through orca tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 out/
 /.idea/
 *.rdb
+
+.classpath
+.project
+.settings

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -77,6 +77,27 @@ class TaskService {
     } execute()
   }
 
+  Map createAndWaitForCompletion(Map body, int maxPolls = 20, int intervalMs = 500) {
+    Map createResult = create(body)
+    if (!createResult.get("ref")) {
+      return createResult
+    }
+
+    String taskId = ((String) createResult.get("ref")).split('/')[2]
+
+    int i = 0
+    while (i < maxPolls) {
+      i++
+      sleep(intervalMs)
+
+      Map task = getTask(taskId)
+      if (['SUCCEEDED', 'TERMINAL'].contains((String) task.get("status"))) {
+        return task
+      }
+    }
+    return null
+  }
+
   /**
    * @deprecated  This pipeline operation does not belong here.
    */

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
@@ -16,20 +16,23 @@
 
 package com.netflix.spinnaker.gate.controllers
 
-import com.netflix.spinnaker.gate.services.PipelineService
+import com.netflix.spinnaker.gate.services.TaskService
+import com.netflix.spinnaker.gate.services.internal.Front50Service
 import org.codehaus.jackson.map.ObjectMapper
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import spock.lang.Specification
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 
 class PipelineControllerSpec extends Specification {
 
   def "should update a pipeline"() {
     given:
-    def pipelineService = Mock(PipelineService)
-    MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new PipelineController(pipelineService: pipelineService)).build()
+    def taskSerivce = Mock(TaskService)
+    def front50Service = Mock(Front50Service)
+    MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new PipelineController(taskService: taskSerivce, front50Service: front50Service)).build()
 
     and:
     def pipeline = [
@@ -51,6 +54,25 @@ class PipelineControllerSpec extends Specification {
 
     then:
     response.status == 200
-    1 * pipelineService.update(pipeline.id, pipeline)
+    1 * taskSerivce.createAndWaitForCompletion([
+      description: "Update pipeline 'test pipeline",
+      application: 'application',
+      job: [
+        [
+          type: 'updatePipeline',
+          pipeline: [
+            id: 'id',
+            name: 'test pipeline',
+            stages: [],
+            triggers: [],
+            limitConcurrent: true,
+            parallel: true,
+            index: 4,
+            application: 'application'
+          ]
+        ]
+      ]
+    ]) >> { [id: 'task-id', application: 'application', status: 'SUCCEEDED'] }
+    1 * front50Service.getPipelineConfigsForApplication('application') >> []
   }
 }


### PR DESCRIPTION
Moves write operations for pipelines to be orchestrated by orca, rather than being written directly into front50. Keeps the same external payload API as what was previously exposed.

Depends on https://github.com/spinnaker/orca/pull/1442

@spinnaker/netflix-reviewers PTAL
