### PR TITLE
fix(core): disable favorPathExtension

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.filter.ShallowEtagHeaderFilter
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 import retrofit.RetrofitError
@@ -119,4 +120,10 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
       ]
     }
   }
+
+  @Override
+  void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+    configurer.favorPathExtension(false)
+  }
+
 }


### PR DESCRIPTION
Spring automatically treats the last part of a URL path as a file if it includes a known extension, e.g. `.c` or `.pdf`, which breaks searches in those cases.