### PR TITLE
fix(credentials): collection<map> isnt compatible with app engine regions response

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -58,7 +58,6 @@ interface ClouddriverService {
   static class AccountDetails extends Account {
     String accountType
     String environment
-    Collection<Map> regions
     Boolean challengeDestructiveActions
     Boolean primaryAccount
     String cloudProvider


### PR DESCRIPTION
app engine returns a list of string for the regions field.