### PR TITLE
feat(authN): Restrict github auth by organization membership

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/provider/GithubProviderTokenServices.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/provider/GithubProviderTokenServices.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.oauth2.provider
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.security.oauth2.client.OAuth2RestOperations
+import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken
+import org.springframework.security.oauth2.common.OAuth2AccessToken
+import org.springframework.security.oauth2.client.resource.BaseOAuth2ProtectedResourceDetails
+import org.springframework.stereotype.Component
+
+@Slf4j
+@Component
+@ConditionalOnExpression(''''${security.oauth2.providerRequirements.type:}' == "github"''')
+class GithubProviderTokenServices implements SpinnakerProviderTokenServices {
+  @Autowired
+  ResourceServerProperties sso
+
+  @Autowired
+  GithubRequirements requirements
+
+  private String tokenType = DefaultOAuth2AccessToken.BEARER_TYPE
+  private OAuth2RestOperations restTemplate
+
+  @Component
+  @ConfigurationProperties("security.oauth2.providerRequirements")
+  static class GithubRequirements {
+    String organization
+  }
+
+  boolean githubOrganizationMember(String organization, List<Map<String,String>> organizations) {
+    for (int i = 0; i < organizations.size(); i++) {
+      if (organization == organizations[i]["login"]) {
+        return true
+      }
+    }
+    return false
+  }
+
+  boolean checkOrganization(String accessToken, String organizationsUrl, String organization) {
+    try {
+      log.debug("Getting user organizations from: " + organizationsUrl)
+      OAuth2RestOperations restTemplate = this.restTemplate;
+      if (restTemplate == null) {
+        BaseOAuth2ProtectedResourceDetails resource = new BaseOAuth2ProtectedResourceDetails();
+        resource.setClientId(sso.clientId)
+        restTemplate = new OAuth2RestTemplate(resource)
+      }
+      OAuth2AccessToken existingToken = restTemplate.getOAuth2ClientContext()
+        .getAccessToken()
+      if (existingToken == null || !accessToken.equals(existingToken.getValue())) {
+        DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(
+          accessToken)
+        token.setTokenType(this.tokenType)
+        restTemplate.getOAuth2ClientContext().setAccessToken(token)
+      }
+      List<Map<String, String>> organizations = restTemplate
+        .getForEntity(organizationsUrl, List.class).getBody()
+      return githubOrganizationMember(organization, organizations)
+    }
+    catch (Exception ex) {
+      log.warn("Could not fetch user organizations: " + ex.getClass() + ", "
+        + ex.getMessage())
+      return Collections.<String, Object>singletonMap("error",
+        "Could not fetch user organizations")
+    }
+  }
+
+  boolean hasAllProviderRequirements(String token, Map details) {
+    boolean hasRequirements = true
+    if (requirements.organization != null && details.containsKey("organizations_url")) {
+      boolean orgMatch = checkOrganization(token, details['organizations_url'],
+        requirements.organization)
+      if (!orgMatch) {
+        log.debug("User does not include required organization: " + requirements.organization)
+        hasRequirements = false
+      }
+    }
+    return hasRequirements
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/provider/SpinnakerProviderTokenServices.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/provider/SpinnakerProviderTokenServices.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.oauth2.provider
+
+import org.springframework.stereotype.Component
+
+@Component
+interface SpinnakerProviderTokenServices {
+  boolean hasAllProviderRequirements(String token, Map details)
+}


### PR DESCRIPTION
This adds the ability to restrict github authentication to only users belonging to a certain organization. It adds in a provider specific beanto encapsulate the parts that aren't general oauth2 handling. The interface is defined in SpinnakerProviderTokenServices, and it's just a single call that takes the user token and the map of user info. The github provider bean keys off the
security.oauth.providerRequirements.type setting being 'github', and if so it loads the extra provider specific requirements.  This is a proposed fix for spinnaker/fiat#188

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
