### PR TITLE
fix(x509): Allow OAuth and x509 to be used together again

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -62,6 +62,9 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   ExternalSslAwareEntryPoint entryPoint
 
+  @Autowired(required = false)
+  List<OAuthSsoConfigurer> configurers
+
   @Primary
   @Bean
   ResourceServerTokenServices spinnakerUserInfoTokenServices() {
@@ -84,6 +87,10 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
 
     http.exceptionHandling().authenticationEntryPoint(entryPoint)
     http.addFilterBefore(externalAuthTokenFilter, AbstractPreAuthenticatedProcessingFilter.class)
+
+    configurers?.each {
+      it.configure(http)
+    }
   }
 
   /**

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuthSsoConfigurer.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuthSsoConfigurer.groovy
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.gate.security.oauth2;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+interface OAuthSsoConfigurer {
+  void configure(HttpSecurity http) throws Exception
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509Config.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509Config.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.security.x509
 import com.netflix.spinnaker.gate.security.AuthConfig
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
 import com.netflix.spinnaker.gate.security.oauth2.OAuth2SsoConfig
+import com.netflix.spinnaker.gate.security.oauth2.OAuthSsoConfigurer
 import com.netflix.spinnaker.gate.security.saml.SamlSsoConfig
 import com.netflix.spinnaker.gate.security.saml.SamlSsoConfigurer
 import org.springframework.beans.factory.annotation.Autowired
@@ -128,6 +129,20 @@ class X509Config {
       Authentication authenticate(Authentication authentication) throws AuthenticationException {
         throw new UnsupportedOperationException("No authentication should be done with this AuthenticationManager");
       }
+    }
+  }
+
+  @ConditionalOnBean(OAuth2SsoConfig)
+  @Bean
+  X509OAuthConfig withOAuthConfig() {
+    new X509OAuthConfig()
+  }
+
+  class X509OAuthConfig implements OAuthSsoConfigurer {
+    @Override
+    void configure(HttpSecurity http) throws Exception {
+      X509Config.this.configure(http)
+      http.securityContext().securityContextRepository(new X509SecurityContextRepository())
     }
   }
 


### PR DESCRIPTION
Changes made along with the Spring Boot version bump in #433 seem to have caused x509 config to be ignored when OAuth is also used.  The certificate would still be required in order to establish a connection but would not be used for authentication and so all requests would be handled as an anonymous user and redirected to the login URL.  This change just mirrors the existing approach for allowing x509 and SAML to coexist.