### PR TITLE
feat(web): Enable request trace header, log annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.109.2'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.110.4'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -266,7 +266,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
    */
   @Bean
   FilterRegistrationBean authenticatedRequestFilter() {
-    def frb = new FilterRegistrationBean(new AuthenticatedRequestFilter(false, true))
+    def frb = new FilterRegistrationBean(new AuthenticatedRequestFilter(false, true, true))
     frb.order = Ordered.LOWEST_PRECEDENCE
     return frb
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/InsightConfiguration.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/InsightConfiguration.groovy
@@ -24,6 +24,8 @@ import groovy.util.logging.Slf4j
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
+import static net.logstash.logback.argument.StructuredArguments.value
+
 @Slf4j
 @Component
 @CompileStatic
@@ -51,7 +53,7 @@ class InsightConfiguration {
           label: label
         ]
       } catch (Exception e) {
-        log.info("Unable to apply context to link (url: ${url})", e)
+        log.info("Unable to apply context to link (url: {})", value("url", url), e)
         return [url: url, label: label]
       }
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -34,6 +34,8 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+import static net.logstash.logback.argument.StructuredArguments.value
+
 @RequestMapping("/applications")
 @RestController
 @Slf4j
@@ -83,7 +85,7 @@ class ApplicationController {
   Map getApplication(@PathVariable("application") String application, @RequestParam(value = "expand", defaultValue = "true") boolean expand) {
     def result = applicationService.getApplication(application, expand)
     if (!result) {
-      log.warn("Application ${application} not found")
+      log.warn("Application {} not found", value("application", application))
       throw new NotFoundException("Application not found (id: ${application})")
     } else if (!result.name) {
       // applicationService.getApplication() doesn't set the name unless clusters are found. Deck requires the name.

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -43,6 +43,8 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import retrofit.RetrofitError
 
+import static net.logstash.logback.argument.StructuredArguments.value
+
 @Slf4j
 @CompileStatic
 @RestController
@@ -207,7 +209,8 @@ class PipelineController {
     } catch (NotFoundException e) {
       throw e
     } catch (e) {
-      log.error("Unable to trigger pipeline (application: ${application}, pipelineName: ${pipelineNameOrId})", e)
+      log.error("Unable to trigger pipeline (application: {}, pipelineName: {})",
+        value("application", application), value("pipelineName", pipelineNameOrId), e)
       new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
     }
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/FiatSessionFilter.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/FiatSessionFilter.groovy
@@ -31,6 +31,8 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpSession
 
+import static net.logstash.logback.argument.StructuredArguments.value
+
 @Slf4j
 class FiatSessionFilter implements Filter {
 
@@ -56,8 +58,8 @@ class FiatSessionFilter implements Filter {
         HttpServletRequest httpReq = (HttpServletRequest) request
         HttpSession session = httpReq.getSession(false)
         if (session != null) {
-          log.info("Invalidating user '${user}' session '${session.id}'" +
-            " because Fiat permission was not found.")
+          log.info("Invalidating user '{}' session '{}' because Fiat permission was not found.",
+          value("user", user), value("session", session))
           session.invalidate()
           SecurityContextHolder.clearContext()
         }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
@@ -23,6 +23,8 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+
 public class RequestLoggingInterceptor extends HandlerInterceptorAdapter {
 
   private Logger log = LoggerFactory.getLogger(getClass());
@@ -30,15 +32,14 @@ public class RequestLoggingInterceptor extends HandlerInterceptorAdapter {
   @Override
   public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
     // 127.0.0.1 "GET /limecat.jpg HTTP/1.0" 200 2326
-    log.debug(String.format(
-      "%s \"%s %s %s\" %d %d",
-      sourceIpAddress(request),
-      request.getMethod(),
-      getRequestEndpoint(request),
-      request.getProtocol(),
-      response.getStatus(),
-      getResponseSize(response)
-    ));
+    log.debug("{} \"{} {} {}\" {} {}",
+      value("sourceIp", sourceIpAddress(request)),
+      value("requestMethod", request.getMethod()),
+      value("requestEndpoint", getRequestEndpoint(request)),
+      value("requestProtocol", request.getProtocol()),
+      value("responseStatus", response.getStatus()),
+      value("responseSize", getResponseSize(response))
+      );
   }
 
   private static String sourceIpAddress(HttpServletRequest request) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
@@ -34,6 +34,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+
 public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
 
   private static Logger log = LoggerFactory.getLogger(RateLimitingInterceptor.class);
@@ -82,7 +84,9 @@ public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
     if (principal.isLearning()) {
       if (rate.isThrottled()) {
         learningThrottlingCounter.increment();
-        log.warn("Rate limiting principal (principal: {}, rateSeconds: {}, capacity: {}, learning: true)", principal.getName(), rate.rateSeconds, rate.capacity);
+        log.warn("Rate limiting principal (principal: {}, rateSeconds: {}, capacity: {}, learning: true)",
+          value("principal", principal.getName()), value("rateSeconds", rate.rateSeconds),
+          value("rateCapacity", rate.capacity));
       }
       return true;
     }
@@ -90,7 +94,9 @@ public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
 
     if (rate.isThrottled()) {
       throttlingCounter.increment();
-      log.warn("Rate limiting principal (principal: {}, rateSeconds: {}, capacity: {}, learning: false)", principal.getName(), rate.rateSeconds, rate.capacity);
+      log.warn("Rate limiting principal (principal: {}, rateSeconds: {}, capacity: {}, learning: false)",
+        value("principal", principal.getName()), value("rateSeconds", rate.rateSeconds),
+        value("rateCapacity", rate.capacity));
       response.sendError(429, "Rate capacity exceeded");
       return false;
     }
@@ -123,7 +129,8 @@ public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
       if ("anonymous".equals(principal)) {
         String rateLimitApp = request.getHeader("X-RateLimit-App");
         if (rateLimitApp != null && !rateLimitApp.equals("")) {
-          log.info("Unknown or anonymous principal, using X-RateLimit-App instead: " + rateLimitApp);
+          log.info("Unknown or anonymous principal, using X-RateLimit-App instead: {}",
+            value("rateLimitApp", rateLimitApp));
           return rateLimitApp;
         }
       }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
@@ -25,6 +25,8 @@ import redis.clients.jedis.exceptions.JedisException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+
 public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalProvider {
 
   private final static Logger log = LoggerFactory.getLogger(RedisRateLimitPrincipalProvider.class);
@@ -68,7 +70,8 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
       try {
         return Integer.parseInt(capacity);
       } catch (NumberFormatException e) {
-        log.error("invalid principal capacity value, expected integer (principal: {}, value: {})", name, capacity);
+        log.error("invalid principal capacity value, expected integer (principal: {}, value: {})",
+          value("principal", name), value("capacity", capacity));
       }
     }
     return overrideOrDefault(name, rateLimiterConfiguration.getCapacityByPrincipal(), rateLimiterConfiguration.getCapacity());
@@ -80,7 +83,8 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
       try {
         return Integer.parseInt(rateSeconds);
       } catch (NumberFormatException e) {
-        log.error("invalid principal rateSeconds value, expected integer (principal: {}, value: {})", name, rateSeconds);
+        log.error("invalid principal rateSeconds value, expected integer (principal: {}, value: {})",
+          value("principal", name), value("rateSeconds", rateSeconds));
       }
     }
     return overrideOrDefault(name, rateLimiterConfiguration.getRateSecondsByPrincipal(), rateLimiterConfiguration.getRateSeconds());
@@ -91,7 +95,8 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
     List<String> ignoring = new ArrayList<>(jedis.smembers(getIgnoringKey()));
 
     if (enforcing.contains(name) && ignoring.contains(name)) {
-      log.warn("principal is configured to be enforced AND ignored in Redis, ENFORCING for request (principal: {})", name);
+      log.warn("principal is configured to be enforced AND ignored in Redis, ENFORCING for request (principal: {})",
+        value("principal", name));
       return false;
     }
 
@@ -100,7 +105,8 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
       ignoring = rateLimiterConfiguration.getIgnoring();
 
       if (enforcing.contains(name) && ignoring.contains(name)) {
-        log.warn("principal is configured to be enforced AND ignored in static config, ENFORCING for request (principal: {})", name);
+        log.warn("principal is configured to be enforced AND ignored in static config, ENFORCING for request (principal: {})",
+          value("principal", name));
         return false;
       }
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
@@ -38,6 +38,8 @@ import retrofit.RetrofitError
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
 
+import static net.logstash.logback.argument.StructuredArguments.*
+
 /**
  * ResourceServerTokenServices is an interface used to manage access tokens. The UserInfoTokenService object is an
  * implementation of that interface that uses an access token to get the logged in user's data (such as email or
@@ -73,7 +75,7 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
     Map details = oAuth2Authentication.userAuthentication.details as Map
 
     if (log.isDebugEnabled()) {
-      log.debug("UserInfo details: " + new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(details))
+      log.debug("UserInfo details: ", entries(details))
     }
 
     def isServiceAccount = isServiceAccount(details)


### PR DESCRIPTION
Enables generation of a X-SPINNAKER-REQUEST-ID per inbound request and sets as a request header on all downstream requests (kork 1.100.0).

Annotation for JSON logging.