### PR TITLE
fix(hystrix): Avoid an `NaN` when publishing `hystrix.currentTime` (#…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherCommand.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherCommand.groovy
@@ -65,7 +65,7 @@ class HystrixSpectatorPublisherCommand implements HystrixMetricsPublisherCommand
       }
     })
 
-    metricRegistry.gauge(createMetricName("currentTime"), null, new ToDoubleFunction() {
+    metricRegistry.gauge(createMetricName("currentTime"), metrics, new ToDoubleFunction() {
       @Override
       double applyAsDouble(Object ref) {
         return System.currentTimeMillis()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherThreadPool.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/hystrix/spectator/HystrixSpectatorPublisherThreadPool.groovy
@@ -48,7 +48,7 @@ class HystrixSpectatorPublisherThreadPool implements HystrixMetricsPublisherThre
 
   @Override
   public void initialize() {
-    metricRegistry.gauge(createMetricName("currentTime"), null, new ToDoubleFunction() {
+    metricRegistry.gauge(createMetricName("currentTime"), metrics, new ToDoubleFunction() {
       @Override
       double applyAsDouble(Object ref) {
         return System.currentTimeMillis()


### PR DESCRIPTION
…558)

I'm not sure this particular metric has any use but it appears that the
recent spectator bump has resulted in it being `NaN`.

@lwander 