### PR TITLE
feat(authN): Restrict github auth by organization membership

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2SsoProperties
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -65,10 +66,13 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
   @Autowired(required = false)
   List<OAuthSsoConfigurer> configurers
 
+  @Autowired
+  ResourceServerProperties sso;
+
   @Primary
   @Bean
   ResourceServerTokenServices spinnakerUserInfoTokenServices() {
-    new SpinnakerUserInfoTokenServices()
+    new SpinnakerUserInfoTokenServices(userInfoEndpointUrl: sso.getUserInfoUri(), clientId: sso.getClientId())
   }
 
   @Bean

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
@@ -23,7 +23,7 @@ class SpinnakerUserInfoTokenServicesSpec extends Specification {
 
   def "should check restricted domain flag if set"() {
     setup:
-      def userInfoRequirements = new OAuth2SsoConfig.UserInfoRequirements();
+      def userInfoRequirements = new OAuth2SsoConfig.UserInfoRequirements()
       @Subject tokenServices = new SpinnakerUserInfoTokenServices(userInfoRequirements: userInfoRequirements)
 
     expect: "no domain restriction means everything matches"
@@ -58,5 +58,19 @@ class SpinnakerUserInfoTokenServicesSpec extends Specification {
       !tokenServices.hasAllUserInfoRequirements(["hd": "foo.com"])
       !tokenServices.hasAllUserInfoRequirements(["bar": "bar.com"])
       tokenServices.hasAllUserInfoRequirements(["hd": "foo.com", "bar": "bar.com"])
+  }
+
+  def "should check restricted organizations if set"() {
+    setup:
+    def userInfoRequirements = new OAuth2SsoConfig.UserInfoRequirements()
+    userInfoRequirements.organization = "testorg"
+    @Subject tokenServices = new SpinnakerUserInfoTokenServices(userInfoRequirements: userInfoRequirements)
+
+    expect: "no organization in response doesn't match"
+      !tokenServices.hasAllUserInfoRequirements([:])
+
+    and: "organization in response does match"
+      tokenServices.hasAllUserInfoRequirements(['organizations':[['login':'testorg']]])
+      tokenServices.hasAllUserInfoRequirements(['organizations':[['login':'dummy'],['login':'testorg']]])
   }
 }


### PR DESCRIPTION
This adds the ability to restrict github authentication to only users
belonging to a certain organization. If there's a
userInfoRequirements.organization defined in the gate config and an
organizations_url is returned in the user info for an oauth2 request we
make a second request to the organizations_url and merge that data into
the map we return as the initial user object. The
hasAllUserInfoRequirements() function can then filter based on
organization membership. That works a lot like the existing filters, but
because the organizations come back as an array a simple static match or
regex wasn't enough. The user does have to have their membership in the
organization set to "public" in order for this check to be able to see
it. This is a proposed fix for
https://github.com/spinnaker/fiat/issues/188