### PR TITLE
feat(cloud-iap): Add new security config to integrate with Cloud IAP.

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -50,6 +50,11 @@ dependencies {
     exclude group: 'org.springframework.security'
   }
 
+  // IAP
+  compile('com.nimbusds:nimbus-jose-jwt:5.2')
+
+  compileOnly spinnaker.dependency("lombok")
+
   testCompile "com.squareup.okhttp:mockwebserver:${spinnaker.version('okHttp')}"
   testCompile apachedsDependencies
   testCompile spinnaker.dependency("korkJedisTest")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilter.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.iap;
+
+import com.google.common.base.Preconditions;
+import com.netflix.spinnaker.fiat.model.resources.ServiceAccount;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.security.User;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.io.IOException;
+import java.net.URL;
+import java.security.interfaces.ECPublicKey;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import retrofit.RetrofitError;
+
+/***
+ * This filter verifies the request header from Cloud IAP containing a JWT token, after the user
+ * has been authenticated and authorized by IAP via Google OAuth2.0 and IAP's authorization service.
+ * The user email from the payload used to create the Spinnaker user.
+ */
+public class IAPAuthenticationFilter implements Filter {
+
+  private IAPConfig.IAPSecurityConfigProperties configProperties;
+
+  private PermissionService permissionService;
+
+  private Front50Service front50Service;
+
+  private static final String signatureAttribute = "JWTSignature";
+
+  private final Map<String, JWK> keyCache = new HashMap<>();
+
+  private Logger logger = LoggerFactory.getLogger(IAPAuthenticationFilter.class);
+
+  public IAPAuthenticationFilter(
+    IAPConfig.IAPSecurityConfigProperties configProperties,
+    PermissionService permissionService,
+    Front50Service front50Service) {
+    this.configProperties = configProperties;
+    this.permissionService = permissionService;
+    this.front50Service = front50Service;
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse res = (HttpServletResponse) response;
+    HttpSession session = req.getSession();
+
+    try {
+      String token = req.getHeader(configProperties.jwtHeader);
+      Preconditions.checkNotNull(token);
+
+      SignedJWT jwt = SignedJWT.parse(token);
+
+      Base64URL signatureInSession = (Base64URL) session.getAttribute(signatureAttribute);
+
+      if (signatureInSession != null && signatureInSession.equals(jwt.getSignature())) {
+        // Signature matches in previous request signatures in current session, skip validation.
+        chain.doFilter(req, res);
+        return;
+      }
+
+      User verifiedUser = verifyJWTAndGetUser(jwt);
+
+      PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
+        verifiedUser,
+        null /* credentials */,
+        // Need to set authorities list even if empty to get a valid authentication.
+        verifiedUser.getAuthorities()
+      );
+
+      // Service accounts are already logged in.
+      if (!isServiceAccount(verifiedUser.getEmail())) {
+        permissionService.login(verifiedUser.getEmail());
+      }
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      // Save the signature to skip validation for subsequent requests with same token.
+      session.setAttribute(signatureAttribute, jwt.getSignature());
+
+    } catch (Exception e) {
+      logger.error("Could not verify JWT Token", e);
+      res.sendError(HttpServletResponse.SC_FORBIDDEN, "Could not verify JWT Token");
+      session.invalidate();
+      return;
+    }
+
+    chain.doFilter(req, res);
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+  private boolean isServiceAccount(String email) {
+    if (email == null || !permissionService.isEnabled()) {
+      return false;
+    }
+    try {
+      List<ServiceAccount> serviceAccounts = front50Service.getServiceAccounts();
+      for (ServiceAccount serviceAccount : serviceAccounts) {
+
+        if (email.equalsIgnoreCase(serviceAccount.getName())) {
+          return true;
+        }
+      }
+      return false;
+    } catch (RetrofitError re) {
+      logger.warn("Could not get list of service accounts.", re);
+    }
+    return false;
+  }
+
+  private User verifyJWTAndGetUser(SignedJWT jwt) throws Exception {
+    JWSHeader jwsHeader = jwt.getHeader();
+
+    Preconditions.checkNotNull(jwsHeader.getAlgorithm());
+    Preconditions.checkNotNull(jwsHeader.getKeyID());
+
+    JWTClaimsSet claims = jwt.getJWTClaimsSet();
+
+    Preconditions.checkArgument(claims.getAudience().contains(configProperties.audience));
+    Preconditions.checkArgument(claims.getIssuer().contains(configProperties.issuerId));
+
+    Date currentTime = new Date();
+    Preconditions.checkArgument(claims.getIssueTime().before(currentTime));
+    Preconditions.checkArgument(claims.getExpirationTime().after(currentTime));
+
+    Preconditions.checkNotNull(claims.getSubject());
+    String email = (String) claims.getClaim("email");
+    Preconditions.checkNotNull(email);
+
+    ECPublicKey publicKey = getKey(jwsHeader.getKeyID(), jwsHeader.getAlgorithm().getName());
+    Preconditions.checkNotNull(publicKey);
+
+    JWSVerifier jwsVerifier = new ECDSAVerifier(publicKey);
+    Preconditions.checkState(jwt.verify(jwsVerifier));
+
+    User verifiedUser = new User();
+    verifiedUser.setEmail(email);
+
+    return verifiedUser;
+  }
+
+  private ECPublicKey getKey(String kid, String alg) throws Exception {
+    JWK jwk = keyCache.get(kid);
+    if (jwk == null) {
+      // update cache loading jwk public key data from url
+      JWKSet jwkSet = JWKSet.load(new URL(configProperties.iapVerifyKeyUrl));
+      for (JWK key : jwkSet.getKeys()) {
+        keyCache.put(key.getKeyID(), key);
+      }
+      jwk = keyCache.get(kid);
+    }
+    // confirm that algorithm matches
+    if (jwk != null && jwk.getAlgorithm() != null && jwk.getAlgorithm().getName().equals(alg)) {
+      return ECKey.parse(jwk.toJSONString()).toECPublicKey();
+    }
+    return null;
+  }
+
+  /**
+   * Clears the public key cache every 5 hours. This is cleared periodically to capture potential
+   * IAP public key changes.
+   */
+  @Scheduled(fixedDelay = 18000000L)
+  void clearKeyCache() {
+    logger.debug("Clearing IAP public key cache.");
+    keyCache.clear();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.iap;
+
+import com.google.common.base.Preconditions;
+import com.netflix.spinnaker.gate.security.AuthConfig;
+import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig;
+import com.netflix.spinnaker.gate.security.iap.IAPConfig.IAPSecurityConfigProperties;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+/**
+ * This Web Security configuration supports the Google Cloud Identity-Aware Proxy authentication
+ * model.
+ */
+@Configuration
+@SpinnakerAuthConfig
+@EnableWebSecurity
+@ConditionalOnExpression("${security.iap.enabled:false}")
+@EnableConfigurationProperties(IAPSecurityConfigProperties.class)
+public class IAPConfig extends WebSecurityConfigurerAdapter {
+
+  @Autowired
+  AuthConfig authConfig;
+
+  @Autowired
+  PermissionService permissionService;
+
+  @Autowired
+  Front50Service front50Service;
+
+  @Autowired
+  IAPSecurityConfigProperties configProperties;
+
+  @ConfigurationProperties("security.iap")
+  @Data
+  public static class IAPSecurityConfigProperties {
+
+    String jwtHeader = "x-goog-iap-jwt-assertion";
+    String issuerId = "https://cloud.google.com/iap";
+    String audience;
+    String iapVerifyKeyUrl = "https://www.gstatic.com/iap/verify/public_key-jwk";
+  }
+
+  private final Logger logger = LoggerFactory.getLogger(IAPConfig.class);
+
+  @Override
+  public void configure(HttpSecurity http) throws Exception {
+    logger.info("IAP JWT token verification is enabled.");
+
+    Preconditions.checkNotNull(configProperties.getAudience(), "Please set the "
+      + "Audience field. You can retrieve this field from the IAP console: "
+      + "https://cloud.google.com/iap/docs/signed-headers-howto#verify_the_id_token_header.");
+
+    authConfig.configure(http);
+
+    IAPAuthenticationFilter authFilter = new IAPAuthenticationFilter(
+      configProperties, permissionService, front50Service);
+
+    http.addFilterBefore(authFilter, BasicAuthenticationFilter.class);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -126,5 +126,5 @@ interface Front50Service {
   List<Map> getSnapshotHistory(@Path("id") String id, @Query("limit") int limit)
 
   @GET('/serviceAccounts')
-  List<Map> getServiceAccounts()
+  List<ServiceAccount> getServiceAccounts()
 }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilterSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilterSpec.groovy
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.security.iap
+
+import com.google.common.io.BaseEncoding
+import com.netflix.spinnaker.gate.services.PermissionService
+import com.netflix.spinnaker.gate.services.internal.Front50Service
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import org.slf4j.Logger
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletResponse
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+
+class IAPAuthenticationFilterSpec extends Specification {
+
+  /**
+   * The security context Authentication is set in the filter. If this is not cleared between tests,
+   * it could affect other tests in run in the same thread.
+   */
+  def cleanup() {
+    SecurityContextHolder.clearContext()
+  }
+
+  def "should verify JWT Token and login to fiat using the email from payload"() {
+
+    def request = new MockHttpServletRequest()
+    def response = new MockHttpServletResponse()
+    def chain = Mock(FilterChain)
+    def permissionService = Mock(PermissionService)
+    def front50Service = Mock(Front50Service)
+    def config = new IAPConfig.IAPSecurityConfigProperties()
+    config.audience = "test_audience"
+
+    // Create key to sign JWT Token
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("EC")
+    gen.initialize(Curve.P_256.toECParameterSpec())
+    KeyPair keyPair = gen.generateKeyPair()
+    def publicKey = BaseEncoding.base64().encode(keyPair.public.encoded)
+
+    // Create the JWT Token
+    def header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(publicKey).build()
+    def claims = createValidClaimsBuilder().build()
+    def jwt = new SignedJWT(header, claims)
+
+    jwt.sign(new ECDSASigner((ECPrivateKey) keyPair.private))
+
+    request.addHeader(config.jwtHeader, jwt.serialize())
+
+    @Subject IAPAuthenticationFilter filter = new IAPAuthenticationFilter(
+      config, permissionService, front50Service)
+
+    // Add public key to key cache
+    ECKey key = new ECKey.Builder(Curve.P_256, (ECPublicKey) keyPair.public)
+      .algorithm(JWSAlgorithm.ES256)
+      .build()
+    filter.keyCache.put(publicKey, key)
+
+    when:
+    filter.doFilter(request, response, chain)
+
+    then:
+    1 * chain.doFilter(request, response)
+    1 * permissionService.login("test-email")
+  }
+
+  def "subsequent requests in same session with same valid signature should skip validation"() {
+
+    def request = new MockHttpServletRequest()
+    def response = new MockHttpServletResponse()
+    def chain = Mock(FilterChain)
+    def permissionService = Mock(PermissionService)
+    def front50Service = Mock(Front50Service)
+    def config = new IAPConfig.IAPSecurityConfigProperties()
+    config.audience = "test_audience"
+
+    // Create key to sign JWT Token
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("EC")
+    gen.initialize(Curve.P_256.toECParameterSpec())
+    KeyPair keyPair = gen.generateKeyPair()
+    def publicKey = BaseEncoding.base64().encode(keyPair.public.encoded)
+
+    // Create the JWT Token
+    def header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(publicKey).build()
+    def claims = createValidClaimsBuilder().build()
+    def jwt = new SignedJWT(header, claims)
+
+    jwt.sign(new ECDSASigner((ECPrivateKey) keyPair.private))
+
+    request.addHeader(config.jwtHeader, jwt.serialize())
+
+    @Subject IAPAuthenticationFilter filter = new IAPAuthenticationFilter(
+      config, permissionService, front50Service)
+
+    // Add public key to key cache
+    ECKey key = new ECKey.Builder(Curve.P_256, (ECPublicKey) keyPair.public)
+      .algorithm(JWSAlgorithm.ES256)
+      .build()
+    filter.keyCache.put(publicKey, key)
+
+    when:
+    filter.doFilter(request, response, chain)
+
+    then:
+    1 * chain.doFilter(request, response)
+    1 * permissionService.isEnabled()
+    1 * permissionService.login("test-email")
+    request.getSession(false)
+      .getAttribute(IAPAuthenticationFilter.signatureAttribute) == jwt.signature
+
+    when:
+    filter.doFilter(request, response, chain)
+
+    then:
+    1 * chain.doFilter(request, response)
+    0 * permissionService.isEnabled()
+    0 * permissionService.login("test-email")
+  }
+
+  @Unroll
+  def "requests with invalid JWT payloads should exit with Forbidden status code"() {
+
+    def request = new MockHttpServletRequest()
+    def response = new MockHttpServletResponse()
+    def chain = Mock(FilterChain)
+    def permissionService = Mock(PermissionService)
+    def front50Service = Mock(Front50Service)
+    def config = new IAPConfig.IAPSecurityConfigProperties()
+    config.audience = "test_audience"
+
+    // Create key to sign JWT Token
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("EC")
+    gen.initialize(Curve.P_256.toECParameterSpec())
+    KeyPair keyPair = gen.generateKeyPair()
+    def publicKey = BaseEncoding.base64().encode(keyPair.public.encoded)
+    def header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(publicKey).build()
+
+    @Subject IAPAuthenticationFilter filter = new IAPAuthenticationFilter(
+      config, permissionService, front50Service)
+    filter.logger = Mock(Logger)
+
+    // Add public key to key cache
+    ECKey key = new ECKey.Builder(Curve.P_256, (ECPublicKey) keyPair.public)
+      .algorithm(JWSAlgorithm.ES256)
+      .build()
+    filter.keyCache.put(publicKey, key)
+
+    when:
+    // Create valid JWT Token header and claims
+    def claims = createValidClaimsBuilder().build()
+
+    def jwt = new SignedJWT(header, claims)
+    jwt.sign(new ECDSASigner((ECPrivateKey) keyPair.private))
+    request.addHeader(config.jwtHeader, jwt.serialize())
+
+    filter.doFilter(request, response, chain)
+
+    then:
+    1 * chain.doFilter(request, response)
+    1 * permissionService.login("test-email")
+
+    when:
+    request = new MockHttpServletRequest()
+    response = new MockHttpServletResponse()
+
+    def invalidJwt = new SignedJWT(header, invalidClaims)
+    invalidJwt.sign(new ECDSASigner((ECPrivateKey) keyPair.private))
+    request.addHeader(config.jwtHeader, invalidJwt.serialize())
+
+    filter.doFilter(request, response, chain)
+
+    then:
+    0 * chain.doFilter(request, response)
+    response.status == HttpServletResponse.SC_FORBIDDEN
+
+    where:
+    invalidClaims                                                       | _
+    createValidClaimsBuilder().issueTime(new Date() + 100).build()      | _
+    createValidClaimsBuilder().expirationTime(new Date() - 100).build() | _
+    createValidClaimsBuilder().audience(null).build()                   | _
+    createValidClaimsBuilder().issuer(null).build()                     | _
+    createValidClaimsBuilder().subject(null).build()                    | _
+    createValidClaimsBuilder().claim("email", null).build()             | _
+  }
+
+  JWTClaimsSet.Builder createValidClaimsBuilder() {
+    return new JWTClaimsSet.Builder()
+      .issueTime(new Date() - 1)
+      .expirationTime(new Date() + 1)
+      .audience("test_audience")
+      .issuer("https://cloud.google.com/iap")
+      .subject("subject")
+      .claim("email", "test-email")
+  }
+}


### PR DESCRIPTION
Cloud Identity-Aware Proxy provides authentication for GCP backend services via Google OAuth2.0 and IAM policies. It also adds JSON Web Tokens in the incoming request headers for securing the application. This PR adds a new security module to validate the request using the token and authenticate the user, via a `PreAuthenticatedAuthenticationToken` and the user email from the payload. It handles the sign-in to Fiat, and caches the token signature in the session so that subsequent requests with same signature can skip validation.

https://cloud.google.com/iap/docs/signed-headers-howto#verify_the_id_token_header

Example configuration:
```
security:
  iap:
    enabled: true
    audience: /projects/{project_number}/backendServices/{service_id}
```
