### PR TITLE
feat(web): Save pipelines via orca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 out/
 /.idea/
 *.rdb
+
+.classpath
+.project
+.settings

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -17,9 +17,12 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.services.PipelineService
 
 import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes
+import com.netflix.spinnaker.gate.services.TaskService
+import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileStatic
@@ -48,6 +51,15 @@ class PipelineController {
   @Autowired
   PipelineService pipelineService
 
+  @Autowired
+  TaskService taskService
+
+  @Autowired
+  Front50Service front50Service
+
+  @Autowired
+  ObjectMapper objectMapper
+
   @ApiOperation(value = "Delete a pipeline definition")
   @RequestMapping(value = "/{application}/{pipelineName:.+}", method = RequestMethod.DELETE)
   void deletePipeline(@PathVariable String application, @PathVariable String pipelineName) {
@@ -57,7 +69,21 @@ class PipelineController {
   @ApiOperation(value = "Save a pipeline definition")
   @RequestMapping(value = '', method = RequestMethod.POST)
   void savePipeline(@RequestBody Map pipeline) {
-    pipelineService.save(pipeline)
+    def operation = [
+      description: (String) "Save pipeline '${pipeline.get("name") ?: "Unknown"}'",
+      application: pipeline.get('application'),
+      job: [
+        [
+          type: "savePipeline",
+          pipeline: (String) Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+        ]
+      ]
+    ]
+    def result = taskService.createAndWaitForCompletion(operation)
+
+    if ("TERMINAL".equalsIgnoreCase((String) result.get("status"))) {
+      throw new PipelineException("Pipeline save operation failed with terminal status: ${result.get("id", "unknown task id")}")
+    }
   }
 
   @ApiOperation(value = "Rename a pipeline definition")
@@ -81,7 +107,24 @@ class PipelineController {
   @ApiOperation(value = "Update a pipeline definition")
   @RequestMapping(value = "{id}", method = RequestMethod.PUT)
   Map updatePipeline(@PathVariable("id") String id, @RequestBody Map pipeline) {
-    pipelineService.update(id, pipeline)
+    def operation = [
+      description: (String) "Update pipeline '${pipeline.get("name") ?: 'Unknown'}'",
+      application: (String) pipeline.get('application'),
+      job: [
+        [
+          type: 'updatePipeline',
+          pipeline: (String) Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipeline).bytes)
+        ]
+      ]
+    ]
+
+    def result = taskService.createAndWaitForCompletion(operation)
+
+    if ("TERMINAL".equalsIgnoreCase((String) result.get("status"))) {
+      throw new PipelineException("Pipeline save operation failed with terminal status: ${result.get("id", "unknown task id")}")
+    }
+
+    return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"))?.find { id == (String) it.get("id") }
   }
 
   @ApiOperation(value = "Retrieve pipeline execution logs")
@@ -193,6 +236,10 @@ class PipelineController {
   @InheritConstructors
   class PipelineException extends RuntimeException implements HasAdditionalAttributes {
     Map<String, Object> additionalAttributes = [:]
+
+    PipelineException(String message) {
+      super(message)
+    }
 
     PipelineException(Map<String, Object> additionalAttributes) {
       this.additionalAttributes = additionalAttributes

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -77,6 +77,27 @@ class TaskService {
     } execute()
   }
 
+  Map createAndWaitForCompletion(Map body, int maxPolls = 20, int intervalMs = 500) {
+    Map createResult = create(body)
+    if (!createResult.get("ref")) {
+      return createResult
+    }
+
+    String taskId = ((String) createResult.get("ref")).split('/')[2]
+
+    int i = 0
+    while (i < maxPolls) {
+      i++
+      sleep(intervalMs)
+
+      Map task = getTask(taskId)
+      if (['SUCCEEDED', 'TERMINAL'].contains((String) task.get("status"))) {
+        return task
+      }
+    }
+    return null
+  }
+
   /**
    * @deprecated  This pipeline operation does not belong here.
    */


### PR DESCRIPTION
Reverts the revert of #434.

Change done here is to base64 encode the pipeline so that pipeline expressions are not evaluated.

Depends on https://github.com/spinnaker/orca/pull/1515