### PR TITLE
fix(search): Ensure that keyword searches are >= 3 characters

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
@@ -41,6 +41,11 @@ class SearchController {
                    @RequestParam(value = "page", defaultValue = "1", required = false) int page,
                    @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp,
                    HttpServletRequest httpServletRequest) {
+    if (query?.size() < 3) {
+      // keyword searches must have a minimum of 3 characters
+      return []
+    }
+
     def filters = httpServletRequest.getParameterNames().findAll { String parameterName ->
       !["q", "type", "platform", "pageSize", "page"].contains(parameterName)
     }.collectEntries { String parameterName ->

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/SearchControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/SearchControllerSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.services.SearchService
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest;
+
+class SearchControllerSpec extends Specification {
+  def searchService = Mock(SearchService)
+  def httpServletRequest = Mock(HttpServletRequest)
+
+  @Subject
+  def controller = new SearchController(searchService: searchService)
+
+  @Unroll
+  def "should return empty results when `q` parameter is < 3 characters"() {
+    when:
+    controller.search(query, null, null, 100, 0, null, httpServletRequest).isEmpty()
+
+    then:
+    expectedSearches * searchService.search(query, null, null, null, 100, 0, [:]) >> { return [] }
+
+    where:
+    query || expectedSearches
+    null  || 0
+    ""    || 0
+    "a"   || 0
+    "ab"  || 0
+    "abc" || 1
+  }
+}


### PR DESCRIPTION
Otherwise it's likely the search will timeout after 60s for larger
environments.
