### PR TITLE
fix(web): reverting pipeline refresh behavior

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -155,7 +155,7 @@ class ApplicationService {
 
   Map getPipelineConfigForApplication(String app, String pipelineNameOrId) {
     HystrixFactory.newMapCommand(GROUP, "getPipelineConfig") {
-      front50Service.getPipelineConfigsForApplication(app, false).find { it.name == pipelineNameOrId || it.id == pipelineNameOrId }
+      front50Service.getPipelineConfigsForApplication(app, true).find { it.name == pipelineNameOrId || it.id == pipelineNameOrId }
     } execute()
   }
 

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -252,7 +252,7 @@ class ApplicationServiceSpec extends Specification {
 
     then:
     result == expected
-    1 * front50.getPipelineConfigsForApplication(app, false) >> [ [ id: "by-id", name: "by-name" ] ]
+    1 * front50.getPipelineConfigsForApplication(app, true) >> [ [ id: "by-id", name: "by-name" ] ]
 
     where:
     nameOrId  || expected


### PR DESCRIPTION
Front50 improvements should make this behavior unnecessary. 
@ajordens PTAL