### PR TITLE
fix(SAML): Allow max authentication age configurable

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -45,8 +45,11 @@ dependencies {
 
   // SAML
   compile('org.opensaml:opensaml:2.6.4')
-  compile("org.springframework.security.extensions:spring-security-saml2-core:1.0.2.RELEASE")
-  compile("org.springframework.security.extensions:spring-security-saml-dsl:1.0.0.M3") {
+  compile('ca.juliusdavies:not-yet-commons-ssl:0.3.11')
+  compile("org.springframework.security.extensions:spring-security-saml2-core:1.0.4.RELEASE") {
+    exclude group: 'ca.juliusdavies'
+  }
+  compile("org.springframework.security.extensions:spring-security-saml-dsl:1.0.2.RELEASE") {
     exclude group: 'org.springframework.boot'
     exclude group: 'org.springframework.security'
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -43,6 +43,7 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.saml.SAMLCredential
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService
+import org.springframework.security.saml.websso.WebSSOProfileConsumerImpl
 import org.springframework.security.web.authentication.RememberMeServices
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices
 import org.springframework.stereotype.Component
@@ -84,6 +85,8 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
     List<String> requiredRoles
     UserAttributeMapping userAttributeMapping = new UserAttributeMapping()
+    // Maximum time between users authentication and processing of the AuthNResponse message. (in seconds)
+    long maxAuthenticationAge = 7200
 
     /**
      * Ensure that the keystore exists and can be accessed with the given keyStorePassword and keyStoreAliasName
@@ -145,6 +148,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           .metadataFilePath(samlSecurityConfigProperties.metadataUrl)
           .discoveryEnabled(false)
           .and()
+        .webSSOProfileConsumer(webSSOProfileConsumer())
         .serviceProvider()
           .entityId(samlSecurityConfigProperties.issuerId)
           .protocol(samlSecurityConfigProperties.redirectProtocol)
@@ -246,5 +250,12 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
         return attributes
       }
     }
+  }
+
+  @Bean
+  WebSSOProfileConsumerImpl webSSOProfileConsumer() {
+    WebSSOProfileConsumerImpl webSSOProfileConsumer = new WebSSOProfileConsumerImpl()
+    webSSOProfileConsumer.setMaxAuthenticationAge(samlSecurityConfigProperties.maxAuthenticationAge)
+    webSSOProfileConsumer
   }
 }


### PR DESCRIPTION
Default max authenticaion age is 7200 seconds. Then spinnaker only allows users to single sign-on for up to 7200 seconds since inital authentication with the IDP.
These changes allows max authentication age configurable.