### PR TITLE
feat(authz): support migrating clouddriver account authz config to permissions

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -43,6 +43,7 @@ interface ClouddriverService {
     String type
     String providerVersion
     Collection<String> requiredGroupMembership = []
+    Map<String, Collection<String>> permissions
   }
 
 

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -27,35 +27,43 @@ class CredentialsServiceSpec extends Specification {
   @Unroll
   def "should return allowed account names"() {
     setup:
-      AccountLookupService accountLookupService = Mock(AccountLookupService) {
-        getAccounts() >> accounts
-      }
-      FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
+    AccountLookupService accountLookupService = Mock(AccountLookupService) {
+      getAccounts() >> accounts
+    }
+    FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
 
-      @Subject
-      CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
-                                                                     fiatConfig: fiatConfig)
+    @Subject
+    CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
+      fiatConfig: fiatConfig)
 
     when:
-      def allowedAccounts = credentialsService.getAccountNames(roles)
+    def allowedAccounts = credentialsService.getAccountNames(roles)
 
     then:
-      allowedAccounts == expectedAccounts
+    allowedAccounts == expectedAccounts
 
     where:
-      roles              | accounts                       || expectedAccounts
-      null               | []                             || []
-      []                 | []                             || []
-      [null]             | []                             || []
-      ["roleA"]          | [acnt("acntA")]                || ["acntA"]
-      ["roleA"]          | [acnt("acntB")]                || ["acntB"]
-      ["roleA", "roleB"] | [acnt("acntA"), acnt("acntB")] || ["acntA", "acntB"]
-      ["roleA"]          | [acnt("acntA", "roleA")]       || ["acntA"]
-      ["ROLEA"]          | [acnt("acntA", "rolea")]       || ["acntA"]
-      ["roleA"]          | [acnt("acntA", "roleB")]       || []
+    roles              | accounts                                                      || expectedAccounts
+    null               | []                                                            || []
+    []                 | []                                                            || []
+    [null]             | []                                                            || []
+    ["roleA"]          | [acnt("acntA")]                                               || ["acntA"]
+    ["roleA"]          | [acnt("acntB")]                                               || ["acntB"]
+    ["roleA", "roleB"] | [acnt("acntA"), acnt("acntB")]                                || ["acntA", "acntB"]
+    ["roleA"]          | [acnt("acntA", "roleA")]                                      || ["acntA"]
+    ["ROLEA"]          | [acnt("acntA", "rolea")]                                      || ["acntA"]
+    ["roleA"]          | [acnt("acntA", "roleB")]                                      || []
+    ["roleA"]          | [acnt("acntA", [:])]                                          || ["acntA"]
+    ["roleA"]          | [acnt("acntA", [WRITE: []])]                                  || []
+    ["roleA"]          | [acnt("acntA", [READ: ['roleA'], WRITE: null])]               || []
+    ["roleA"]          | [acnt("acntA", [READ: ['roleA']])]                            || []
+    ["roleA"]          | [acnt("acntA", [READ: ['roleA'], WRITE: ['roleA']])]          || ['acntA']
+    ["ROLEA"]          | [acnt("acntA", [READ: ['roleA'], WRITE: ['roleA']])]          || ['acntA']
+    ["roleA"]          | [acnt("acntA", [READ: ['roleA'], WRITE: ['ROLEA']])]          || ['acntA']
+    ["roleB"]          | [acnt("acntA", [READ: ['roleA'], WRITE: ['roleA']], 'roleB')] || []
   }
 
-  static ClouddriverService.Account acnt(String name, String... reqGroupMembership) {
-    new ClouddriverService.Account(name: name, requiredGroupMembership: reqGroupMembership)
+  static ClouddriverService.Account acnt(String name, Map<String, List<String>> permissions = null, String... reqGroupMembership) {
+    new ClouddriverService.Account(name: name, requiredGroupMembership: reqGroupMembership, permissions: permissions)
   }
 }


### PR DESCRIPTION
As part of migrating to fiat enabled, I want to support the production migration from requiredGroupMemberships based configuration in clouddriver to permissions based configuration - this change will support both but prefer the non-deprecated format

