### PR TITLE
fix(fiat): Always create `FiatService` regardless of `services.fiat.enabled`

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -152,7 +152,8 @@ class GateConfig extends RedisHttpSessionConfiguration {
 
   @Bean
   FiatService fiatService(OkHttpClient okHttpClient) {
-    createClient "fiat", FiatService, okHttpClient
+    // always create the fiat service even if 'services.fiat.enabled' is 'false' (it can be enabled dynamically)
+    createClient "fiat", FiatService, okHttpClient, null, true
   }
 
   @Bean
@@ -211,12 +212,17 @@ class GateConfig extends RedisHttpSessionConfiguration {
     createClient "kayenta", KayentaService, okHttpClient
   }
 
-  private <T> T createClient(String serviceName, Class<T> type, OkHttpClient okHttpClient, String dynamicName = null) {
+  private <T> T createClient(String serviceName,
+                             Class<T> type,
+                             OkHttpClient okHttpClient,
+                             String dynamicName = null,
+                             boolean forceEnabled = false) {
     Service service = serviceConfiguration.getService(serviceName)
     if (service == null) {
       throw new IllegalArgumentException("Unknown service ${serviceName} requested of type ${type}")
     }
-    if (!service.enabled) {
+
+    if (!service.enabled && !forceEnabled) {
       return null
     }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.gate.services
 
 import com.netflix.spinnaker.fiat.model.UserPermission
 import com.netflix.spinnaker.fiat.model.resources.Role
-import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.fiat.shared.FiatStatus
@@ -40,9 +39,6 @@ class PermissionService {
 
   @Autowired
   FiatService fiatService
-
-  @Autowired
-  FiatClientConfigurationProperties fiatConfig
 
   @Autowired
   FiatPermissionEvaluator permissionEvaluator


### PR DESCRIPTION
Introduce an ability to override the `services.enabled` check that
`GateConfig.createClient()` is doing.

The check will be left in for historical reasons but it is confusing to
have a null service class injected.
