### PR TITLE
refactor(core): Create new endpoint to manually trigger with Echo

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -230,8 +230,8 @@ class PipelineController {
   @ApiOperation(value = "Trigger a pipeline execution")
   @RequestMapping(value = "/v2/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
   HttpEntity invokePipelineConfigViaEcho(@PathVariable("application") String application,
-                                  @PathVariable("pipelineNameOrId") String pipelineNameOrId,
-                                  @RequestBody(required = false) Map trigger) {
+                                         @PathVariable("pipelineNameOrId") String pipelineNameOrId,
+                                         @RequestBody(required = false) Map trigger) {
     trigger = trigger ?: [:]
     trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
     trigger.notifications = trigger.notifications ?: []
@@ -239,13 +239,13 @@ class PipelineController {
     RequestContext.setApplication(application)
     try {
       def body = pipelineService.triggerViaEcho(application, pipelineNameOrId, trigger)
-      new ResponseEntity(body, HttpStatus.ACCEPTED)
+      return new ResponseEntity(body, HttpStatus.ACCEPTED)
     } catch (NotFoundException e) {
       throw e
     } catch (e) {
       log.error("Unable to trigger pipeline (application: {}, pipelineId: {})",
         value("application", application), value("pipelineId", pipelineNameOrId), e)
-      new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
+      return new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
     }
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -20,10 +20,9 @@ package com.netflix.spinnaker.gate.controllers
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.PipelineService
-
-import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
+import com.netflix.spinnaker.kork.web.exceptions.HasAdditionalAttributes
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileDynamic
@@ -36,13 +35,8 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
 import retrofit.RetrofitError
 
 import static net.logstash.logback.argument.StructuredArguments.value
@@ -228,24 +222,20 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Trigger a pipeline execution")
+  @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ')")
   @RequestMapping(value = "/v2/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
   HttpEntity invokePipelineConfigViaEcho(@PathVariable("application") String application,
                                          @PathVariable("pipelineNameOrId") String pipelineNameOrId,
                                          @RequestBody(required = false) Map trigger) {
     trigger = trigger ?: [:]
-    trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
-    trigger.notifications = trigger.notifications ?: []
-
     RequestContext.setApplication(application)
     try {
       def body = pipelineService.triggerViaEcho(application, pipelineNameOrId, trigger)
       return new ResponseEntity(body, HttpStatus.ACCEPTED)
-    } catch (NotFoundException e) {
-      throw e
     } catch (e) {
       log.error("Unable to trigger pipeline (application: {}, pipelineId: {})",
         value("application", application), value("pipelineId", pipelineNameOrId), e)
-      return new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
+      throw e
     }
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -227,6 +227,28 @@ class PipelineController {
     }
   }
 
+  @ApiOperation(value = "Trigger a pipeline execution")
+  @RequestMapping(value = "/v2/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
+  HttpEntity invokePipelineConfigViaEcho(@PathVariable("application") String application,
+                                  @PathVariable("pipelineNameOrId") String pipelineNameOrId,
+                                  @RequestBody(required = false) Map trigger) {
+    trigger = trigger ?: [:]
+    trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
+    trigger.notifications = trigger.notifications ?: []
+
+    RequestContext.setApplication(application)
+    try {
+      def body = pipelineService.triggerViaEcho(application, pipelineNameOrId, trigger)
+      new ResponseEntity(body, HttpStatus.ACCEPTED)
+    } catch (NotFoundException e) {
+      throw e
+    } catch (e) {
+      log.error("Unable to trigger pipeline (application: {}, pipelineId: {})",
+        value("application", application), value("pipelineId", pipelineNameOrId), e)
+      new ResponseEntity([message: e.message], new HttpHeaders(), HttpStatus.UNPROCESSABLE_ENTITY)
+    }
+  }
+
   @ApiOperation(value = "Evaluate a pipeline expression using the provided execution as context", response = HashMap.class)
   @RequestMapping(value = "{id}/evaluateExpression")
   Map evaluateExpressionForExecution(@PathVariable("id") String id,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -96,6 +96,26 @@ class PipelineService {
     orcaServiceSelector.withContext(RequestContext.get()).startPipeline(pipelineConfig, trigger.user?.toString())
   }
 
+  Map triggerViaEcho(String application, String pipelineNameOrId, Map parameters) {
+    String user = parameters.remove("user")
+    def eventId = UUID.randomUUID()
+    parameters.put("eventId", eventId)
+
+    Map eventMap = [
+      content: [
+        application: application,
+        pipelineNameOrId: pipelineNameOrId,
+        trigger: parameters,
+        user: user
+      ],
+      details: [
+        type: "manual"
+      ]
+    ]
+    echoService.postEvent(eventMap)
+    return [eventId: eventId]
+  }
+
   Map startPipeline(Map pipelineConfig, String user) {
     orcaServiceSelector.withContext(RequestContext.get()).startPipeline(pipelineConfig, user)
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -97,7 +98,7 @@ class PipelineService {
   }
 
   Map triggerViaEcho(String application, String pipelineNameOrId, Map parameters) {
-    String user = parameters.remove("user")
+    def user = AuthenticatedRequest.getSpinnakerUser()
     def eventId = UUID.randomUUID()
     parameters.put("eventId", eventId)
 
@@ -105,8 +106,9 @@ class PipelineService {
       content: [
         application: application,
         pipelineNameOrId: pipelineNameOrId,
+        runAsUser: user.orElse(""),
         trigger: parameters,
-        user: user
+        user: user.orElse("anonymous")
       ],
       details: [
         type: "manual"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -98,7 +98,6 @@ class PipelineService {
   }
 
   Map triggerViaEcho(String application, String pipelineNameOrId, Map parameters) {
-    def user = AuthenticatedRequest.getSpinnakerUser()
     def eventId = UUID.randomUUID()
     parameters.put("eventId", eventId)
 
@@ -106,9 +105,8 @@ class PipelineService {
       content: [
         application: application,
         pipelineNameOrId: pipelineNameOrId,
-        runAsUser: user.orElse(""),
         trigger: parameters,
-        user: user.orElse("anonymous")
+        user: AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
       ],
       details: [
         type: "manual"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -39,4 +39,7 @@ interface EchoService {
 
   @GET("/pubsub/subscriptions")
   List<Map<String, String>> getPubsubSubscriptions()
+
+  @POST('/')
+  String postEvent(@Body Map event)
 }


### PR DESCRIPTION
This change adds a new endpoint to trigger a pipeline that will send the request through Echo rather than directly to Orca.  By sending the request through Echo, processing steps that happen for automated triggers will also be applied to manual triggers. Eventually we'll migrate existing workflows to go through Echo, but for a safe rollout we're leaving the existing endpoint unchanged.