### PR TITLE
feat(web): Support rate limits per source application

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfiguration.java
@@ -51,6 +51,13 @@ public class RateLimiterConfiguration {
   List<PrincipalOverride> capacityByPrincipal = new ArrayList<>();
 
   /**
+   * A source app-specific capacity override map. This can be defined if
+   * you want to give a specific source app more or less capacity per
+   * rateSeconds than the default.
+   */
+  List<SourceAppOverride> capacityBySourceApp = new ArrayList<>();
+
+  /**
    * A principal-specific rate override map.
    */
   List<PrincipalOverride> rateSecondsByPrincipal = new ArrayList<>();
@@ -86,6 +93,10 @@ public class RateLimiterConfiguration {
     return rateSecondsByPrincipal;
   }
 
+  public List<SourceAppOverride> getCapacityBySourceApp() {
+    return capacityBySourceApp;
+  }
+
   public boolean isLearning() {
     return learning;
   }
@@ -109,6 +120,35 @@ public class RateLimiterConfiguration {
 
     public Integer getOverride() {
       return override;
+    }
+
+    public void setPrincipal(String principal) {
+      this.principal = principal;
+    }
+
+    public void setOverride(Integer override) {
+      this.override = override;
+    }
+  }
+
+  public static class SourceAppOverride {
+    String sourceApp;
+    Integer override;
+
+    public String getSourceApp() {
+      return sourceApp;
+    }
+
+    public Integer getOverride() {
+      return override;
+    }
+
+    public void setSourceApp(String sourceApp) {
+      this.sourceApp = sourceApp;
+    }
+
+    public void setOverride(Integer override) {
+      this.override = override;
     }
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitPrincipalProvider.java
@@ -16,6 +16,11 @@
 package com.netflix.spinnaker.gate.ratelimit;
 
 public interface RateLimitPrincipalProvider {
+  String DECK_APP = "deck";
 
-  RateLimitPrincipal getPrincipal(String name);
+  RateLimitPrincipal getPrincipal(String name, String sourceApp);
+
+  default boolean supports(String sourceApp) {
+    return !DECK_APP.equalsIgnoreCase(sourceApp);
+  }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
@@ -26,7 +26,7 @@ public class StaticRateLimitPrincipalProvider extends AbstractRateLimitPrincipal
   }
 
   @Override
-  public RateLimitPrincipal getPrincipal(String name) {
+  public RateLimitPrincipal getPrincipal(String name, String sourceApp) {
     return new RateLimitPrincipal(
       name,
       overrideOrDefault(name, rateLimiterConfiguration.getRateSecondsByPrincipal(), rateLimiterConfiguration.getRateSeconds()),

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptorSpec.groovy
@@ -105,7 +105,7 @@ class RateLimitingInterceptorSpec extends Specification {
 
     then:
     noExceptionThrown()
-    2 * request.getHeader("X-RateLimit-App") >> { return "deck" }
+    1 * request.getHeader("X-RateLimit-App") >> { return "deck" }
     0 * _
   }
 }


### PR DESCRIPTION
feat(web): Support rate limits per source application

```
rateLimit:
    learning: false
    enabled: true
    rateSeconds: 10
    capacity: 500
    redis:
    enabled: true
    capacityBySourceApp:
    - sourceApp: deck
    override: 100
```

Source application limits must be explicitly enabled in redis:

```
sadd "rateLimit:enforcing" "app:deck"
```

They can also be overridden in redis:

```
set "rateLimit:capacity:app:deck" 25
```

A per-principal capacity will override that of the source application.