### PR TITLE
feat(cors): Allow new 'X-Spinnaker-Priority' header

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/CorsFilter.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/CorsFilter.groovy
@@ -55,7 +55,7 @@ class CorsFilter implements Filter {
     response.setHeader("Access-Control-Allow-Origin", origin)
     response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH")
     response.setHeader("Access-Control-Max-Age", "3600")
-    response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type, authorization, X-RateLimit-App")
+    response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type, authorization, X-RateLimit-App, X-Spinnaker-Priority")
     response.setHeader("Access-Control-Expose-Headers", [Headers.AUTHENTICATION_REDIRECT_HEADER_NAME].join(", "))
     chain.doFilter(req, res)
   }


### PR DESCRIPTION
Gate needs to allow this in CORS before deck can start sending it.