### PR TITLE
fix(fiat): Transitional support for fiat migration.

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AllowedAccountsSupport.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AllowedAccountsSupport.java
@@ -1,0 +1,47 @@
+package com.netflix.spinnaker.gate.security;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator;
+import com.netflix.spinnaker.gate.services.CredentialsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Returns list of WRITE enabled accounts to populate X-SPINNAKER-ACCOUNTS header.
+ */
+@Component
+public class AllowedAccountsSupport {
+
+  private final FiatPermissionEvaluator fiatPermissionEvaluator;
+
+  private final CredentialsService credentialsService;
+
+  private final boolean fiatEnabled;
+
+  @Autowired
+  public AllowedAccountsSupport(FiatPermissionEvaluator fiatPermissionEvaluator,
+                                CredentialsService credentialsService,
+                                @Value("${services.fiat.enabled:false}") boolean fiatEnabled) {
+    this.fiatPermissionEvaluator = fiatPermissionEvaluator;
+    this.credentialsService = credentialsService;
+    this.fiatEnabled = fiatEnabled;
+  }
+
+  public Collection<String> filterAllowedAccounts(String username, Collection<String> roles) {
+    if (fiatEnabled) {
+      return fiatPermissionEvaluator.getPermission(username).getAccounts()
+        .stream()
+        .filter(v -> v.getAuthorizations().contains(Authorization.WRITE))
+        .map(Account.View::getName)
+        .collect(Collectors.toSet());
+    }
+
+    return credentialsService.getAccountNames(roles);
+  }
+}
+

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousConfig.groovy
@@ -51,6 +51,7 @@ class AnonymousConfig extends WebSecurityConfigurerAdapter {
   List<String> anonymousAllowedAccounts = new CopyOnWriteArrayList<>()
 
   void configure(HttpSecurity http) {
+    updateAnonymousAccounts()
     // Not using the ImmutableUser version in order to update allowedAccounts.
     def principal = new User(email: defaultEmail, allowedAccounts: anonymousAllowedAccounts)
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.security.ldap
 
+import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.security.AuthConfig
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
 import com.netflix.spinnaker.gate.services.PermissionService
@@ -23,10 +24,8 @@ import com.netflix.spinnaker.security.User
 import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
-import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import org.springframework.ldap.core.DirContextAdapter
 import org.springframework.ldap.core.DirContextOperations
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -97,6 +96,9 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     PermissionService permissionService
 
+    @Autowired
+    AllowedAccountsSupport allowedAccountsSupport
+
     @Override
     UserDetails mapUserFromContext(DirContextOperations ctx, String username, Collection<? extends GrantedAuthority> authorities) {
       def roles = sanitizeRoles(authorities)
@@ -104,7 +106,8 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
 
       return new User(username: username,
                       email: ctx.getStringAttribute("mail"),
-                      roles: roles)
+                      roles: roles,
+                      allowedAccounts: allowedAccountsSupport.filterAllowedAccounts(username, roles))
     }
 
     @Override

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -16,12 +16,11 @@
 
 package com.netflix.spinnaker.gate.security.saml
 
+import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.security.AuthConfig
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
 import com.netflix.spinnaker.gate.security.saml.SamlSsoConfig.UserAttributeMapping
-import com.netflix.spinnaker.gate.services.CredentialsService
 import com.netflix.spinnaker.gate.services.PermissionService
-import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
 import org.opensaml.saml2.core.Assertion
@@ -181,13 +180,10 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
     new SAMLUserDetailsService() {
 
       @Autowired
-      CredentialsService credentialsService
-
-      @Autowired
-      ClouddriverService clouddriverService
-
-      @Autowired
       PermissionService permissionService
+
+      @Autowired
+      AllowedAccountsSupport allowedAccountsSupport
 
       @Override
       User loadUserBySAML(SAMLCredential credential) throws UsernameNotFoundException {
@@ -211,7 +207,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           firstName: attributes[userAttributeMapping.firstName]?.get(0),
           lastName: attributes[userAttributeMapping.lastName]?.get(0),
           roles: roles,
-          allowedAccounts: credentialsService.getAccountNames(roles),
+          allowedAccounts: allowedAccountsSupport.filterAllowedAccounts(username, roles),
           username: username)
       }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -55,6 +55,7 @@ class PermissionService {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "login") {
         try {
           fiatService.loginUser(userId, "")
+          permissionEvaluator.invalidatePermission(userId)
         } catch (RetrofitError e) {
           classifyError(e)
         }
@@ -67,6 +68,7 @@ class PermissionService {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "loginWithRoles") {
         try {
           fiatService.loginWithRoles(userId, roles)
+          permissionEvaluator.invalidatePermission(userId)
         } catch (RetrofitError e) {
           classifyError(e)
         }
@@ -79,6 +81,7 @@ class PermissionService {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "logout") {
         try {
           fiatService.logoutUser(userId)
+          permissionEvaluator.invalidatePermission(userId)
         } catch (RetrofitError e) {
           classifyError(e)
         }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.CredentialsService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
@@ -54,8 +56,11 @@ class CredentialsControllerSpec extends Specification {
     CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
       fiatConfig: fiatConfig)
 
+    FiatPermissionEvaluator fpe = Stub(FiatPermissionEvaluator)
+    AllowedAccountsSupport allowedAccountsSupport = new AllowedAccountsSupport(fpe, credentialsService, false)
+
     server.start()
-    mockMvc = MockMvcBuilders.standaloneSetup(new CredentialsController(accountLookupService:  accountLookupService, credentialsService: credentialsService)).build()
+    mockMvc = MockMvcBuilders.standaloneSetup(new CredentialsController(accountLookupService:  accountLookupService, allowedAccountsSupport: allowedAccountsSupport)).build()
   }
 
   @Unroll


### PR DESCRIPTION
Continue to propagate X-SPINNAKER-ACCOUNTS header when
fiat is enabled, allowing a live upgrade into fiat.

Removes auth filtering on /credentials endpoint.
Credentials include an authorized flag which can be used
for filtering choices in the UI, but account metadata is
required for proper UI rendering even for accounts that
the user does not currently have permission for.

requires spinnaker/fiat#231 for invalidatePermissions