### PR TITLE
feat(canary-v2): add ad-hoc/manual execution endpoint

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiParam
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
@@ -54,7 +55,23 @@ class V2CanaryController {
     v2CanaryService.listJudges()
   }
 
-  // TODO: Add endpoint for initiating a canary run.
+  @ApiOperation(value = 'Start a canary execution')
+  @RequestMapping(value = '/canary/{canaryConfigId:.+}', method = RequestMethod.POST)
+  Map initiateCanary(@PathVariable String canaryConfigId,
+                     @RequestBody Map executionRequest,
+                     @RequestParam(value = 'application', required = false) String application,
+                     @RequestParam(value = 'parentPipelineExecutionId', required = false) String parentPipelineExecutionId,
+                     @RequestParam(value = 'metricsAccountName', required = false) String metricsAccountName,
+                     @RequestParam(value = 'storageAccountName', required = false) String storageAccountName,
+                     @RequestParam(value = 'configurationAccountName', required = false) String configurationAccountName) {
+    v2CanaryService.initiateCanary(canaryConfigId,
+                                   executionRequest,
+                                   application,
+                                   parentPipelineExecutionId,
+                                   metricsAccountName,
+                                   storageAccountName,
+                                   configurationAccountName)
+  }
 
   @ApiOperation(value = 'Retrieve a canary result')
   @RequestMapping(value = '/canary/{canaryConfigId}/{canaryExecutionId}', method = RequestMethod.GET)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2CanaryService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2CanaryService.groovy
@@ -66,6 +66,28 @@ class V2CanaryService {
     }).execute() as List
   }
 
+  Map initiateCanary(String canaryConfigId,
+                     Map executionRequest,
+                     String application,
+                     String parentPipelineExecutionId,
+                     String metricsAccountName,
+                     String storageAccountName,
+                     String configurationAccountName) {
+    return HystrixFactory.newMapCommand(HYSTRIX_GROUP, "initiateCanary", {
+      try {
+        return kayentaService.initiateCanary(canaryConfigId,
+                                             executionRequest,
+                                             application,
+                                             parentPipelineExecutionId,
+                                             metricsAccountName,
+                                             storageAccountName,
+                                             configurationAccountName)
+      } catch (RetrofitError error) {
+        throw classifyError(error)
+      }
+    }).execute() as Map
+  }
+
   Map getCanaryResults(String canaryExecutionId, String storageAccountName) {
     return HystrixFactory.newMapCommand(HYSTRIX_GROUP, "getCanaryResults", {
       try {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KayentaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KayentaService.groovy
@@ -51,6 +51,15 @@ interface KayentaService {
   @GET("/judges")
   List listJudges()
 
+  @POST("/canary/{canaryConfigId}")
+  Map initiateCanary(@Path("canaryConfigId") String canaryConfigId,
+                     @Body Map executionRequest,
+                     @Query("application") String application,
+                     @Query("parentPipelineExecutionId") String parentPipelineExecutionId,
+                     @Query("metricsAccountName") String metricsAccountName,
+                     @Query("storageAccountName") String storageAccountName,
+                     @Query("configurationAccountName") String configurationAccountName)
+
   @GET("/canary/{canaryExecutionId}")
   Map getCanaryResult(@Path("canaryExecutionId") String canaryExecutionId,
                       @Query("storageAccountName") String storageAccountName)


### PR DESCRIPTION
We need this endpoint exposed to the UI to support manual execution of analysis tasks. 

This is my first PR for any of our services, so I'm assuming I've done at least a few things wrong 😆