### PR TITLE
fix(web): Enable the `OkHttpMetricsInterceptor`

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -173,7 +173,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
     if (serviceConfiguration.getService("clouddriver").getConfig().containsKey("dynamicEndpoints")) {
       def endpoints = (Map<String, String>) serviceConfiguration.getService("clouddriver").getConfig().get("dynamicEndpoints")
       dynamicServices = (Map<String, ClouddriverService>) endpoints.collectEntries { k, v ->
-        [k, createClient("clouddriver", ClouddriverService, okHttpClient, k)]
+        [k, createClient("clouddriver", ClouddriverService, okHttpClient, k, false)]
       }
     }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.gate.config
 
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
 import com.squareup.okhttp.ConnectionPool
 import com.squareup.okhttp.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,10 +44,11 @@ class RetrofitConfig {
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-  OkHttpClient okHttpClient() {
+  OkHttpClient okHttpClient(Registry registry) {
     def okHttpClient = okHttpClientConfig.create()
     okHttpClient.connectionPool = new ConnectionPool(maxIdleConnections, keepAliveDurationMs)
     okHttpClient.retryOnConnectionFailure = retryOnConnectionFailure
+    okHttpClient.interceptors().add(new OkHttpMetricsInterceptor(registry))
     return okHttpClient
   }
 


### PR DESCRIPTION
Metrics for all okhttp connections will be emitted under
`okhttp.requests`.

Also fix creation of the `ClouddriverServiceSelector` bean that was
broken in spinnaker/gate#565
