### PR TITLE
chore(core): Upgrade spinnaker-dependencies to 1.152.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.132.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.152.1'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -19,13 +19,14 @@ package com.netflix.spinnaker.gate.config
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.gate.interceptors.RequestIdInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestLoggingInterceptor
-import com.netflix.spinnaker.gate.ratelimit.RateLimiter
 import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider
+import com.netflix.spinnaker.gate.ratelimit.RateLimiter
 import com.netflix.spinnaker.gate.ratelimit.RateLimitingInterceptor
 import com.netflix.spinnaker.gate.retrofit.UpstreamBadRequest
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
@@ -37,6 +38,7 @@ import org.springframework.web.filter.ShallowEtagHeaderFilter
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector
 import retrofit.RetrofitError
 
 import javax.servlet.Filter
@@ -80,6 +82,11 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
     if (rateLimiter != null) {
       registry.addInterceptor(new RateLimitingInterceptor(rateLimiter, spectatorRegistry, rateLimiterPrincipalProvider))
     }
+  }
+
+  @Bean
+  HandlerMappingIntrospector mvcHandlerMappingIntrospector(ApplicationContext context) {
+    return new HandlerMappingIntrospector(context)
   }
 
   @Bean


### PR DESCRIPTION
Also a change to our web configuration. The upgraded spring version that comes with this spinnaker-dependencies bump added more validation (https://github.com/spring-projects/spring-security/issues/4995) and is wired up correctly when using more of the auto configuration features of Spring that we don't use. I'm not eager to start using more auto config, so this just adds the missing bean.