### PR TITLE
fix(logging): reduce legacy permission logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ out/
 .classpath
 .project
 .settings
-swagger/swagger.json
+swagger.json

--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -17,6 +17,7 @@
 dependencies {
   spinnaker.group("bootWeb")
   spinnaker.group('retrofitDefault')
+  spinnaker.group('test')
 
   compile spinnaker.dependency("korkSecurity")
   compile spinnaker.dependency('spectatorApi')

--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupServiceSpec.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/services/DefaultProviderLookupServiceSpec.groovy
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import spock.lang.Specification
+import spock.lang.Subject
+
+
+class DefaultProviderLookupServiceSpec extends Specification {
+
+  ClouddriverService clouddriverService = Mock(ClouddriverService)
+
+  @Subject
+  def defaultProviderLookupService = new DefaultProviderLookupService(clouddriverService)
+
+  def "it should replace requiredGroupMemberships if permissions present"() {
+    when:
+    defaultProviderLookupService.refreshCache()
+    def accounts = defaultProviderLookupService.accounts
+
+    then:
+    accounts != null
+    !accounts.isEmpty()
+    accounts[0].permissions != null
+    accounts[0].permissions == expected
+
+    1 * clouddriverService.getAccountDetails() >> {
+      [new ClouddriverService.AccountDetails(requiredGroupMembership: origRequiredGroupMemberships, permissions: origPerms)]
+    }
+    0 * _
+
+    where:
+    origPerms                    | origRequiredGroupMemberships | expected
+    null                         | []                           | [:]
+    [:]                          | ['foo']                      | [:]
+    null                         | ['mgmt-spinnaker']           | [READ: ['mgmt-spinnaker'], WRITE: ['mgmt-spinnaker']]
+    null                         | ['MGMT-spinnaker']           | [READ: ['mgmt-spinnaker'], WRITE: ['mgmt-spinnaker']]
+    [WRITE: ['bacon-spinnaker']] | ['mgmt-spinnaker']           | [WRITE: ['bacon-spinnaker']]
+    [WRITE: ['BACON-spinnaker']] | ['mgmt-spinnaker']           | [WRITE: ['bacon-spinnaker']]
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import spock.lang.Specification
 import spock.lang.Subject
@@ -27,9 +28,12 @@ class CredentialsServiceSpec extends Specification {
   @Unroll
   def "should return allowed account names"() {
     setup:
-    AccountLookupService accountLookupService = Mock(AccountLookupService) {
-      getAccounts() >> accounts
+    ClouddriverService clouddriverService = Stub(ClouddriverService) {
+      getAccountDetails() >> accounts
     }
+
+    AccountLookupService accountLookupService = new DefaultProviderLookupService(clouddriverService)
+    accountLookupService.refreshCache()
     FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
 
     @Subject


### PR DESCRIPTION
Moves the translation of / preference of permissions over requiredGroupMemberships to the
DefaultProviderLookupService which refreshes on a 30s interval rather than every time
permissions are evaluated in CredentialsService.
