### PR TITLE
chore(build): Add debug flag to gate build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ The REST API fronts the following services:
 * [Igor](https://github.com/spinnaker/igor)
 * [Orca](https://github.com/spinnaker/orca)
  
+### Debugging
+
+To start the JVM in debug mode, set the Java system property `DEBUG=true`:
+
+```
+./gradlew -DDEBUG=true
+```
+
+The JVM will then listen for a debugger to be attached on port 8184.  The JVM will _not_ wait for
+the debugger to be attached before starting Gate; the relevant JVM arguments can be seen and
+modified as needed in `build.gradle`.

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ allprojects {
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
 
+  tasks.withType(JavaExec) {
+    if (System.getProperty('DEBUG', 'false') == 'true') {
+      jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8184'
+    }
+  }
+
   group = "com.netflix.spinnaker.gate"
 
   test {


### PR DESCRIPTION
Starting gate with ./gradlew -DDEBUG=true now causes the JVM to listen on port 8184 for a remote debugger.