### PR TITLE
fix(oauth2): Ensure we use 'Bearer' instead of 'bearer' when forwardi…

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/ExternalAuthTokenFilterSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/ExternalAuthTokenFilterSpec.groovy
@@ -1,0 +1,37 @@
+package com.netflix.spinnaker.gate.security.oauth2
+
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoRestTemplateFactory
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext
+import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.servlet.FilterChain
+
+class ExternalAuthTokenFilterSpec extends Specification {
+
+  def "should ensure Bearer token is forwarded properly"() {
+    def request = new MockHttpServletRequest()
+    request.addHeader("Authorization", "bearer foo")
+    def response = new MockHttpServletResponse()
+    def chain = Mock(FilterChain)
+    def restTemplateFactory = Mock(UserInfoRestTemplateFactory)
+    def restTemplate = Mock(OAuth2RestTemplate)
+    def oauth2ClientContext = new DefaultOAuth2ClientContext()
+
+    @Subject ExternalAuthTokenFilter filter = new ExternalAuthTokenFilter(userInfoRestTemplateFactory: restTemplateFactory)
+
+    when:
+    filter.doFilter(request, response, chain)
+
+    then:
+    chain.doFilter(request, response)
+    restTemplateFactory.getUserInfoRestTemplate() >> restTemplate
+    restTemplate.getOAuth2ClientContext() >> oauth2ClientContext
+    def token = oauth2ClientContext.accessToken
+    token.tokenType == "Bearer"
+    token.value == "foo"
+  }
+}


### PR DESCRIPTION
…ng auth token

FWIW, I haven't tested this through to confirm the outgoing request is indeed capitalized. Can you take it for a spin and confirm, @briansneddon ?

Fixes https://github.com/spinnaker/spinnaker/issues/2074