### PR TITLE
fix(provider/gce): Allow short queries with explicit flag

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
@@ -39,15 +39,16 @@ class SearchController {
                    @RequestParam(value = "platform", required = false) String platform,
                    @RequestParam(value = "pageSize", defaultValue = "10000", required = false) int pageSize,
                    @RequestParam(value = "page", defaultValue = "1", required = false) int page,
+                   @RequestParam(value = "allowShortQuery", defaultValue = "false", required = false) boolean allowShortQuery,
                    @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp,
                    HttpServletRequest httpServletRequest) {
-    if (query?.size() < 3) {
+    if (!allowShortQuery && query?.size() < 3) {
       // keyword searches must have a minimum of 3 characters
       return []
     }
 
     def filters = httpServletRequest.getParameterNames().findAll { String parameterName ->
-      !["q", "type", "platform", "pageSize", "page"].contains(parameterName)
+      !["q", "type", "platform", "pageSize", "page", "allowShortQuery"].contains(parameterName)
     }.collectEntries { String parameterName ->
       [parameterName, httpServletRequest.getParameter(parameterName)]
     }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/SearchControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/SearchControllerSpec.groovy
@@ -31,19 +31,24 @@ class SearchControllerSpec extends Specification {
   def controller = new SearchController(searchService: searchService)
 
   @Unroll
-  def "should return empty results when `q` parameter is < 3 characters"() {
+  def "should return empty results when `q` parameter is < 3 characters and rejectShortQuery is true or omitted"() {
     when:
-    controller.search(query, null, null, 100, 0, null, httpServletRequest).isEmpty()
+    controller.search(query, null, null, 100, 0, allowShortQuery, null, httpServletRequest).isEmpty()
 
     then:
     expectedSearches * searchService.search(query, null, null, null, 100, 0, [:]) >> { return [] }
 
     where:
-    query || expectedSearches
-    null  || 0
-    ""    || 0
-    "a"   || 0
-    "ab"  || 0
-    "abc" || 1
+    query || allowShortQuery || expectedSearches
+    null  || false           || 0
+    ""    || false           || 0
+    "a"   || false           || 0
+    "ab"  || false           || 0
+    "abc" || false           || 1
+    null  || true            || 1
+    ""    || true            || 1
+    "a"   || true            || 1
+    "ab"  || true            || 1
+    "abc" || true            || 1
   }
 }


### PR DESCRIPTION
The search endpoint rejects short queries, returning an empty
result set.  There are a few cases where we need to pass a short
query; create an explicit flag to make this possible.