### PR TITLE
fix(x509): add the cert identity as a role for authz checks

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsService.groovy
@@ -67,6 +67,9 @@ class X509AuthenticationUserDetailsService implements AuthenticationUserDetailsS
     }
 
     def roles = []
+    if (email) {
+      roles.add(email)
+    }
     if (rolesExtractor) {
       roles += rolesExtractor.fromCertificate(x509)
     }


### PR DESCRIPTION
allows granting read or write permission to specific certificates