### PR TITLE
fix(authN): Handle case of missing port(s) in post authN redirect

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
@@ -126,7 +126,10 @@ class AuthController {
       return matcher.matches()
     }
 
+    def toURLPort = (toURL.port == -1 && toURL.protocol == 'https') ? 443 : toURL.port
+    def deckBaseUrlPort = (deckBaseUrl.port == -1 && deckBaseUrl.protocol == 'https') ? 443 : deckBaseUrl.port
+
     return toURL.host == deckBaseUrl.host &&
-        toURL.port == deckBaseUrl.port
+        toURLPort == deckBaseUrlPort
   }
 }


### PR DESCRIPTION
### **Issue:**
Was working with @ndouglascampbell on a Gate/Deck redirect issue, and we found this bug. We have the following variables set in our configuration files.

**gate.yml:**
```
services:
  deck:
    baseUrl: https://spinnaker.foo.com:443
```

**URL Post AuthN**
`https://gate-url:8084/auth/redirect?to=https%3A%2F%2Fspinnaker.foo.com%2F%23%2Finfrastructure`

This caused an the conditional in this MR to fail due to the ports; when it tried to compare the address in the configuration vs the redirect address in the query param. 

For the deck `baseUrl`, it got a port value of `443`. (Redundant, we know, but we were migration from a config where we listened to SSL on a different port). For the query param in the url, it got a value of `-1` (the default value if no port specified).

### **Fix:**
If port 443 is missing, but the scheme is https, we should set the default to 443, instead of -1.