### PR TITLE
feat(retrofit): allow request timeouts to be configured

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
@@ -28,6 +28,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
 
+import java.util.concurrent.TimeUnit
+
 @Configuration
 class RetrofitConfig {
   @Value('${okHttpClient.connectionPool.maxIdleConnections:5}')
@@ -39,6 +41,12 @@ class RetrofitConfig {
   @Value('${okHttpClient.retryOnConnectionFailure:true}')
   boolean retryOnConnectionFailure
 
+  @Value('${okHttpClient.connectTimeoutMs:15000}')
+  int connectTimeoutMs
+
+  @Value('${okHttpClient.readTimeoutMs:20000}')
+  int readTimeoutMs
+
   @Autowired
   OkHttpClientConfiguration okHttpClientConfig
 
@@ -49,6 +57,8 @@ class RetrofitConfig {
     okHttpClient.connectionPool = new ConnectionPool(maxIdleConnections, keepAliveDurationMs)
     okHttpClient.retryOnConnectionFailure = retryOnConnectionFailure
     okHttpClient.interceptors().add(new OkHttpMetricsInterceptor(registry))
+    okHttpClient.setConnectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+    okHttpClient.setReadTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
     return okHttpClient
   }
 


### PR DESCRIPTION
Fetching the revision history for a pipeline's configuration from GCS is currently taking upwards of 16 seconds when running locally on my machine.  While the request from front50 to GCS eventually completes successfully, the request from Gate to Front50 times out before it has chance to
complete.  This commit makes Gate's request timeout configurable to account for situations such as this.