### PR TITLE
feat(web): Low priority request shedding interceptor

### DIFF
--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -19,6 +19,7 @@ dependencies {
   spinnaker.group('retrofitDefault')
   spinnaker.group('test')
 
+  compile spinnaker.dependency("kork")
   compile spinnaker.dependency("korkSecurity")
   compile spinnaker.dependency('spectatorApi')
   compile spinnaker.dependency("groovy")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -20,10 +20,12 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestIdInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestLoggingInterceptor
+import com.netflix.spinnaker.gate.interceptors.RequestSheddingInterceptor
 import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter
 import com.netflix.spinnaker.gate.ratelimit.RateLimitingInterceptor
 import com.netflix.spinnaker.gate.retrofit.UpstreamBadRequest
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -58,6 +60,9 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
   RateLimiter rateLimiter
 
   @Autowired
+  DynamicConfigService dynamicConfigService
+
+  @Autowired
   Registry spectatorRegistry
 
   @Value('${rateLimit.learning:true}')
@@ -85,6 +90,7 @@ public class GateWebConfig extends WebMvcConfigurerAdapter {
     }
 
     registry.addInterceptor(new RequestContextInterceptor())
+    registry.addInterceptor(new RequestSheddingInterceptor(dynamicConfigService, this.registry))
   }
 
   @Bean

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptor.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.interceptors;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.annotation.PreDestroy;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+/**
+ * A request interceptor for shedding low-priority requests from Deck.
+ *
+ * Low priority requests are identified by the X-Spinnaker-Priority
+ * request header, which must also include a "low" value. If missing
+ * or given any other value, the request will be treated as as normal.
+ *
+ * Uses the dynamic config service to enable/disable the functionality,
+ * and further to optionally drop low priority requests on specific
+ * request paths. A path pattern must be defined before any low priority
+ * requests will be dropped.
+ *
+ *  A percentage chance config key is also available which takes a
+ * value between 0 and 100, representing the percentage chance that
+ * the request will be dropped. If the value is set to "60", there
+ * will be a 60% chance the request will be dropped; this value is
+ * only considered when the enabled key is also set to "true".
+ *
+ * If enabled but an internal error occurs due to configuration, the
+ * interceptor will elect to drop all low priority requests.
+ */
+public class RequestSheddingInterceptor extends HandlerInterceptorAdapter {
+
+  final static String PRIORITY_HEADER = "X-Spinnaker-Priority";
+  final static String LOW_PRIORITY = "low";
+
+  final static String ENABLED_KEY = "requestShedding";
+  final static String CHANCE_KEY = "requestShedding.chance";
+  final static String PATHS_KEY = "requestShedding.paths";
+
+  private final static Logger log = LoggerFactory.getLogger(RequestSheddingInterceptor.class);
+  private final static Splitter splitter = Splitter.on(",").omitEmptyStrings().trimResults();
+  private final static Random random = new Random();
+
+  private final DynamicConfigService configService;
+  private final Registry registry;
+  private final ScheduledExecutorService executorService;
+
+  private final Id requestsId;
+
+  private final CopyOnWriteArrayList<Pattern> pathPatterns = new CopyOnWriteArrayList<>();
+
+  public RequestSheddingInterceptor(DynamicConfigService configService, Registry registry) {
+    this.configService = configService;
+    this.registry = registry;
+
+    this.requestsId = registry.createId("requestShedding.requests");
+
+    this.executorService = Executors.newScheduledThreadPool(1);
+    this.executorService.scheduleWithFixedDelay(this::compilePatterns, 0, 30, TimeUnit.SECONDS);
+  }
+
+  @PreDestroy
+  protected void shutdown() {
+    this.executorService.shutdown();
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request,
+                           HttpServletResponse response,
+                           Object handler) throws Exception {
+    if (configService.isEnabled(ENABLED_KEY, false) && isDroppable(request)) {
+      if (shouldDropRequestWithChance()) {
+        log.warn("Dropping low priority request: {}", request.getRequestURI());
+        registry.counter(requestsId.withTag("action", "dropped")).increment();
+
+        response.setDateHeader("Retry-After", Instant.now().plus(Duration.ofMinutes(1)).toEpochMilli());
+        throw new LowPriorityRequestRejected();
+      }
+      log.debug("Dice roll prevented low priority request shedding: {}", request.getRequestURI());
+      registry.counter(requestsId.withTag("action", "allowed")).increment();
+    }
+
+    return super.preHandle(request, response, handler);
+  }
+
+  private boolean isDroppable(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+
+    // We want our error handler to service the errors correctly
+    if ("/error".equals(uri)) {
+      return false;
+    }
+
+    return LOW_PRIORITY.equals(request.getHeader(PRIORITY_HEADER)) && hasPathMatch(uri);
+  }
+
+  private boolean shouldDropRequestWithChance() {
+    Integer chance = configService.getConfig(Integer.class, CHANCE_KEY, 100);
+    if (chance < 0 || chance > 100) {
+      log.warn("Request shedding drop chance is out of bounds: {}, assuming 100", chance);
+      chance = 100;
+    }
+    return random.nextInt(100) <= chance;
+  }
+
+  private boolean hasPathMatch(String requestedPath) {
+    if (!pathPatterns.isEmpty()) {
+      for (Pattern pattern : pathPatterns) {
+        if (pattern.matcher(requestedPath).matches()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  public void compilePatterns() {
+    String pathMatchers = configService.getConfig(String.class, PATHS_KEY, "");
+    if (Strings.isNullOrEmpty(pathMatchers)) {
+      return;
+    }
+
+    List<String> paths = splitter.splitToList(pathMatchers);
+    if (paths.isEmpty()) {
+      return;
+    }
+
+    List<Pattern> newPatterns = new ArrayList<>();
+    for (String path : paths) {
+      try {
+        newPatterns.add(Pattern.compile(path));
+      } catch (PatternSyntaxException e) {
+        log.error("Path pattern invalid, skipping: {}", path, e);
+      }
+    }
+
+    pathPatterns.addAll(newPatterns);
+    pathPatterns.removeIf(p -> !newPatterns.contains(p));
+  }
+
+  @ResponseStatus(value = SERVICE_UNAVAILABLE, reason = LowPriorityRequestRejected.REASON)
+  static class LowPriorityRequestRejected extends RuntimeException {
+    final static String REASON = "Low priority requests are not currently being accepted";
+    LowPriorityRequestRejected() {
+      super(REASON);
+    }
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptorSpec.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.interceptors
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static com.netflix.spinnaker.gate.interceptors.RequestSheddingInterceptor.*
+
+class RequestSheddingInterceptorSpec extends Specification {
+
+  DynamicConfigService configService = Mock()
+
+  @Subject
+  RequestSheddingInterceptor subject = new RequestSheddingInterceptor(configService, new NoopRegistry())
+
+  HttpServletRequest request = Mock()
+  HttpServletResponse response = Mock()
+  Object handler = Mock()
+
+  def "should do nothing when disabled"() {
+    when:
+    def result = subject.preHandle(request, response, handler)
+
+    then:
+    noExceptionThrown()
+    1 * configService.isEnabled(ENABLED_KEY, false) >> false
+    0 * _
+    result == true
+  }
+
+  def "should do nothing if request is not low priority"() {
+    when:
+    def result = subject.preHandle(request, response, handler)
+
+    then:
+    noExceptionThrown()
+    1 * configService.isEnabled(ENABLED_KEY, false) >> true
+    1 * request.getHeader(PRIORITY_HEADER) >> "normal"
+    1 * request.getRequestURI() >> "/foo"
+    0 * _
+    result == true
+  }
+
+  @Unroll
+  def "should allow requests not matching paths"() {
+    when:
+    subject.compilePatterns()
+    subject.preHandle(request, response, handler)
+
+    then:
+    noExceptionThrown()
+    1 * configService.isEnabled(ENABLED_KEY, false) >> true
+    1 * request.getHeader(PRIORITY_HEADER) >> "low"
+    1 * request.getRequestURI() >> requestPath
+    1 * configService.getConfig(String, PATHS_KEY, "") >> pathMatchers
+    0 * _
+
+    where:
+    requestPath | pathMatchers
+    "/foo"      | null
+    "/foo"      | "/bar"
+    "/foo/bar"  | "^/bar"
+    "/foo/bar"  | "/bar"
+    "/foo"      | "/bar,/baz"
+  }
+
+  @Unroll
+  def "should drop requests matching #pathMatchers"() {
+    when:
+    subject.compilePatterns()
+    subject.preHandle(request, response, handler)
+
+    then:
+    thrown(LowPriorityRequestRejected)
+    1 * configService.isEnabled(ENABLED_KEY, false) >> true
+    1 * request.getHeader(PRIORITY_HEADER) >> "low"
+    2 * request.getRequestURI() >> requestPath
+    1 * configService.getConfig(String, PATHS_KEY, "") >> pathMatchers
+    1 * configService.getConfig(Integer, CHANCE_KEY, 100) >> 100
+    1 * response.setDateHeader("Retry-After", _)
+    0 * _
+
+    where:
+    requestPath | pathMatchers
+    "/foo"      | ".*"
+    "/foo"      | "/f.*,/bar"
+  }
+}


### PR DESCRIPTION
A dumb, coarse-grained request shedding interceptor. For when we need to pull the plug on a part of the system to save the rest of it.

```yaml
requestShedding:
  enabled: true

  # optional knobs...
  paths: "/projects/.*/clusters,/somethingElse"
  chance: 60
```

And then sending a request to gate with `X-Spinnaker-Priority: low`:

```json
{
	"error": "Service Unavailable",
	"exception": "com.netflix.spinnaker.gate.interceptors.RequestSheddingInterceptor$LowPriorityRequestRejected",
	"message": "Low priority requests are not currently being accepted",
	"status": 503,
	"timestamp": 1536537123528
}
```

Verified that `/health` and `/error` are not intercepted, regardless of header value.

I elected to go with a global chance config instead of per-path to keep the complexity down, since we'll only be using this when things are dicey.