### PR TITLE
feat(core): ServiceSelector orca queue sharding

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/Service.groovy
@@ -23,10 +23,35 @@ class Service {
   boolean enabled = true
   String vipAddress
   String baseUrl
-
+  MultiBaseUrl shards
+  int priority = 1
   Map<String, Object> config = [:]
 
   void setBaseUrl(String baseUrl) {
     this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl
+  }
+
+  static class BaseUrl {
+    String vipAddress
+    String baseUrl
+    int priority = 1
+    Map<String, Object> config = [:]
+  }
+
+  static class MultiBaseUrl {
+    String baseUrl
+    List<BaseUrl> baseUrls
+  }
+
+  List<BaseUrl> getBaseUrls() {
+    if (shards?.baseUrl) {
+      return [
+        new BaseUrl(baseUrl: shards.baseUrl)
+      ]
+    } else if (shards?.baseUrls) {
+      return shards.baseUrls
+    }
+
+    return [new BaseUrl(baseUrl: baseUrl)]
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestIdInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestLoggingInterceptor
 import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider
@@ -82,6 +83,8 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
     if (rateLimiter != null) {
       registry.addInterceptor(new RateLimitingInterceptor(rateLimiter, spectatorRegistry, rateLimiterPrincipalProvider))
     }
+
+    registry.addInterceptor(new RequestContextInterceptor())
   }
 
   @Bean

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ExecutionsController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ExecutionsController.java
@@ -16,7 +16,9 @@
 package com.netflix.spinnaker.gate.controllers;
 
 import java.util.List;
-import com.netflix.spinnaker.gate.services.internal.OrcaService;
+
+import com.netflix.spinnaker.gate.security.RequestContext;
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,18 +30,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ExecutionsController {
 
-  private OrcaService orcaService;
+  private OrcaServiceSelector orcaServiceSelector;
 
   @Autowired
-  public ExecutionsController(OrcaService orcaService) {
-    this.orcaService = orcaService;
+  public ExecutionsController(OrcaServiceSelector orcaServiceSelector) {
+    this.orcaServiceSelector = orcaServiceSelector;
   }
 
   @ApiOperation(value = "Retrieve a list of the most recent pipeline executions for the provided `pipelineConfigIds` that match the provided `statuses` query parameter")
   @RequestMapping(method = RequestMethod.GET)
   List getLatestExecutionsByConfigIds(@RequestParam(value = "pipelineConfigIds") String pipelineConfigIds,
-                                    @RequestParam(value = "limit", required = false) Integer limit,
-                                    @RequestParam(value = "statuses", required = false) String statuses) {
-    return orcaService.getLatestExecutionsByConfigIds(pipelineConfigIds, limit, statuses);
+                                      @RequestParam(value = "limit", required = false) Integer limit,
+                                      @RequestParam(value = "statuses", required = false) String statuses) {
+    return orcaServiceSelector.withContext(RequestContext.get()).getLatestExecutionsByConfigIds(pipelineConfigIds, limit, statuses);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineConfigController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineConfigController.groovy
@@ -17,9 +17,10 @@
 
 package com.netflix.spinnaker.gate.controllers
 
+import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.Front50Service
-import com.netflix.spinnaker.gate.services.internal.OrcaService
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -35,13 +36,13 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/pipelineConfigs")
 class PipelineConfigController {
-  private static final String HYSTRIX_GROUP = "pipelineConfigs";
+  private static final String HYSTRIX_GROUP = "pipelineConfigs"
 
   @Autowired
   Front50Service front50Service
 
   @Autowired
-  OrcaService orcaService
+  OrcaServiceSelector orcaServiceSelector
 
   @RequestMapping(method = RequestMethod.GET)
   Collection<Map> getAllPipelineConfigs() {
@@ -66,7 +67,7 @@ class PipelineConfigController {
     if (pipelineConfig == null) {
       throw new NotFoundException("Pipeline config '${pipelineConfigId}' could not be found")
     }
-    String template = orcaService.convertToPipelineTemplate(pipelineConfig).body.in().text
+    String template = orcaServiceSelector.withContext(RequestContext.get()).convertToPipelineTemplate(pipelineConfig).body.in().text
     return template
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.PipelineService
 
 import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes
@@ -188,6 +189,9 @@ class PipelineController {
   @ApiOperation(value = "Initiate a pipeline execution")
   @RequestMapping(value = '/start', method = RequestMethod.POST)
   ResponseEntity start(@RequestBody Map map) {
+    if (map.containsKey("application")) {
+      RequestContext.setApplication(map.get("application").toString())
+    }
     String authenticatedUser = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
     maybePropagateTemplatedPipelineErrors(map, {
       pipelineService.startPipeline(map, authenticatedUser)
@@ -203,6 +207,7 @@ class PipelineController {
     trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
     trigger.notifications = trigger.notifications ?: [];
 
+    RequestContext.setApplication(application)
     try {
       def body = pipelineService.trigger(application, pipelineNameOrId, trigger)
       new ResponseEntity(body, HttpStatus.ACCEPTED)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.interceptors;
+
+import com.netflix.spinnaker.gate.security.RequestContext;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RequestContextInterceptor extends HandlerInterceptorAdapter {
+
+  private static Pattern applicationPattern = Pattern.compile("/applications/([^/]+)");
+  private static Pattern orchestrationMatch = Pattern.compile("/(?:tasks$|tasks/)");
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    RequestContext.set(
+      new RequestContext(
+        AuthenticatedRequest.getSpinnakerUserOrigin().orElse(null),
+        AuthenticatedRequest.getSpinnakerUser().orElse(null)
+      )
+    );
+
+    Matcher m = applicationPattern.matcher(request.getRequestURI());
+    if (m.find()) {
+      RequestContext.setApplication(m.group(1));
+    }
+
+    if (orchestrationMatch.matcher(request.getRequestURI()).matches()) {
+      RequestContext.setExecutionType("orchestration");
+    }
+
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+    throws Exception {
+    RequestContext.clear();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/RequestContext.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/RequestContext.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security;
+
+public class RequestContext {
+  private static final ThreadLocal<RequestContext> threadLocal = new ThreadLocal<>();
+
+  private String application;
+  private String authenticatedUser;
+  private String executionType;
+  private String executionId;
+  private String origin;
+
+  public RequestContext(String origin, String authenticatedUser) {
+    this.origin = origin;
+     this.authenticatedUser = authenticatedUser != null ? authenticatedUser : "anonymous";
+  }
+
+  public static void set(RequestContext requestContext) {
+    threadLocal.set(requestContext);
+  }
+
+  public static void setApplication(String application) {
+    threadLocal.get().application = application;
+  }
+
+  public static void setExecutionType(String executionType) {
+    threadLocal.get().executionType = executionType;
+  }
+
+  public static void setExecutionId(String executionId) {
+    threadLocal.get().executionId = executionId;
+  }
+
+  public static RequestContext get() { return threadLocal.get(); }
+
+  public static void clear() { threadLocal.remove(); }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public String getAuthenticatedUser() {
+    return authenticatedUser;
+  }
+
+  public String getExecutionType() {
+    return executionType;
+  }
+
+  public String getExecutionId() {
+    return executionId;
+  }
+
+  public String getOrigin() { return origin; }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ExecutionHistoryService.groovy
@@ -17,11 +17,12 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.netflix.spinnaker.gate.security.RequestContext
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import com.google.common.base.Preconditions
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
-import com.netflix.spinnaker.gate.services.internal.OrcaService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -30,21 +31,23 @@ import org.springframework.stereotype.Component
 @Slf4j
 class ExecutionHistoryService {
   @Autowired
-  OrcaService orcaService
+  OrcaServiceSelector orcaServiceSelector
 
   List getTasks(String app, Integer limit, String statuses) {
     Preconditions.checkNotNull(app)
 
+    RequestContext requestContext = RequestContext.get()
     def command = HystrixFactory.newListCommand("taskExecutionHistory", "getTasksForApp") {
-      orcaService.getTasks(app, limit, statuses)
+      orcaServiceSelector.withContext(requestContext).getTasks(app, limit, statuses)
     }
     return command.execute()
   }
 
   List getPipelines(String app, Integer limit, String statuses, Boolean expand) {
     Preconditions.checkNotNull(app)
+    RequestContext requestContext = RequestContext.get()
     def command = HystrixFactory.newListCommand("pipelineExecutionHistory", "getPipelinesForApp-$app") {
-      orcaService.getPipelines(app, limit, statuses, expand)
+      orcaServiceSelector.withContext(requestContext).getPipelines(app, limit, statuses, expand)
     }
     return command.execute()
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineTemplateService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineTemplateService.groovy
@@ -15,8 +15,9 @@
  */
 package com.netflix.spinnaker.gate.services
 
+import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.internal.Front50Service
-import com.netflix.spinnaker.gate.services.internal.OrcaService
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,16 +28,16 @@ import org.springframework.stereotype.Component
 @Slf4j
 class PipelineTemplateService {
 
-  private static final String GROUP = "pipelineTemplates";
+  private static final String GROUP = "pipelineTemplates"
 
-  private final Front50Service front50Service;
+  private final Front50Service front50Service
 
-  private final OrcaService orcaService;
+  private final OrcaServiceSelector orcaServiceSelector
 
   @Autowired
-  public PipelineTemplateService(Front50Service front50Service, OrcaService orcaService) {
+  public PipelineTemplateService(Front50Service front50Service, OrcaServiceSelector orcaServiceSelector) {
     this.front50Service = front50Service;
-    this.orcaService = orcaService;
+    this.orcaServiceSelector = orcaServiceSelector;
   }
 
   Map get(String id) {
@@ -48,6 +49,6 @@ class PipelineTemplateService {
   }
 
   Map resolve(String source, String executionId, String pipelineConfigId) {
-    orcaService.resolvePipelineTemplate(source, executionId, pipelineConfigId)
+    orcaServiceSelector.withContext(RequestContext.get()).resolvePipelineTemplate(source, executionId, pipelineConfigId)
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ProjectService.groovy
@@ -17,10 +17,11 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
-import com.netflix.spinnaker.gate.services.internal.OrcaService
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,7 +37,7 @@ class ProjectService {
   Front50Service front50Service
 
   @Autowired
-  OrcaService orcaService
+  OrcaServiceSelector orcaServiceSelector
 
   @Autowired
   ClouddriverServiceSelector clouddriverServiceSelector
@@ -54,8 +55,9 @@ class ProjectService {
   }
 
   List<Map> getAllPipelines(String projectId, int limit, String statuses) {
+    RequestContext requestContext = RequestContext.get()
     HystrixFactory.newListCommand(GROUP, "getAllPipelines") {
-      return orcaService.getPipelinesForProject(projectId, limit, statuses)
+      return orcaServiceSelector.withContext(requestContext).getPipelinesForProject(projectId, limit, statuses)
     } execute()
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SecurityGroupService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/SecurityGroupService.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
-import com.netflix.spinnaker.gate.services.internal.OrcaService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -30,9 +29,6 @@ class SecurityGroupService {
 
   @Autowired
   ClouddriverServiceSelector clouddriverServiceSelector
-
-  @Autowired
-  OrcaService orcaService
 
   /**
    * Keyed by account

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/WebhookService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/WebhookService.groovy
@@ -16,8 +16,9 @@
 
 package com.netflix.spinnaker.gate.services
 
+import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.internal.EchoService
-import com.netflix.spinnaker.gate.services.internal.OrcaService
+import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -28,7 +29,7 @@ class WebhookService {
   EchoService echoService
 
   @Autowired
-  OrcaService orcaService
+  OrcaServiceSelector orcaServiceSelector
 
   void webhooks(String type, String source, Map event) {
     echoService.webhooks(type, source, event)
@@ -39,6 +40,6 @@ class WebhookService {
   }
 
   List preconfiguredWebhooks() {
-    return orcaService.preconfiguredWebhooks()
+    return orcaServiceSelector.withContext(RequestContext.get()).preconfiguredWebhooks()
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaServiceSelector.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaServiceSelector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services.internal;
+
+import com.netflix.spinnaker.gate.security.RequestContext;
+import com.netflix.spinnaker.kork.web.selector.SelectableService;
+public class OrcaServiceSelector {
+
+  private final SelectableService selectableService;
+
+  public OrcaServiceSelector(SelectableService selectableService) {
+    this.selectableService = selectableService;
+  }
+
+  public OrcaService withContext(RequestContext context) {
+    SelectableService.Criteria criteria = new SelectableService.Criteria(null, null, null, null, null);
+
+    if (context != null) {
+      criteria = new SelectableService.Criteria(
+        context.getApplication(),
+        context.getAuthenticatedUser(),
+        context.getExecutionType(),
+        context.getExecutionId(),
+        context.getOrigin()
+      );
+    }
+
+    return (OrcaService) selectableService.getService(criteria);
+  }
+}


### PR DESCRIPTION
Applies `ServiceSelector` from kork to gate's `OrcaService`, enabling routing requests across multiple orca clusters by any [supported selector class](https://github.com/spinnaker/kork/tree/master/kork-web/src/main/java/com/netflix/spinnaker/kork/web/selector). This implementation targets sharding orca's queue (such as by varying `keiko.queue.redis.queueName` per orca cluster) in order to partition compute resources by i.e. spinnaker application or request origin, but assumes a common execution repository across all orca clusters.

Example configuration:

```
services:
  orca:
    shards:
      baseUrls:
        - baseUrl: https://localhost:8083
        - baseUrl: https://localhost:9083
          priority: 10
          config:
            selectorClass: com.netflix.spinnaker.kork.web.selector.ByApplicationServiceSelector
            applicationPattern: spintest
```
In this case, requests related to running pipelines or orchestrations for the application "spintest" route to `https://localhost:9083` while gate will send all other orca requests to `https://localhost:8083`.