### PR TITLE
fix(gate/log): Append to log instead of overwrite

### DIFF
--- a/gate-web/etc/init/gate.conf
+++ b/gate-web/etc/init/gate.conf
@@ -9,4 +9,4 @@ expect fork
 
 stop on stopping spinnaker
 
-exec /opt/gate/bin/gate 2>&1 > /var/log/spinnaker/gate/gate.log &
+exec /opt/gate/bin/gate 2>&1 >> /var/log/spinnaker/gate/gate.log &


### PR DESCRIPTION
Changing to appending to the log file so logs will correctly rotate.  This prevents large amounts of null data at the start of a rotated log file.