### PR TITLE
feat(loadBalancers): Add support for an oidc config endpoint

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/OidcClientConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/OidcClientConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.config;
+
+import com.netflix.spinnaker.gate.services.NoopOidcConfigService;
+import com.netflix.spinnaker.gate.services.OidcConfigService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OidcClientConfig {
+  @Bean
+  @ConditionalOnMissingBean(OidcConfigService.class)
+  OidcConfigService noopOidcConfigService() {
+    return new NoopOidcConfigService();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OidcConfigController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/OidcConfigController.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.OidcConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/oidcConfigs")
+public class OidcConfigController {
+  @Autowired
+  OidcConfigService oidcConfigService;
+
+  @RequestMapping(method = RequestMethod.GET)
+  List byApp(@RequestParam(value = "app") String app) {
+    return oidcConfigService.getOidcConfigs(app);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NoopOidcConfigService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NoopOidcConfigService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NoopOidcConfigService implements OidcConfigService {
+  public List getOidcConfigs(String app) {
+    return new ArrayList<>();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/OidcConfigService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/OidcConfigService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import java.util.List;
+
+public interface OidcConfigService {
+  List getOidcConfigs(String app);
+}


### PR DESCRIPTION
OIDC Configs will be very install specific so this just adds the interface and a `NoopOidcConfigService` that returns an empty list. The assumption is that custom installs will wire up their own OIDC Config providers.