### PR TITLE
fix(security): Sets all WebSecurityConfigurerAdapters to LOWEST_PRECE…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/anonymous/AnonymousConfig.groovy
@@ -25,6 +25,8 @@ import org.apache.commons.lang.exception.ExceptionUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -41,6 +43,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 @Configuration
 @Slf4j
 @EnableWebSecurity
+@Order(Ordered.LOWEST_PRECEDENCE)
 class AnonymousConfig extends WebSecurityConfigurerAdapter {
   static String key = "spinnaker-anonymous"
   static String defaultEmail = "anonymous"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
@@ -30,6 +30,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -45,6 +47,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 @EnableWebSecurity
 @ConditionalOnExpression("${google.iap.enabled:false}")
 @EnableConfigurationProperties(IAPSecurityConfigProperties.class)
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class IAPSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.ldap.core.DirContextAdapter
 import org.springframework.ldap.core.DirContextOperations
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
@@ -42,6 +44,7 @@ import org.springframework.stereotype.Component
 @Configuration
 @SpinnakerAuthConfig
 @EnableWebSecurity
+@Order(Ordered.LOWEST_PRECEDENCE)
 class LdapSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -29,6 +29,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -49,6 +51,7 @@ import javax.servlet.http.HttpServletResponse
 @Import(SecurityAutoConfiguration)
 @EnableOAuth2Sso
 @EnableConfigurationProperties
+@Order(Ordered.LOWEST_PRECEDENCE)
 // Note the 4 single-quotes below - this is a raw groovy string, because SpEL and groovy
 // string syntax overlap!
 @ConditionalOnExpression(''''${security.oauth2.client.clientId:}'!=""''')

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -36,6 +36,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
@@ -60,6 +62,7 @@ import static org.springframework.security.extensions.saml2.config.SAMLConfigure
 @EnableWebSecurity
 @Import(SecurityAutoConfiguration)
 @Slf4j
+@Order(Ordered.LOWEST_PRECEDENCE)
 class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509Config.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509Config.groovy
@@ -33,6 +33,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
@@ -118,6 +120,7 @@ class X509Config {
     new X509StandaloneAuthConfig()
   }
 
+  @Order(Ordered.LOWEST_PRECEDENCE)
   class X509StandaloneAuthConfig extends WebSecurityConfigurerAdapter {
     void configure(HttpSecurity http) {
       authConfig.configure(http)


### PR DESCRIPTION
…DENCE. With this change and the management.port set to a different port, it ensures that requests to management endpoints do not get caught by the AnyRequest matcher of the application. This is part of an effort to Make Endpoints Great Again (#MEGA).

The following settings would now allow a user to use the management endpoints without going through any security hops (and once we get these settings in Halyard, should fix https://github.com/spinnaker/spinnaker/issues/2765)

```
management:
  port: 8085
  security:
    enabled: true
    roles: ANONYMOUS

endpoints.sensitive: false
spring.hateoas.use-hal-as-default-json-media-type: false
```