### PR TITLE
feat(swabbie): expose optOut endpoint

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.gate.services.internal.MineService
 import com.netflix.spinnaker.gate.services.internal.OrcaService
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import com.netflix.spinnaker.gate.services.internal.RoscoService
+import com.netflix.spinnaker.gate.services.internal.SwabbieService
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.selector.DefaultServiceSelector
 import com.netflix.spinnaker.kork.web.selector.SelectableService
@@ -210,6 +211,12 @@ class GateConfig extends RedisHttpSessionConfiguration {
   @ConditionalOnProperty('services.kayenta.enabled')
   KayentaService kayentaService(OkHttpClient okHttpClient) {
     createClient "kayenta", KayentaService, okHttpClient
+  }
+
+  @Bean
+  @ConditionalOnProperty('services.swabbie.enabled')
+  SwabbieService swabbieService(OkHttpClient okHttpClient) {
+    createClient("swabbie", SwabbieService, okHttpClient)
   }
 
   private <T> T createClient(String serviceName,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.CleanupService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/cleanup")
+public class CleanupController {
+
+  private CleanupService cleanupService;
+
+  @Autowired
+  public CleanupController(CleanupService cleanupService) {
+    this.cleanupService = cleanupService;
+  }
+
+  @ApiOperation(value = "Opt out of clean up for a marked resource.", response = HashMap.class)
+  @RequestMapping(method = RequestMethod.PUT, value = "/resources/{namespace}/{resourceId}/optOut")
+  Map optOut(@PathVariable String namespace,
+             @PathVariable String resourceId) {
+    return cleanupService.optOut(namespace, resourceId);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import com.netflix.spinnaker.gate.services.commands.HystrixFactory;
+import com.netflix.spinnaker.gate.services.internal.SwabbieService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class CleanupService {
+  private static final String GROUP = "cleanup";
+
+  @Autowired(required = false)
+  SwabbieService swabbieService;
+
+  public Map optOut(String namespace, String resourceId) {
+    return (Map) HystrixFactory.newMapCommand(GROUP, "optOut", () -> {
+      return swabbieService.optOut(namespace, resourceId, "");
+    }).execute();
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services.internal;
+
+import retrofit.http.Body;
+import retrofit.http.Headers;
+import retrofit.http.PUT;
+import retrofit.http.Path;
+
+import java.util.Map;
+
+public interface SwabbieService {
+  @Headers("Accept: application/json")
+  @PUT("/resources/state/{namespace}/{resourceId}/optOut")
+  Map optOut(@Path("namespace") String namespace,
+             @Path("resourceId") String resourceId,
+             @Body String ignored);
+}


### PR DESCRIPTION
Expose the opt out endpoint for a resource through gate. 
Keep swabbie as a non-required service.

To use, add in `gate.yml`
```
swabbie:
    enabled: true
    baseUrl: https://localhost:8088
```