### PR TITLE
chore(okhttp): pick up okhttp from spinnaker-dependencies 1.0.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.0.13'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.0.26'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RetrofitConfig.groovy
@@ -18,11 +18,8 @@ package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
-import com.netflix.spinnaker.okhttp.OkHttpMetricsInterceptor
-import com.squareup.okhttp.ConnectionPool
 import com.squareup.okhttp.OkHttpClient
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -30,26 +27,13 @@ import org.springframework.context.annotation.Scope
 
 @Configuration
 class RetrofitConfig {
-  @Value('${okHttpClient.connectionPool.maxIdleConnections:5}')
-  int maxIdleConnections
-
-  @Value('${okHttpClient.connectionPool.keepAliveDurationMs:300000}')
-  int keepAliveDurationMs
-
-  @Value('${okHttpClient.retryOnConnectionFailure:true}')
-  boolean retryOnConnectionFailure
-
   @Autowired
   OkHttpClientConfiguration okHttpClientConfig
 
   @Bean
   @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
   OkHttpClient okHttpClient(Registry registry) {
-    def okHttpClient = okHttpClientConfig.create()
-    okHttpClient.connectionPool = new ConnectionPool(maxIdleConnections, keepAliveDurationMs)
-    okHttpClient.retryOnConnectionFailure = retryOnConnectionFailure
-    okHttpClient.interceptors().add(new OkHttpMetricsInterceptor(registry))
-    return okHttpClient
+    return okHttpClientConfig.create()
   }
 
 }


### PR DESCRIPTION
The connection pool, retry settings and metrics interceptor should be
handled directly in okHttpClientConfig and not needed explicitly in gate.
