### PR TITLE
feat(web): Expose the /v1/data/[static|adhoc] api from clouddriver

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -17,11 +17,13 @@
 package com.netflix.spinnaker.gate.services.internal
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import retrofit.client.Response
 import retrofit.http.GET
 import retrofit.http.Headers
 import retrofit.http.Path
 import retrofit.http.Query
 import retrofit.http.QueryMap
+import retrofit.http.Streaming
 
 interface ClouddriverService {
 
@@ -268,4 +270,14 @@ interface ClouddriverService {
 
   @GET('/certificates/{cloudProvider}')
   List<Map> getCertificates(@Path("cloudProvider") String cloudProvider)
+
+  @Streaming
+  @GET('/v1/data/static/{id}')
+  Response getStaticData(@Path('id') String id, @QueryMap Map<String, String> filters)
+
+  @Streaming
+  @GET('/v1/data/adhoc/{groupId}/{bucketId}/{objectId}')
+  Response getAdhocData(@Path(value = 'groupId', encode = false) String groupId,
+                        @Path(value = 'bucketId', encode = false) String bucketId,
+                        @Path(value = 'objectId', encode = false) String objectId)
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DataController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DataController.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.services.DataService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.HandlerMapping
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/v1/data")
+class DataController {
+  @Autowired
+  DataService dataService
+
+  @RequestMapping(value = "/static/{id}", method = RequestMethod.GET)
+  StreamingResponseBody getStaticData(@PathVariable("id") String id,
+                                      @RequestParam Map<String, String> filters) {
+    return new StreamingResponseBody() {
+      @Override
+      void writeTo (OutputStream outputStream) throws IOException {
+        dataService.getStaticData(id, filters, outputStream)
+        outputStream.flush()
+      }
+    }
+  }
+
+  @RequestMapping(value = "/adhoc/{groupId}/{bucketId}/**")
+  StreamingResponseBody getAdhocData(@PathVariable("groupId") String groupId,
+                                     @PathVariable("bucketId") String bucketId,
+                                     HttpServletRequest httpServletRequest) {
+    String pattern = (String) httpServletRequest.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE)
+    String objectId = new AntPathMatcher().extractPathWithinPattern(pattern, httpServletRequest.getServletPath())
+
+    return new StreamingResponseBody() {
+      @Override
+      void writeTo (OutputStream outputStream) throws IOException {
+        dataService.getAdhocData(groupId, bucketId, objectId, outputStream)
+        outputStream.flush()
+      }
+    }
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/DataService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/DataService.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.hystrix.HystrixCommand
+import com.netflix.spinnaker.gate.services.commands.HystrixFactory
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import java.util.concurrent.Callable;
+
+@CompileStatic
+@Component
+class DataService {
+  private static final String GROUP = "data"
+
+  @Autowired
+  ClouddriverServiceSelector clouddriverServiceSelector
+
+  private static HystrixCommand<Void> voidCommand(String type, Callable<Void> work) {
+    HystrixFactory.newVoidCommand(GROUP, type, work)
+  }
+
+  void getStaticData(String id, Map<String, String> filters, OutputStream outputStream) {
+    voidCommand("static", {
+      def response = clouddriverServiceSelector.select(null).getStaticData(id, filters)
+      outputStream << response.getBody().in()
+    }).execute()
+  }
+
+  void getAdhocData(String groupId, String bucketId, String objectId, OutputStream outputStream) {
+    voidCommand("adhoc", {
+      def response = clouddriverServiceSelector.select(null).getAdhocData(groupId, bucketId, objectId)
+      outputStream << response.getBody().in()
+    }).execute()
+  }
+}


### PR DESCRIPTION
Results are streamed directly from clouddriver.

```
curl http://localhost:7101/v1/data/static/my_static_id
curl http://localhost:7101/v1/data/adhoc/titus/my_account:us-east-1:my_bucket/TitusWorker-001/stderr
```
