### PR TITLE
fix(swagger): Include pipeline templates in Swagger

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -63,7 +63,7 @@ swagger:
     - .*applications.*
     - .*securityGroups.*
     - /search
-    - .*pipelines.*
+    - .*pipeline.*
     - .*loadBalancers.*
     - .*instances.*
     - .*images.*


### PR DESCRIPTION
".*pipelines.*" doesn't match "pipelineTemplates", so the pipeline templates API calls were not included in Swagger.

Remove the "s" in ".*pipelines.*" to fix this.