### PR TITLE
fix(credentials): Swap `LoadingCache` for `@Scheduled`

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SchedulingConfigurerConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SchedulingConfigurerConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulingConfigurerConfiguration implements SchedulingConfigurer {
+  @Override
+  public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.setPoolSize(10);
+    taskScheduler.initialize();
+
+    taskRegistrar.setTaskScheduler(taskScheduler);
+  }
+}


### PR DESCRIPTION
Given that accounts rarely change, it is reasonable to cache the
entire set of accounts from clouddriver for ~30s and refresh on a
background thread.

This handles a situation where `clouddriver` is momentarily unavailable.
