### PR TITLE
feat(fiat): Delegate whether fiat is enabled to `FiatStatus`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.0'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '0.161.2'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/security/AuthConfig.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.security
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.filters.FiatSessionFilter
 import com.netflix.spinnaker.gate.services.PermissionService
 import com.netflix.spinnaker.security.User
@@ -55,15 +56,20 @@ class AuthConfig {
   FiatClientConfigurationProperties configProps
 
   @Autowired
+  FiatStatus fiatStatus
+
+  @Autowired
   FiatPermissionEvaluator permissionEvaluator
 
   @Value('${fiat.sessionFilter.enabled:true}')
   boolean fiatSessionFilterEnabled
 
   void configure(HttpSecurity http) throws Exception {
-    Filter fiatSessionFilter = new FiatSessionFilter(fiatSessionFilterEnabled,
-                                                     configProps,
-                                                     permissionEvaluator)
+    Filter fiatSessionFilter = new FiatSessionFilter(
+      fiatSessionFilterEnabled,
+      fiatStatus,
+      permissionEvaluator
+    )
     // @formatter:off
     SecurityBuilder result = http
       .authorizeRequests()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CredentialsService.groovy
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.gate.services
 
-import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,23 +29,23 @@ class CredentialsService {
   AccountLookupService accountLookupService
 
   @Autowired
-  FiatClientConfigurationProperties fiatConfig
-
-  Collection<String> getAccountNames() {
-    getAccountNames([])
-  }
+  FiatStatus fiatStatus
 
   Collection<String> getAccountNames(Collection<String> userRoles) {
-    getAccounts(userRoles)*.name
+    getAccounts(userRoles, false)*.name
+  }
+
+  Collection<String> getAccountNames(Collection<String> userRoles, boolean ignoreFiatStatus) {
+    getAccounts(userRoles, ignoreFiatStatus)*.name
   }
 
   /**
    * Returns all account names that a user with the specified list of userRoles has access to.
    */
-  List<AccountDetails> getAccounts(Collection<String> userRoles) {
+  List<AccountDetails> getAccounts(Collection<String> userRoles, boolean ignoreFiatStatus) {
     final Set<String> userRolesLower = userRoles*.toLowerCase() as Set<String>
     return accountLookupService.getAccounts().findAll { AccountDetails account ->
-      if (fiatConfig.enabled) {
+      if (!ignoreFiatStatus && fiatStatus.isEnabled()) {
         return true // Returned list is filtered later.
       }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.fiat.model.resources.Role
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.security.SpinnakerUser
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.security.User
@@ -46,12 +47,15 @@ class PermissionService {
   @Autowired
   FiatPermissionEvaluator permissionEvaluator
 
+  @Autowired
+  FiatStatus fiatStatus
+
   boolean isEnabled() {
-    return fiatConfig.enabled
+    return fiatStatus.isEnabled()
   }
 
   void login(String userId) {
-    if (fiatConfig.enabled) {
+    if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "login") {
         try {
           fiatService.loginUser(userId, "")
@@ -64,7 +68,7 @@ class PermissionService {
   }
 
   void loginWithRoles(String userId, Collection<String> roles) {
-    if (fiatConfig.enabled) {
+    if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "loginWithRoles") {
         try {
           fiatService.loginWithRoles(userId, roles)
@@ -77,7 +81,7 @@ class PermissionService {
   }
 
   void logout(String userId) {
-    if (fiatConfig.enabled) {
+    if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "logout") {
         try {
           fiatService.logoutUser(userId)
@@ -90,7 +94,7 @@ class PermissionService {
   }
 
   void sync() {
-    if (fiatConfig.enabled) {
+    if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "sync") {
         try {
           fiatService.sync()
@@ -102,7 +106,7 @@ class PermissionService {
   }
 
   Set<Role> getRoles(String userId) {
-    if (!fiatConfig.enabled) {
+    if (!fiatStatus.isEnabled()) {
       return []
     }
     return HystrixFactory.newListCommand(HYSTRIX_GROUP, "getRoles") {
@@ -121,7 +125,7 @@ class PermissionService {
       return []
     }
 
-    if (!fiatConfig.enabled) {
+    if (!fiatStatus.isEnabled()) {
       log.debug("getServiceAccounts: Fiat disabled.")
       return []
     }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/CredentialsControllerSpec.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.CredentialsService
@@ -50,14 +51,18 @@ class CredentialsControllerSpec extends Specification {
   }
 
   void setup() {
-    FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
+    def fiatStatus = Mock(FiatStatus) {
+      _ * isEnabled() >> { return false }
+    }
 
     @Subject
-    CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
-      fiatConfig: fiatConfig)
+    CredentialsService credentialsService = new CredentialsService(
+      accountLookupService: accountLookupService,
+      fiatStatus: fiatStatus
+    )
 
     FiatPermissionEvaluator fpe = Stub(FiatPermissionEvaluator)
-    AllowedAccountsSupport allowedAccountsSupport = new AllowedAccountsSupport(fpe, credentialsService, false)
+    AllowedAccountsSupport allowedAccountsSupport = new AllowedAccountsSupport(fiatStatus, fpe, credentialsService)
 
     server.start()
     mockMvc = MockMvcBuilders.standaloneSetup(new CredentialsController(accountLookupService:  accountLookupService, allowedAccountsSupport: allowedAccountsSupport)).build()

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/CredentialsServiceSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import spock.lang.Specification
@@ -34,17 +35,19 @@ class CredentialsServiceSpec extends Specification {
 
     AccountLookupService accountLookupService = new DefaultProviderLookupService(clouddriverService)
     accountLookupService.refreshCache()
-    FiatClientConfigurationProperties fiatConfig = new FiatClientConfigurationProperties(enabled: false)
+
+    def fiatStatus = Mock(FiatStatus) {
+      _ * isEnabled() >> { return false }
+    }
 
     @Subject
-    CredentialsService credentialsService = new CredentialsService(accountLookupService: accountLookupService,
-      fiatConfig: fiatConfig)
+    CredentialsService credentialsService = new CredentialsService(
+      accountLookupService: accountLookupService,
+      fiatStatus: fiatStatus
+    )
 
-    when:
-    def allowedAccounts = credentialsService.getAccountNames(roles)
-
-    then:
-    allowedAccounts == expectedAccounts
+    expect:
+    credentialsService.getAccountNames(roles) == expectedAccounts
 
     where:
     roles              | accounts                                                      || expectedAccounts


### PR DESCRIPTION
This allows for fiat to be selectively enabled at runtime via the
`DynamicConfigService` (environment-specific).

The `AllowedAccountsSupport` bean now supports a legacy lookup of
allowed accounts in the event that it's not possible to fetch permissions
from fiat (`legacyFallback` must be enabled).
