### PR TITLE
fix(swagger): Include pipeline-config-controller in Swagger

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -63,6 +63,7 @@ swagger:
     - .*applications.*
     - .*securityGroups.*
     - /search
+    - .*pipelineConfigs.*
     - .*pipelines.*
     - .*loadBalancers.*
     - .*instances.*


### PR DESCRIPTION
The `swagger.json` generated by `swagger/generate_swagger.sh` omits the `pipeline-config-controller` endpoints.  Therefore clients generated from that `swagger.json` file fail to generate methods needed to interact with the `pipeline-config-controller`.  This change adds a search pattern that includes the needed endpoints.