### PR TITLE
test(LDAP): Adds ldap integration tests

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -11,6 +11,7 @@ tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
 
 apply plugin: 'org.springframework.boot'
 apply plugin: 'spinnaker.package'
+apply from: "$rootDir/gradle/ldap.gradle"
 
 repositories {
   maven {
@@ -49,6 +50,7 @@ dependencies {
   }
 
   testCompile "com.squareup.okhttp:mockwebserver:${spinnaker.version('okHttp')}"
+  testCompile apachedsDependencies
   testCompile spinnaker.dependency("korkJedisTest")
 
   //this brings in the jetty GzipFilter which boot will autoconfigure

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -42,7 +42,6 @@ import org.springframework.stereotype.Component
 @Configuration
 @SpinnakerAuthConfig
 @EnableWebSecurity
-@Import(SecurityAutoConfiguration)
 class LdapSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorConfig.groovy
@@ -34,6 +34,7 @@ class HystrixSpectatorConfig {
   @PostConstruct
   void enableSpecatorPublisher() {
     log.info("Enabling HystrixSpectatorPublisher")
+    HystrixPlugins.reset()
     HystrixPlugins.getInstance().registerMetricsPublisher(
       new HystrixSpectatorPublisher(registry)
     )

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -239,8 +239,7 @@ class FunctionalSpec extends Specification {
   }
 
   @EnableAutoConfiguration(exclude = [SecurityAutoConfiguration, GroovyTemplateAutoConfiguration])
-  @Configuration
-  static class FunctionalConfiguration {
+  private static class FunctionalConfiguration {
 
     @Bean
     ClouddriverServiceSelector clouddriverSelector() {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/RedisTestConfig.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/config/RedisTestConfig.groovy
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.gate.config
+
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+@Component
+class RedisTestConfig {
+
+  EmbeddedRedis redis
+
+  int port
+
+  @PostConstruct
+  void startRedis() {
+    redis = EmbeddedRedis.embed()
+    port = redis.port
+    System.setProperty("redis.connection", "redis://localhost:${port}")
+  }
+
+  @PreDestroy
+  void stopRedis() {
+    redis?.destroy()
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/FormLoginRequestBuilder.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/FormLoginRequestBuilder.groovy
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security
+
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.web.servlet.RequestBuilder
+
+import javax.servlet.ServletContext
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+/**
+ * @author Rob Winch
+ * @author Travis Tomsu
+ *
+ * Class is derived from
+ * https://github.com/spring-projects/spring-security/blob/master/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuilders.java
+ */
+public class FormLoginRequestBuilder implements RequestBuilder {
+  private String usernameParam = "username"
+  private String passwordParam = "password"
+  private String username = "user"
+  private String password = "password"
+  private String loginProcessingUrl = "/login"
+  private MediaType acceptMediaType = MediaType.APPLICATION_FORM_URLENCODED
+  private MockHttpSession session
+
+  @Override
+  MockHttpServletRequest buildRequest(ServletContext servletContext) {
+    MockHttpServletRequest request = post(this.loginProcessingUrl)
+        .accept(this.acceptMediaType).param(this.usernameParam, this.username)
+        .param(this.passwordParam, this.password)
+        .session(session)
+        .buildRequest(servletContext)
+    return request
+  }
+
+  /**
+   * Specifies the URL to POST to. Default is "/login"
+   *
+   * @param loginProcessingUrl the URL to POST to. Default is "/login"
+   * @return
+   */
+  FormLoginRequestBuilder loginProcessingUrl(String loginProcessingUrl) {
+    this.loginProcessingUrl = loginProcessingUrl
+    return this
+  }
+
+  /**
+   * The HTTP parameter to place the username. Default is "username".
+   * @param usernameParameter the HTTP parameter to place the username. Default is
+   * "username".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder userParameter(String usernameParameter) {
+    this.usernameParam = usernameParameter
+    return this
+  }
+
+  /**
+   * The HTTP parameter to place the password. Default is "password".
+   * @param passwordParameter the HTTP parameter to place the password. Default is
+   * "password".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder passwordParam(String passwordParameter) {
+    this.passwordParam = passwordParameter
+    return this
+  }
+
+  /**
+   * The value of the password parameter. Default is "password".
+   * @param password the value of the password parameter. Default is "password".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder password(String password) {
+    this.password = password
+    return this
+  }
+
+  /**
+   * The value of the username parameter. Default is "user".
+   * @param username the value of the username parameter. Default is "user".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder user(String username) {
+    this.username = username
+    return this
+  }
+
+  /**
+   * Specify both the password parameter name and the password.
+   *
+   * @param passwordParameter the HTTP parameter to place the password. Default is
+   * "password".
+   * @param password the value of the password parameter. Default is "password".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder password(String passwordParameter,
+                                          String password) {
+    passwordParam(passwordParameter)
+    this.password = password
+    return this
+  }
+
+  /**
+   * Specify both the password parameter name and the password.
+   *
+   * @param usernameParameter the HTTP parameter to place the username. Default is
+   * "username".
+   * @param username the value of the username parameter. Default is "user".
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder user(String usernameParameter, String username) {
+    userParameter(usernameParameter)
+    this.username = username
+    return this
+  }
+
+  /**
+   * Specify a media type to to set as the Accept header in the request.
+   *
+   * @param acceptMediaType the {@link MediaType} to set the Accept header to.
+   * Default is: MediaType.APPLICATION_FORM_URLENCODED
+   * @return the {@link FormLoginRequestBuilder} for additional customizations
+   */
+  FormLoginRequestBuilder acceptMediaType(MediaType acceptMediaType) {
+    this.acceptMediaType = acceptMediaType
+    return this
+  }
+
+  FormLoginRequestBuilder session(MockHttpSession session) {
+    this.session = session
+    return this
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/GateSystemTest.java
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/GateSystemTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security;
+
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@WebAppConfiguration()
+@DirtiesContext
+public @interface GateSystemTest {
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/YamlFileApplicationContextInitializer.java
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/YamlFileApplicationContextInitializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security;
+
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+
+// source: https://stackoverflow.com/a/37349492/5569046
+public class YamlFileApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+  @Override
+  public void initialize(ConfigurableApplicationContext applicationContext) {
+    try {
+      Resource resource = applicationContext.getResource("classpath:gate.yml");
+      YamlPropertySourceLoader sourceLoader = new YamlPropertySourceLoader();
+      PropertySource<?> yamlTestProperties = sourceLoader.load("yamlTestProperties", resource, null);
+      applicationContext.getEnvironment().getPropertySources().addLast(yamlTestProperties);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/ApacheDSServer.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/ApacheDSServer.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.ldap
+
+import org.springframework.security.ldap.server.ApacheDSContainer
+
+class ApacheDSServer {
+
+  private static ApacheDSContainer server
+  private static Integer serverPort
+
+  static void startServer(String ldif) throws Exception {
+    server = new ApacheDSContainer("dc=unit,dc=test", ldif)
+    serverPort = getAvailablePort()
+    server.port = serverPort
+    server.afterPropertiesSet()
+  }
+
+  static void stopServer() throws Exception {
+    serverPort = null
+    server?.stop()
+  }
+
+  static int getServerPort() {
+    if (!serverPort) {
+      throw new IllegalStateException("The ApacheDSContainer is not currently running")
+    }
+    return serverPort
+  }
+
+  private static int getAvailablePort() throws IOException {
+    ServerSocket serverSocket = null
+    try {
+      serverSocket = new ServerSocket(0)
+      return serverSocket.getLocalPort()
+    }
+    finally {
+      serverSocket?.close()
+    }
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/ApacheDSServerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/ApacheDSServerSpec.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.ldap
+
+import org.springframework.ldap.AuthenticationException
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource
+import spock.lang.Specification
+
+class ApacheDSServerSpec extends Specification {
+
+  def setup() {
+    ApacheDSServer.startServer("classpath:ldap-server.ldif")
+  }
+
+  def cleanup() {
+    ApacheDSServer.stopServer()
+  }
+
+  def "should connect to LDAP server"() {
+    setup:
+    int port = ApacheDSServer.getServerPort()
+    def contextSource = new DefaultSpringSecurityContextSource("ldap://127.0.0.1:${port}/dc=unit,dc=test")
+    contextSource.afterPropertiesSet()
+
+    expect:
+    contextSource.getContext("uid=batman,ou=users,dc=unit,dc=test", "batman")
+
+    when:
+    contextSource.getContext("uid=batman,ou=users,dc=unit,dc=test", "badPassword")
+
+    then:
+    thrown AuthenticationException
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.ldap
+
+import com.netflix.spinnaker.gate.Main
+import com.netflix.spinnaker.gate.config.RedisTestConfig
+import com.netflix.spinnaker.gate.security.FormLoginRequestBuilder
+import com.netflix.spinnaker.gate.security.GateSystemTest
+import com.netflix.spinnaker.gate.security.YamlFileApplicationContextInitializer
+import com.netflix.spinnaker.gate.services.AccountLookupService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.security.web.FilterChainProxy
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import spock.lang.Specification
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@Slf4j
+@TestPropertySource("/ldap.properties")
+@GateSystemTest
+@ContextConfiguration(
+    classes = [Main, LdapSsoConfig, LdapTestConfig],
+    initializers = YamlFileApplicationContextInitializer
+)
+class LdapAuthSpec extends Specification {
+
+  @Autowired
+  WebApplicationContext wac
+
+  MockMvc mockMvc
+
+  @Autowired
+  FilterChainProxy springSecurityFilterChain
+
+  def setup() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).addFilter(springSecurityFilterChain).build()
+  }
+
+  def cleanup() {
+    ApacheDSServer.stopServer()
+  }
+
+  def "should do ldap authentication"() {
+    setup:
+    // MockMvc doesn't seem to like to generate and return cookies for some reason. In order to make
+    // the login workflow operate correctly, we have to yank the session out and set it on each
+    // subsequent request.
+    MockHttpSession session = null
+
+    when:
+    mockMvc.perform(get("/credentials"))
+           .andDo(print())
+           .andExpect(status().is3xxRedirection())
+           .andExpect(header().string("Location", "http://localhost/login"))
+           .andDo({ result ->
+      session = (MockHttpSession) result.getRequest().getSession()
+    })
+
+    mockMvc.perform(new FormLoginRequestBuilder().user("batman")
+                                                 .password("batman")
+                                                 .session(session))
+           .andDo(print())
+           .andExpect(status().is(302))
+           .andExpect(redirectedUrl("http://localhost/credentials"))
+
+    def result = mockMvc.perform(get("/credentials").session(session))
+                        .andDo(print())
+                        .andExpect(status().isOk())
+                        .andReturn()
+
+    then:
+    result.response.contentAsString.contains("foo")
+  }
+
+  static class LdapTestConfig {
+
+    @Bean
+    RedisTestConfig redisTestConfig() {
+      new RedisTestConfig()
+    }
+
+    @Autowired
+    LdapSsoConfig ldapSsoConfig(LdapSsoConfig config){
+      ApacheDSServer.startServer("classpath:ldap-server.ldif")
+      Integer ldapPort = ApacheDSServer.getServerPort()
+      log.debug("Setting LDAP server port to $ldapPort")
+      config.ldapConfigProps.url = config.ldapConfigProps.url.replaceFirst("5555", ldapPort.toString())
+      return config
+    }
+
+    @Bean
+    @Primary
+    AccountLookupService accountLookupService() {
+      return new AccountLookupService() {
+        @Override
+        List<ClouddriverService.Account> getAccounts() {
+          return [
+              new ClouddriverService.Account(name: "foo")
+          ]
+        }
+      }
+    }
+  }
+}

--- a/gate-web/src/test/resources/ldap-server.ldif
+++ b/gate-web/src/test/resources/ldap-server.ldif
@@ -1,0 +1,49 @@
+version: 1
+
+dn: ou=users,dc=unit,dc=test
+objectClass: organizationalUnit
+objectClass: top
+ou: users
+
+dn: dc=unit,dc=test
+objectclass: top
+objectclass: domain
+dc: unit
+
+dn: uid=batman,ou=users,dc=unit,dc=test
+objectClass: organizationalPerson
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: top
+cn: Bruce
+sn: Wayne
+uid: batman
+userPassword:: e1NIQX1YRzJlM0RxVkhOcDJQMlVDTmMvRUdqL0NQK2c9
+
+dn: uid=joker,ou=users,dc=unit,dc=test
+objectClass: organizationalPerson
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: top
+cn: Jack
+sn: Nicholson
+uid: joker
+userPassword:: e1NIQX1iSmMraUFPeis2cS9zSjNaRnVLVjdTVGFIVU09
+
+dn: ou=groups,dc=unit,dc=test
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+
+dn: cn=badGuys,ou=groups,dc=unit,dc=test
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: badGuys
+uniqueMember: uid=joker,ou=users,dc=unit,dc=test
+
+dn: cn=goodGuys,ou=groups,dc=unit,dc=test
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: goodGuys
+uniqueMember: uid=batman,ou=users,dc=unit,dc=test
+

--- a/gate-web/src/test/resources/ldap.properties
+++ b/gate-web/src/test/resources/ldap.properties
@@ -1,0 +1,3 @@
+ldap.enabled=true
+ldap.url=ldap://localhost:5555/dc=unit,dc=test
+ldap.userDnPattern=uid={0},ou=users

--- a/gate-web/src/test/resources/logback-test.xml
+++ b/gate-web/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p ${PID:- } --- [%15.15t] %-40.40logger{39} : [%X{X-SPINNAKER-USER}] %m%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.opensaml" level="DEBUG"/>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/gradle/ldap.gradle
+++ b/gradle/ldap.gradle
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ext.apacheDsVersion = '1.5.5'
+
+ext.apachedsDependencies = [
+    "org.apache.directory.server:apacheds-core:$apacheDsVersion",
+    "org.apache.directory.server:apacheds-core-entry:$apacheDsVersion",
+    "org.apache.directory.server:apacheds-protocol-shared:$apacheDsVersion",
+    "org.apache.directory.server:apacheds-protocol-ldap:$apacheDsVersion",
+    "org.apache.directory.server:apacheds-server-jndi:$apacheDsVersion",
+    'org.apache.directory.shared:shared-ldap:0.9.15'
+]


### PR DESCRIPTION
We're sorely lacking proper auth tests, so this PR will hopefully take us a step in the right direction.

The tests stand up an embedded LDAP server (ApacheDS) to authenticate against. An LDIF file is included that defines two users, but only one is used in the tests.

