### PR TITLE
feat(pipeline_template): Convert pipeline config to pipeline template

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineTemplatesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineTemplatesController.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.gate.services.PipelineTemplateService;
 import com.netflix.spinnaker.gate.services.TaskService;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import io.swagger.annotations.ApiOperation;
-import java.util.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +33,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -16,7 +16,16 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
-import retrofit.http.*
+import retrofit.client.Response
+import retrofit.http.Body
+import retrofit.http.DELETE
+import retrofit.http.GET
+import retrofit.http.Headers
+import retrofit.http.PATCH
+import retrofit.http.POST
+import retrofit.http.PUT
+import retrofit.http.Path
+import retrofit.http.Query
 
 interface OrcaService {
 
@@ -107,4 +116,7 @@ interface OrcaService {
   @Headers("Accept: application/json")
   @GET("/pipelineTemplate")
   Map resolvePipelineTemplate(@Query("source") String source)
+
+  @POST("/convertPipelineToTemplate")
+  Response convertToPipelineTemplate(@Body Map<String, ? extends Object> pipelineConfig)
 }


### PR DESCRIPTION
What I'm kinda thinking is this endpoint could get exposed in deck like so:

<img width="321" alt="screen shot 2017-09-20 at 11 41 26 am" src="https://user-images.githubusercontent.com/108741/30661399-b840cbb6-9df8-11e7-9ae7-21a587f21d12.png">

Maybe `Export to Pipeline Template` or something? This would just pop-up a modal with a textbox that has the result of that endpoint.