### PR TITLE
feat(web): Generic exception handling

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -16,18 +16,17 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.netflix.spinnaker.gate.exceptions.NotFoundException
 import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.ExecutionHistoryService
 import com.netflix.spinnaker.gate.services.TaskService
 import groovy.transform.CompileStatic
-import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiParam
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpEntity
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @CompileStatic
@@ -75,7 +74,7 @@ class ApplicationController {
     def result = applicationService.getApplication(application, expand)
     if (!result) {
       log.warn("Application ${application} not found")
-      throw new ApplicationNotFoundException("Application ${application} not found")
+      throw new NotFoundException("Application not found (id: ${application})")
     } else if (!result.name) {
       // applicationService.getApplication() doesn't set the name unless clusters are found. Deck requires the name.
       result.name = application
@@ -203,8 +202,4 @@ class ApplicationController {
     String baseLabel = "release"
     String region = "us-east-1"
   }
-
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  @InheritConstructors
-  static class ApplicationNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/GenericErrorController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/GenericErrorController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.exceptions.HasAdditionalAttributes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.boot.autoconfigure.web.ErrorController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+@RestController
+public class GenericErrorController implements ErrorController {
+  private final ErrorAttributes errorAttributes;
+
+  @Autowired
+  GenericErrorController(ErrorAttributes errorAttributes) {
+    this.errorAttributes = errorAttributes;
+  }
+
+  @RequestMapping(value = "/error")
+  public Map error(@RequestParam(value = "trace", defaultValue = "false") Boolean includeStackTrace,
+            HttpServletRequest httpServletRequest) {
+    ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(httpServletRequest);
+
+    Map<String, Object> attributes = errorAttributes.getErrorAttributes(servletRequestAttributes, includeStackTrace);
+
+    Throwable exception = errorAttributes.getError(servletRequestAttributes);
+    if (exception != null && exception instanceof HasAdditionalAttributes) {
+      attributes.putAll(((HasAdditionalAttributes) exception).getAdditionalAttributes());
+    }
+
+    return attributes;
+  }
+
+  @Override
+  public String getErrorPath() {
+    return "/errors";
+  }
+}
+

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/GenericExceptionHandlers.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/GenericExceptionHandlers.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.exceptions.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@ControllerAdvice
+public class GenericExceptionHandlers {
+  private static final Logger logger = LoggerFactory.getLogger(GenericExceptionHandlers.class);
+
+  private final DefaultErrorAttributes defaultErrorAttributes = new DefaultErrorAttributes();
+
+  @ExceptionHandler(NotFoundException.class)
+  void handleNotFoundException(Exception e, HttpServletResponse response, HttpServletRequest request) throws IOException {
+    storeException(request, response, e);
+    response.sendError(HttpStatus.NOT_FOUND.value(), e.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  void handleException(Exception e, HttpServletResponse response, HttpServletRequest request) throws IOException {
+    logger.error("Internal Server Error", e);
+
+    storeException(request, response, e);
+
+    ResponseStatus responseStatus = e.getClass().getAnnotation(ResponseStatus.class);
+    if (responseStatus != null) {
+      response.sendError(responseStatus.value().value(), e.getMessage());
+    } else {
+      response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
+    }
+
+  }
+
+  private void storeException(HttpServletRequest request, HttpServletResponse response, Exception ex) {
+    // store exception as an attribute of HttpServletRequest such that it can be referenced by GenericErrorController
+    defaultErrorAttributes.resolveException(request, response, null, ex);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
@@ -44,23 +44,13 @@ class ProjectController {
 
   @RequestMapping(value = "/{id:.+}", method = RequestMethod.GET)
   Map get(@PathVariable("id") String projectId) {
-    def result = projectService.get(projectId)
-    if (!result) {
-      log.warn("Project not found (projectId: ${projectId}")
-      throw new ProjectNotFoundException("Project not found (projectId: ${projectId})")
-    }
-    result
+    return projectService.get(projectId)
   }
 
   @RequestMapping(value = "/{id}/clusters", method = RequestMethod.GET)
   List<Map> getClusters(@PathVariable("id") String projectId,
                         @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
-    def result = projectService.getClusters(projectId, sourceApp)
-    if (!result) {
-      log.warn("Project not found (projectId: ${projectId}")
-      throw new ProjectNotFoundException("Project not found (projectId: ${projectId})")
-    }
-    result
+    return projectService.getClusters(projectId, sourceApp)
   }
 
   @RequestMapping(value = "/{id:.+}/pipelines", method = RequestMethod.GET)
@@ -69,8 +59,4 @@ class ProjectController {
                                    @RequestParam(value = "statuses", required = false) String statuses) {
     return projectService.getAllPipelines(projectId, limit, statuses)
   }
-
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  @InheritConstructors
-  static class ProjectNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SecurityGroupController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SecurityGroupController.groovy
@@ -16,11 +16,10 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.netflix.spinnaker.gate.exceptions.NotFoundException
 import com.netflix.spinnaker.gate.services.SecurityGroupService
-import groovy.transform.InheritConstructors
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -39,7 +38,7 @@ class SecurityGroupController {
       if (result) {
         result
       } else {
-        throw new SecurityGroupNotFoundException(id)
+        throw new NotFoundException("No security group found (id: ${id})")
       }
     } else {
       securityGroupService.getAll(sourceApp)
@@ -67,8 +66,4 @@ class SecurityGroupController {
       @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     securityGroupService.getSecurityGroup(account, provider, name, region, sourceApp, vpcId)
   }
-
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  @InheritConstructors
-  static class SecurityGroupNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupController.groovy
@@ -17,18 +17,16 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.netflix.spinnaker.gate.exceptions.NotFoundException
 import com.netflix.spinnaker.gate.services.ServerGroupService
 import groovy.transform.CompileStatic
-import groovy.transform.InheritConstructors
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @CompileStatic
@@ -56,13 +54,9 @@ class ServerGroupController {
                             @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     def serverGroupDetails = serverGroupService.getForApplicationAndAccountAndRegion(applicationName, account, region, serverGroupName, sourceApp)
     if (!serverGroupDetails) {
-      throw new ServerGroupNotFoundException()
+      throw new NotFoundException("Server group now found (id: ${serverGroupName})")
     }
 
     return serverGroupDetails
   }
-
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  @InheritConstructors
-  static class ServerGroupNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
@@ -16,15 +16,13 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.netflix.spinnaker.gate.exceptions.NotFoundException
 import com.netflix.spinnaker.gate.services.CanaryConfigService
-import groovy.transform.InheritConstructors
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -48,11 +46,7 @@ class V2CanaryController {
     if (canaryConfigService) {
       return canaryConfigService.getCanaryConfig(id)
     } else {
-      throw new CanaryConfigNotFoundException()
+      throw new NotFoundException("Canary configuration not found (id: ${id})")
     }
   }
-
-  @ResponseStatus(HttpStatus.NOT_FOUND)
-  @InheritConstructors
-  static class CanaryConfigNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/exceptions/HasAdditionalAttributes.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/exceptions/HasAdditionalAttributes.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.exceptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface HasAdditionalAttributes {
+  default Map<String, Object> getAdditionalAttributes() {
+    return Collections.emptyMap();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/exceptions/NotFoundException.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/exceptions/NotFoundException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.exceptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NotFoundException extends RuntimeException implements HasAdditionalAttributes {
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -17,17 +17,15 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.netflix.spinnaker.gate.exceptions.NotFoundException
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.EchoService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import groovy.transform.CompileStatic
-import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.bind.annotation.ResponseStatus
 
 @CompileStatic
 @Component
@@ -70,7 +68,7 @@ class PipelineService {
   Map trigger(String application, String pipelineNameOrId, Map trigger) {
     def pipelineConfig = applicationService.getPipelineConfigForApplication(application, pipelineNameOrId)
     if (!pipelineConfig) {
-      throw new PipelineConfigNotFoundException()
+      throw new NotFoundException("Pipeline configuration not found (id: ${pipelineNameOrId})")
     }
     pipelineConfig.trigger = trigger
     if (trigger.notifications) {
@@ -122,8 +120,4 @@ class PipelineService {
   Map evaluateExpressionForExecution(String executionId, String pipelineExpression) {
     orcaService.evaluateExpressionForExecution(executionId, pipelineExpression)
   }
-
-  @InheritConstructors
-  @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "pipeline config not found!")
-  static class PipelineConfigNotFoundException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/StrategyService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/StrategyService.groovy
@@ -56,8 +56,4 @@ class StrategyService {
   void move(Map moveCommand) {
     front50Service.moveStrategyConfig(moveCommand)
   }
-
-  @InheritConstructors
-  @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "strategy config not found!")
-  static class StrategyConfigNotFoundException extends RuntimeException {}
 }


### PR DESCRIPTION
Introduces a single NotFoundException that can be used in place of all
previous *NotFoundException classes (ie. ApplicationNotFoundException,
SecurityGroupNotFoundException, etc).

The default ErrorController has been replaced with one that will always
return application/json.

A stacktrace will be included if ?trace=true is appended to the request.

Example error response:

```
{
  "error": "Not Found",
  "exception": "com.netflix.spinnaker.gate.exceptions.NotFoundException",
  "message": "Application not found (id: some_application_name)",
  "status": 404,
  "timestamp": 1499731805410
}
```