### PR TITLE
fix(fiat): Smidge of logs when loading a saml user

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/FiatSessionFilter.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/FiatSessionFilter.groovy
@@ -61,7 +61,8 @@ class FiatSessionFilter implements Filter {
     if (fiatStatus.isEnabled() && this.enabled) {
       String user = AuthenticatedRequest.getSpinnakerUser().orElse(null)
       log.debug("Fiat session filter - found user: ${user}")
-      if (permissionEvaluator.getPermission(user) == null) {
+
+      if (user != null && permissionEvaluator.getPermission(user) == null) {
         HttpServletRequest httpReq = (HttpServletRequest) request
         HttpSession session = httpReq.getSession(false)
         if (session != null) {


### PR DESCRIPTION
Also tweaked the `FiatSessionFilter` to only attempt a permission lookup
(and subsequent HttpSession invalidation) if the `user` is non-null.
