### PR TITLE
Revert "refactor(web): Update pipelines now goes through orca tasks (#422)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,3 @@ build/
 out/
 /.idea/
 *.rdb
-
-.classpath
-.project
-.settings

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -18,12 +18,9 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.services.PipelineService
-import com.netflix.spinnaker.gate.services.TaskService
-import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileStatic
-import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,13 +28,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import retrofit.RetrofitError
 
 @Slf4j
@@ -48,12 +39,6 @@ class PipelineController {
   @Autowired
   PipelineService pipelineService
 
-  @Autowired
-  TaskService taskService
-
-  @Autowired
-  Front50Service front50Service
-
   @ApiOperation(value = "Delete a pipeline definition")
   @RequestMapping(value = "/{application}/{pipelineName:.+}", method = RequestMethod.DELETE)
   void deletePipeline(@PathVariable String application, @PathVariable String pipelineName) {
@@ -63,21 +48,7 @@ class PipelineController {
   @ApiOperation(value = "Save a pipeline definition")
   @RequestMapping(value = '', method = RequestMethod.POST)
   void savePipeline(@RequestBody Map pipeline) {
-    def operation = [
-      description: "Save pipeline '${pipeline.get("name") ?: "Unknown"}'",
-      application: pipeline.get('application'),
-      job: [
-        [
-          type: "savePipeline",
-          pipeline: pipeline
-        ]
-      ]
-    ]
-    def result = taskService.createAndWaitForCompletion(operation)
-
-    if ("TERMINAL".equalsIgnoreCase((String) result.get("status"))) {
-      throw new PipelineSaveFailedException("Pipeline save operation failed with terminal status: ${result.get("id", "unknown task id")}")
-    }
+    pipelineService.save(pipeline)
   }
 
   @ApiOperation(value = "Rename a pipeline definition")
@@ -101,24 +72,7 @@ class PipelineController {
   @ApiOperation(value = "Update a pipeline definition")
   @RequestMapping(value = "{id}", method = RequestMethod.PUT)
   Map updatePipeline(@PathVariable("id") String id, @RequestBody Map pipeline) {
-    def operation = [
-      description: "Update pipeline '${pipeline.get("name") ?: 'Unknown'}",
-      application: (String) pipeline.get('application'),
-      job: [
-        [
-          type: 'updatePipeline',
-          pipeline: pipeline
-        ]
-      ]
-    ]
-
-    def result = taskService.createAndWaitForCompletion(operation)
-
-    if ("TERMINAL".equalsIgnoreCase((String) result.get("status"))) {
-      throw new PipelineSaveFailedException("Pipeline save operation failed with terminal status: ${result.get("id", "unknown task id")}")
-    }
-
-    return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"))?.find { id == (String) it.get("id") }
+    pipelineService.update(id, pipeline)
   }
 
   @ApiOperation(value = "Retrieve pipeline execution logs")
@@ -225,8 +179,4 @@ class PipelineController {
       }
     }
   }
-
-  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-  @InheritConstructors
-  static class PipelineSaveFailedException extends RuntimeException {}
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -77,27 +77,6 @@ class TaskService {
     } execute()
   }
 
-  Map createAndWaitForCompletion(Map body, int maxPolls = 20, int intervalMs = 500) {
-    Map createResult = create(body)
-    if (!createResult.get("ref")) {
-      return createResult
-    }
-
-    String taskId = ((String) createResult.get("ref")).split('/')[2]
-
-    int i = 0
-    while (i < maxPolls) {
-      i++
-      sleep(intervalMs)
-
-      Map task = getTask(taskId)
-      if (['SUCCEEDED', 'TERMINAL'].contains((String) task.get("status"))) {
-        return task
-      }
-    }
-    return null
-  }
-
   /**
    * @deprecated  This pipeline operation does not belong here.
    */

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
@@ -16,23 +16,20 @@
 
 package com.netflix.spinnaker.gate.controllers
 
-import com.netflix.spinnaker.gate.services.TaskService
-import com.netflix.spinnaker.gate.services.internal.Front50Service
+import com.netflix.spinnaker.gate.services.PipelineService
 import org.codehaus.jackson.map.ObjectMapper
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import spock.lang.Specification
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 
 class PipelineControllerSpec extends Specification {
 
   def "should update a pipeline"() {
     given:
-    def taskSerivce = Mock(TaskService)
-    def front50Service = Mock(Front50Service)
-    MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new PipelineController(taskService: taskSerivce, front50Service: front50Service)).build()
+    def pipelineService = Mock(PipelineService)
+    MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new PipelineController(pipelineService: pipelineService)).build()
 
     and:
     def pipeline = [
@@ -54,25 +51,6 @@ class PipelineControllerSpec extends Specification {
 
     then:
     response.status == 200
-    1 * taskSerivce.createAndWaitForCompletion([
-      description: "Update pipeline 'test pipeline",
-      application: 'application',
-      job: [
-        [
-          type: 'updatePipeline',
-          pipeline: [
-            id: 'id',
-            name: 'test pipeline',
-            stages: [],
-            triggers: [],
-            limitConcurrent: true,
-            parallel: true,
-            index: 4,
-            application: 'application'
-          ]
-        ]
-      ]
-    ]) >> { [id: 'task-id', application: 'application', status: 'SUCCEEDED'] }
-    1 * front50Service.getPipelineConfigsForApplication('application') >> []
+    1 * pipelineService.update(pipeline.id, pipeline)
   }
 }


### PR DESCRIPTION
This reverts commit 597355ccd644429d801db3fd693d07998f30e88e.

Major regression: This new save path causes pipeline templates to evaluate
their pipeline expressions at the point of save, rather than at execution
time. Once a fix is put into orca, we'll re-apply this change.