### PR TITLE
feat(web): Support for proxying generic URLs through `gate`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   ext {
     springBootVersion = "1.5.7.RELEASE"
+    kotlinVersion = "1.2.41"
   }
   repositories {
     jcenter()
@@ -10,6 +11,7 @@ buildscript {
   dependencies {
     classpath 'com.netflix.spinnaker.gradle:spinnaker-gradle-project:4.0.0'
     classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+    classpath "com.netflix.nebula:nebula-kotlin-plugin:${kotlinVersion}"
   }
 }
 

--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -1,0 +1,7 @@
+apply from: "$rootDir/gradle/kotlin.gradle"
+
+dependencies {
+  compile project(":gate-core")
+
+  compile spinnaker.dependency("korkExceptions")
+}

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/config/ProxyConfiguration.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/config/ProxyConfiguration.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config
+
+import com.squareup.okhttp.OkHttpClient
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import java.io.File
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.annotation.PostConstruct
+import javax.net.ssl.*
+
+@Configuration
+@EnableConfigurationProperties(
+  ProxyConfigurationProperties::class
+)
+open class ProxyConfiguration
+
+@ConfigurationProperties
+data class ProxyConfigurationProperties(var proxies: List<ProxyConfig> = mutableListOf()) {
+
+  companion object {
+    val logger = LoggerFactory.getLogger(ProxyConfig::class.java)
+  }
+
+  @PostConstruct
+  fun postConstruct() {
+    for (proxy in proxies) {
+      try {
+        // initialize the `okHttpClient` for each proxy
+        proxy.init()
+      } catch (e: Exception) {
+        logger.error("Failed to initialize proxy (id: ${proxy.id})", e)
+      }
+    }
+  }
+}
+
+data class ProxyConfig(var id: String? = null,
+                       var uri: String? = null,
+                       var skipHostnameVerification: Boolean = false,
+                       var keyStore: String? = null,
+                       var keyStoreType: String = KeyStore.getDefaultType(),
+                       var keyStorePassword: String? = null,
+                       var keyStorePasswordFile: String? = null,
+                       var trustStore: String? = null,
+                       var trustStoreType: String = KeyStore.getDefaultType(),
+                       var trustStorePassword: String? = null,
+                       var trustStorePasswordFile: String? = null,
+                       var methods: List<String> = mutableListOf(),
+                       var connectTimeoutMs: Long = 30_000,
+                       var readTimeoutMs: Long = 59_000,
+                       var writeTimeoutMs: Long = 30_000) {
+
+  companion object {
+    val logger = LoggerFactory.getLogger(ProxyConfig::class.java)
+  }
+
+  var okHttpClient = OkHttpClient()
+
+
+  fun init() {
+    okHttpClient.setConnectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+    okHttpClient.setReadTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
+    okHttpClient.setWriteTimeout(writeTimeoutMs, TimeUnit.MILLISECONDS)
+
+    if (skipHostnameVerification) {
+      this.okHttpClient = okHttpClient.setHostnameVerifier({ hostname, _ ->
+        logger.warn("Skipping hostname verification on request to $hostname (id: $id)")
+        true
+      })
+    }
+
+    if (!keyStore.isNullOrEmpty()) {
+      val keyStorePassword = if (!keyStorePassword.isNullOrEmpty()) {
+        keyStorePassword
+      } else if (!keyStorePasswordFile.isNullOrEmpty()) {
+        File(keyStorePasswordFile).readText()
+      } else {
+        throw IllegalStateException("No `keyStorePassword` or `keyStorePasswordFile` specified (id: $id)")
+      }
+
+      val kStore = KeyStore.getInstance(keyStoreType)
+
+      File(this.keyStore).inputStream().use {
+        kStore.load(it, keyStorePassword!!.toCharArray())
+      }
+
+      val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
+      kmf.init(kStore, keyStorePassword!!.toCharArray());
+
+      val keyManagers = kmf.keyManagers
+      var trustManagers : Array<TrustManager>? = null
+
+      if (!trustStore.isNullOrEmpty()) {
+        if (trustStore.equals("*")) {
+          trustManagers = arrayOf(TrustAllTrustManager())
+        } else {
+          val trustStorePassword = if (!trustStorePassword.isNullOrEmpty()) {
+            trustStorePassword
+          } else if (!trustStorePasswordFile.isNullOrEmpty()) {
+            File(trustStorePasswordFile).readText()
+          } else {
+            throw IllegalStateException("No `trustStorePassword` or `trustStorePasswordFile` specified (id: $id)")
+          }
+
+          val tStore = KeyStore.getInstance(trustStoreType)
+          File(this.trustStore).inputStream().use {
+            tStore.load(it, trustStorePassword!!.toCharArray())
+          }
+
+          val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+          tmf.init(tStore)
+
+          trustManagers = tmf.trustManagers
+        }
+      }
+
+      val sslContext = SSLContext.getInstance("TLS")
+      sslContext.init(keyManagers, trustManagers, null);
+
+      this.okHttpClient = okHttpClient.setSslSocketFactory(sslContext.socketFactory)
+    }
+  }
+}
+
+class TrustAllTrustManager : X509TrustManager {
+  override fun checkClientTrusted(certs: Array<X509Certificate>, authType: String) {
+    // do nothing
+  }
+  override fun checkServerTrusted(certs: Array<X509Certificate>, authType: String) {
+    // do nothing
+  }
+
+  override fun getAcceptedIssuers() = null
+}

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spectator.api.Registry
+import com.squareup.okhttp.Request
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.HandlerMapping
+import javax.servlet.http.HttpServletRequest
+
+import com.netflix.spinnaker.config.ProxyConfigurationProperties
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import java.net.SocketException
+
+@RestController
+@RequestMapping(value = ["/proxies"])
+class ProxyController(val objectMapper: ObjectMapper,
+                      val registry: Registry,
+                      val proxyConfigurationProperties: ProxyConfigurationProperties) {
+
+  val proxyInvocationsId = registry.createId("proxy.invocations")
+
+  @GetMapping(value = ["/{proxy}/**"])
+  fun get(@PathVariable(value = "proxy") proxy: String,
+          @RequestParam requestParams: Map<String, String>,
+          httpServletRequest: HttpServletRequest): ResponseEntity<Any> {
+
+    val proxyConfig = proxyConfigurationProperties
+      .proxies
+      .find { it.id.equals(proxy, true) } ?: throw InvalidRequestException("No proxy config found with id '$proxy'")
+
+    val proxyPath = httpServletRequest
+      .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE)
+      .toString()
+      .substringAfter("/proxies/$proxy")
+
+    val proxiedUrlBuilder = Request.Builder().url(proxyConfig.uri + proxyPath).build().httpUrl().newBuilder()
+    for ((key, value) in requestParams) {
+      proxiedUrlBuilder.addQueryParameter(key, value)
+    }
+    val proxiedUrl = proxiedUrlBuilder.build()
+
+    var statusCode = 0
+    var contentType = "text/plain"
+    var responseBody : String
+
+    try {
+      val response = proxyConfig.okHttpClient.newCall(
+        Request.Builder().url(proxiedUrl).build()
+      ).execute()
+      statusCode = response.code()
+      contentType = response.header("Content-Type")
+      responseBody = response.body().string()
+    } catch (e: SocketException) {
+      statusCode = HttpStatus.GATEWAY_TIMEOUT.value()
+      responseBody = e.toString()
+    } catch (e: Exception) {
+      responseBody = e.toString()
+    }
+
+    registry.counter(
+      proxyInvocationsId
+      .withTag("proxy", proxy)
+      .withTag("status", "${statusCode.toString()[0]}xx")
+      .withTag("statusCode", statusCode.toString())
+    ).increment()
+
+    val responseObj = if (responseBody.startsWith("{")) {
+      objectMapper.readValue(responseBody, Map::class.java)
+    } else if (responseBody.startsWith("[")) {
+      objectMapper.readValue(responseBody, Collection::class.java)
+    } else {
+      responseBody
+    }
+
+    val httpHeaders = HttpHeaders()
+    httpHeaders.contentType = MediaType.valueOf(contentType)
+    httpHeaders.put("X-Proxy-Status-Code", mutableListOf(statusCode.toString()))
+    httpHeaders.put("X-Proxy-Url", mutableListOf(proxiedUrl.toString()))
+
+    val status = if (statusCode >= 500 || statusCode == 0) {
+      // an upstream 5xx should manifest as HTTP 502 - Bad Gateway
+      HttpStatus.BAD_GATEWAY
+    } else {
+      HttpStatus.valueOf(statusCode)
+    }
+
+    return ResponseEntity(responseObj, httpHeaders, status)
+  }
+}

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
   compile project(":gate-core")
+  compile project(":gate-proxy")
 
   spinnaker.group('retrofitDefault')
   spinnaker.group("test")
@@ -72,3 +73,5 @@ tasks.withType(org.springframework.boot.gradle.run.BootRunTask) {
 }
 
 tasks.bootRepackage.enabled = Boolean.valueOf(project.repackage)
+
+bootRun.systemProperties = System.properties

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-rootProject.name = "gate"
+apply plugin: "nebula.kotlin"
 
-include "gate-web", "gate-core", "gate-proxy"
-
-def setBuildFile(project) {
-  project.buildFileName = "${project.name}.gradle"
-  project.children.each {
-    setBuildFile(it)
+configurations.all {
+  resolutionStrategy {
+    eachDependency { details ->
+      if (details.requested.group == "org.jetbrains.kotlin") {
+        details.useVersion kotlinVersion
+      }
+    }
   }
 }
 
-rootProject.children.each {
-  setBuildFile(it)
+compileKotlin {
+  kotlinOptions {
+    languageVersion = "1.2"
+    jvmTarget = "1.8"
+  }
 }


### PR DESCRIPTION
This PR allows for selective proxying of requests through `gate`.

It is particularly useful when a UI component wants to communicate with
a service that does not offer up permissive CORS headers.

Still a few outstanding bits to implement:
- success/failure metrics
- method restriction (config supports it, implementation does not)

Example Config:

```
proxies:
  - id: spinnaker-readonly
    uri: http://spinnaker.com
    methods:
    - GET
    - POST
```

Example Usage:

```
curl localhost:7101/proxies/spinnaker-readonly/health

{
  "status": "UP"
}

X-Proxy-Status-Code: 200
X-Proxy-Url: http://spinnaker.com/health
Content-Type: application/vnd.spring-boot.actuator.v1+json;charset=UTF-8
```