### PR TITLE
fix(pipelines): add logging, guards in pipeline save code

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -119,9 +119,13 @@ class PipelineController {
     ]
 
     def result = taskService.createAndWaitForCompletion(operation)
+    String resultStatus = result.get("status")
 
-    if ("TERMINAL".equalsIgnoreCase((String) result.get("status"))) {
+    if ("TERMINAL".equalsIgnoreCase(resultStatus)) {
       throw new PipelineException("Pipeline save operation failed with terminal status: ${result.get("id", "unknown task id")}")
+    }
+    if (!"SUCCEEDED".equalsIgnoreCase(resultStatus)) {
+      throw new PipelineException("Pipeline save operation did not succeed: ${result.get("id", "unknown task id")} (status: ${resultStatus})")
     }
 
     return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"))?.find { id == (String) it.get("id") }


### PR DESCRIPTION
If the save takes longer than 10 seconds right now, we end up throwing a NPE. This adds a few guards against that, as well as some logging to help troubleshoot errors.

@robzienert PTAL