### PR TITLE
fix(test): Ensure executor service does not run in tests

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.gate.interceptors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.netflix.spectator.api.Id;
@@ -86,18 +87,31 @@ public class RequestSheddingInterceptor extends HandlerInterceptorAdapter {
   private final CopyOnWriteArrayList<Pattern> pathPatterns = new CopyOnWriteArrayList<>();
 
   public RequestSheddingInterceptor(DynamicConfigService configService, Registry registry) {
+    this(configService, registry, Executors.newScheduledThreadPool(1));
+  }
+
+  @VisibleForTesting
+  RequestSheddingInterceptor(DynamicConfigService configService,
+                             Registry registry,
+                             ScheduledExecutorService executorService) {
     this.configService = configService;
     this.registry = registry;
 
     this.requestsId = registry.createId("requestShedding.requests");
 
-    this.executorService = Executors.newScheduledThreadPool(1);
-    this.executorService.scheduleWithFixedDelay(this::compilePatterns, 0, 30, TimeUnit.SECONDS);
+    if (executorService != null) {
+      this.executorService = executorService;
+      this.executorService.scheduleWithFixedDelay(this::compilePatterns, 0, 30, TimeUnit.SECONDS);
+    } else {
+      this.executorService = null;
+    }
   }
 
   @PreDestroy
   protected void shutdown() {
-    this.executorService.shutdown();
+    if (this.executorService != null) {
+      this.executorService.shutdown();
+    }
   }
 
   @Override

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/interceptors/RequestSheddingInterceptorSpec.groovy
@@ -31,7 +31,7 @@ class RequestSheddingInterceptorSpec extends Specification {
   DynamicConfigService configService = Mock()
 
   @Subject
-  RequestSheddingInterceptor subject = new RequestSheddingInterceptor(configService, new NoopRegistry())
+  RequestSheddingInterceptor subject = new RequestSheddingInterceptor(configService, new NoopRegistry(), null)
 
   HttpServletRequest request = Mock()
   HttpServletResponse response = Mock()


### PR DESCRIPTION
Ha-ha. Tests for `RequestSheddingInterceptor` could fail sometimes because of the executor service re-running the compilation of paths while executing tests. This causes the spec to transiently fail.