### PR TITLE
feat(credentials): provide proxy for ?expand on /credentials

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/AccountLookupService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/AccountLookupService.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 
 interface AccountLookupService {
-  List<ClouddriverService.Account> getAccounts()
+  List<AccountDetails> getAccounts()
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupService.groovy
@@ -21,6 +21,7 @@ import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
 import com.google.common.util.concurrent.UncheckedExecutionException
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -38,14 +39,14 @@ class DefaultProviderLookupService implements ProviderLookupService, AccountLook
 
   private final ClouddriverService clouddriverService
 
-  private final LoadingCache<String, List<ClouddriverService.Account>> accountsCache = CacheBuilder.newBuilder()
+  private final LoadingCache<String, List<AccountDetails>> accountsCache = CacheBuilder.newBuilder()
     .initialCapacity(1)
     .maximumSize(1)
     .refreshAfterWrite(2, TimeUnit.SECONDS)
-    .build(new CacheLoader<String, List<ClouddriverService.Account>>() {
+    .build(new CacheLoader<String, List<AccountDetails>>() {
         @Override
-        List<ClouddriverService.Account> load(String key) throws Exception {
-          return clouddriverService.accounts
+        List<AccountDetails> load(String key) throws Exception {
+          return clouddriverService.getAccountDetails()
         }
       })
 
@@ -64,7 +65,8 @@ class DefaultProviderLookupService implements ProviderLookupService, AccountLook
   }
 
   @Override
-  public List<ClouddriverService.Account> getAccounts() {
+  public List<AccountDetails> getAccounts() {
     return accountsCache.get(ACCOUNTS_KEY)
   }
+
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -16,7 +16,11 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import retrofit.client.Response
 import retrofit.http.GET
 import retrofit.http.Headers
@@ -30,13 +34,17 @@ interface ClouddriverService {
   @GET('/credentials')
   List<Account> getAccounts()
 
+  @GET('/credentials?expand=true')
+  List<AccountDetails> getAccountDetails()
+
   @GET('/credentials/{account}')
-  Map getAccount(@Path("account") String account)
+  AccountDetails getAccount(@Path("account") String account)
 
   @GET('/task/{taskDetailsId}')
   Map getTaskDetails(@Path("taskDetailsId") String taskDetailsId)
 
   @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonInclude(Include.NON_NULL)
   static class Account {
     String name
     String accountId
@@ -44,6 +52,27 @@ interface ClouddriverService {
     String providerVersion
     Collection<String> requiredGroupMembership = []
     Map<String, Collection<String>> permissions
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = false)
+  static class AccountDetails extends Account {
+    String accountType
+    String environment
+    Collection<Map> regions
+    Boolean challengeDestructiveActions
+    Boolean primaryAccount
+    String cloudProvider
+    private Map<String, Object> details = new HashMap<String, Object>()
+
+    @JsonAnyGetter
+    public Map<String,Object> details() {
+      return details
+    }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+      details.put(name, value)
+    }
   }
 
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -16,9 +16,12 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.security.SpinnakerUser
 import com.netflix.spinnaker.gate.services.CredentialsService
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.Account
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import com.netflix.spinnaker.security.User
 import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -37,19 +41,26 @@ class CredentialsController {
   @Autowired
   CredentialsService credentialsService
 
+  @Autowired
+  ObjectMapper objectMapper
+
   @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
   @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'READ')")
   @ApiOperation(value = "Retrieve a list of accounts")
   @RequestMapping(method = RequestMethod.GET)
-  List<ClouddriverService.Account> getAccounts(@SpinnakerUser User user) {
-    credentialsService.getAccounts(user?.roles ?: [])
+  List<Account> getAccounts(@SpinnakerUser User user, @RequestParam(value = "expand", required = false) boolean expand) {
+    List<AccountDetails> allAccounts = credentialsService.getAccounts(user?.roles ?: [])
+    if (expand) {
+      return allAccounts
+    }
+    return objectMapper.convertValue(allAccounts, new TypeReference<List<Account>>() {})
   }
 
   @PreAuthorize("hasPermission(#account, 'ACCOUNT', 'READ')")
   @ApiOperation(value = "Retrieve an account's details")
   @RequestMapping(value = '/{account:.+}', method = RequestMethod.GET)
-  Map getAccount(@PathVariable("account") String account,
-                 @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+  AccountDetails getAccount(@PathVariable("account") String account,
+                            @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     credentialsService.getAccount(account, sourceApp)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -17,10 +17,11 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.fiat.model.Authorization
-import com.netflix.spinnaker.fiat.model.resources.Permissions
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.Account
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -48,16 +49,12 @@ class CredentialsService {
     getAccounts(userRoles)*.name
   }
 
-  Collection<ClouddriverService.Account> getAccounts() {
-    getAccounts([])
-  }
-
   /**
    * Returns all account names that a user with the specified list of userRoles has access to.
    */
-  List<ClouddriverService.Account> getAccounts(Collection<String> userRoles) {
+  List<AccountDetails> getAccounts(Collection<String> userRoles) {
     HystrixFactory.newListCommand(GROUP, "getAccounts") {
-      return accountLookupService.accounts.findAll { ClouddriverService.Account account ->
+      return accountLookupService.getAccounts().findAll { AccountDetails account ->
         if (fiatConfig.enabled) {
           return true // Returned list is filtered later.
         }
@@ -83,7 +80,7 @@ class CredentialsService {
     } execute()
   }
 
-  Map getAccount(String account, String selectorKey) {
+  AccountDetails getAccount(String account, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getAccount") {
       clouddriverServiceSelector.select(selectorKey).getAccount(account)
     } execute()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/InstanceService.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.config.InsightConfiguration
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
@@ -38,10 +39,13 @@ class InstanceService {
   @Autowired
   ProviderLookupService providerLookupService
 
+  @Autowired
+  ObjectMapper objectMapper
+
   Map getForAccountAndRegion(String account, String region, String instanceId, String selectorKey) {
     HystrixFactory.newMapCommand(GROUP, "getInstancesForAccountAndRegion-${providerLookupService.providerForAccount(account)}") {
       def service = clouddriverServiceSelector.select(selectorKey)
-      def accountDetails = service.getAccount(account)
+      def accountDetails = objectMapper.convertValue(service.getAccount(account), Map)
       def instanceDetails = service.getInstanceDetails(account, region, instanceId)
       def instanceContext = instanceDetails.collectEntries {
         return it.value instanceof String ? [it.key, it.value] : [it.key, ""]

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
@@ -33,7 +33,7 @@ import spock.lang.Unroll
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 
-class CredentialsControllerTest extends Specification {
+class CredentialsControllerSpec extends Specification {
 
   MockMvc mockMvc
   ClouddriverService clouddriverService
@@ -67,7 +67,7 @@ class CredentialsControllerTest extends Specification {
   def "should accept account names with dots"() {
     given:
     1 * clouddriverServiceSelector.select(_) >> clouddriverService
-    1 * clouddriverService.getAccount(account) >> ["accountName": account]
+    1 * clouddriverService.getAccount(account) >> ["name": account]
 
     when:
     MockHttpServletResponse response = mockMvc.perform(get("/credentials/${account}")
@@ -75,7 +75,7 @@ class CredentialsControllerTest extends Specification {
 
     then:
     response.status == 200
-    response.contentAsString == "{\"accountName\":\"${expectedAccount}\"}"
+    response.contentAsString == "{\"name\":\"${expectedAccount}\",\"requiredGroupMembership\":[]}"
 
     where:
     account    || expectedAccount

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.gate.security.GateSystemTest
 import com.netflix.spinnaker.gate.security.YamlFileApplicationContextInitializer
 import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
@@ -118,9 +119,9 @@ class LdapAuthSpec extends Specification {
     AccountLookupService accountLookupService() {
       return new AccountLookupService() {
         @Override
-        List<ClouddriverService.Account> getAccounts() {
+        List<AccountDetails> getAccounts() {
           return [
-              new ClouddriverService.Account(name: "foo")
+              new AccountDetails(name: "foo")
           ]
         }
       }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -63,7 +63,7 @@ class CredentialsServiceSpec extends Specification {
     ["roleB"]          | [acnt("acntA", [READ: ['roleA'], WRITE: ['roleA']], 'roleB')] || []
   }
 
-  static ClouddriverService.Account acnt(String name, Map<String, List<String>> permissions = null, String... reqGroupMembership) {
-    new ClouddriverService.Account(name: name, requiredGroupMembership: reqGroupMembership, permissions: permissions)
+  static AccountDetails acnt(String name, Map<String, List<String>> permissions = null, String... reqGroupMembership) {
+    new AccountDetails(name: name, requiredGroupMembership: reqGroupMembership, permissions: permissions)
   }
 }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/InstanceServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/InstanceServiceSpec.groovy
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.config.InsightConfiguration
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
@@ -26,6 +27,7 @@ class InstanceServiceSpec extends Specification {
   void "should include relevant insight actions for instance"() {
     given:
     def service = new InstanceService(
+        objectMapper: new ObjectMapper(),
         clouddriverServiceSelector: Mock(ClouddriverServiceSelector) {
           1 * select(_) >> {
             Mock(ClouddriverService) {


### PR DESCRIPTION
This was a lot more work than I thought.

Companion PR to expose the `?expand` flag for Clouddriver's `/credentials` endpoint (https://github.com/spinnaker/clouddriver/pull/2326)

I made the details somewhat more strongly typed, but not convinced this buys us more than a regular `Map`.

