### PR TITLE
feat(x509): debounce login calls to fiat with x509

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsServiceSpec.groovy
@@ -1,0 +1,180 @@
+package com.netflix.spinnaker.gate.security.x509
+
+import com.netflix.spinnaker.fiat.model.UserPermission
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.gate.services.PermissionService
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import spock.lang.Specification
+
+import java.security.cert.X509Certificate
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+class X509AuthenticationUserDetailsServiceSpec extends Specification {
+
+  def "should debounce login calls"() {
+    given:
+    def config = Stub(DynamicConfigService) {
+      getConfig(Long, 'x509.loginDebounce.debounceWindowSeconds', _) >> TimeUnit.MINUTES.toSeconds(5)
+      isEnabled('x509.loginDebounce', _) >> true
+    }
+    def email = 'foo@bar.net'
+    def view = new UserPermission(id: email).view
+    def perms = Mock(PermissionService)
+    def clock = new TestClock()
+    def cert = Mock(X509Certificate)
+    def userDetails = new X509AuthenticationUserDetailsService(clock)
+    def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+    userDetails.setPermissionService(perms)
+    userDetails.setDynamicConfigService(config)
+    userDetails.setFiatPermissionEvaluator(fiatPermissionEvaluator)
+
+    when: "initial login"
+    userDetails.handleLogin(email, cert)
+
+    then: "should call login"
+    1 * fiatPermissionEvaluator.getPermission(email) >> view
+    1 * perms.login(email)
+    0 * _
+
+    when: "subsequent login during debounce window"
+    clock.advanceTime(Duration.ofSeconds(30))
+    userDetails.handleLogin(email, cert)
+
+    then: "should not call login"
+    1 * fiatPermissionEvaluator.getPermission(email) >> view
+    0 * _
+
+    when: "subsequent login after debounce window"
+    clock.advanceTime(Duration.ofMinutes(5))
+    userDetails.handleLogin(email, cert)
+
+    then: "should call login"
+    1 * fiatPermissionEvaluator.getPermission(email) >> view
+    1 * perms.login(email)
+    0 * _
+
+    when: "login with no cached permission"
+    userDetails.handleLogin(email, cert)
+
+    then: "should call login"
+    1 * fiatPermissionEvaluator.getPermission(email) >> null
+    1 * perms.login(email)
+    0 * _
+
+  }
+
+  def "should always login if debounceDisabled"() {
+    given:
+    def config = Mock(DynamicConfigService)
+    def email = 'foo@bar.net'
+    def perms = Mock(PermissionService)
+    def clock = new TestClock()
+    def cert = Mock(X509Certificate)
+    def userDetails = new X509AuthenticationUserDetailsService(clock)
+    def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+    userDetails.setPermissionService(perms)
+    userDetails.setDynamicConfigService(config)
+    userDetails.setFiatPermissionEvaluator(fiatPermissionEvaluator)
+
+    when:
+    userDetails.handleLogin(email, cert)
+
+    then:
+    1 * config.isEnabled('x509.loginDebounce', _) >> false
+    1 * perms.login(email)
+    0 * _
+
+    when:
+    userDetails.handleLogin(email, cert)
+
+    then:
+    1 * config.isEnabled('x509.loginDebounce', _) >> false
+    1 * perms.login(email)
+    0 * _
+
+    when:
+    clock.advanceTime(Duration.ofSeconds(30))
+    userDetails.handleLogin(email, cert)
+
+    then:
+    1 * config.isEnabled('x509.loginDebounce', _) >> false
+    1 * perms.login(email)
+    0 * _
+  }
+
+  def "should loginWithRoles if roleExtractor provided"() {
+    given:
+    def config = Mock(DynamicConfigService)
+    def email = 'foo@bar.net'
+    def perms = Mock(PermissionService)
+    def clock = new TestClock()
+    def cert = Mock(X509Certificate)
+    def rolesExtractor = Mock(X509RolesExtractor)
+    def userDetails = new X509AuthenticationUserDetailsService(clock)
+    def fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+    userDetails.setPermissionService(perms)
+    userDetails.setDynamicConfigService(config)
+    userDetails.setRolesExtractor(rolesExtractor)
+    userDetails.setFiatPermissionEvaluator(fiatPermissionEvaluator)
+
+    when:
+    userDetails.handleLogin(email, cert)
+
+    then:
+    1 * rolesExtractor.fromCertificate(cert) >> ['foo', 'bar']
+    1 * config.isEnabled('x509.loginDebounce', _) >> false
+    1 * perms.loginWithRoles(email, [email, 'foo', 'bar'])
+    0 * _
+  }
+
+
+  static class TestClock extends Clock {
+    ZoneId zone = ZoneId.of('UTC')
+    final AtomicLong currentMillis
+
+    TestClock() {
+      this(ZoneId.of('UTC'), System.currentTimeMillis())
+    }
+
+    TestClock(ZoneId zone, long currentMillis) {
+      this.zone = zone
+      this.currentMillis = new AtomicLong(currentMillis)
+    }
+
+    @Override
+    ZoneId getZone() {
+      return zone
+    }
+
+    @Override
+    Clock withZone(ZoneId zone) {
+      if (zone.equals(this.zone)) {
+        return this
+      }
+      return new TestClock(zone, millis())
+    }
+
+    @Override
+    long millis() {
+      return currentMillis.get()
+    }
+
+    @Override
+    Instant instant() {
+      return Instant.ofEpochMilli(millis())
+    }
+
+    void setTime(long millis) {
+      currentMillis.set(millis)
+    }
+
+    void advanceTime(Duration duration) {
+      currentMillis.addAndGet(duration.toMillis())
+    }
+  }
+}


### PR DESCRIPTION
Since x509 auth doesn't establish a session, every API call results in a login call to fiat.
Given that certificates are unlikely to change on a high frequency this introduces a configuration
option (off by default) to introduce a per instance debounce of login calls for a particular identity
(only call login once every debounceWindow).
