### PR TITLE
feat(web): Serve `/applications` out of the recent cache

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -26,6 +26,8 @@ import io.swagger.annotations.ApiParam
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpEntity
+import org.springframework.security.access.prepost.PostFilter
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -60,6 +62,8 @@ class ApplicationController {
 
   @ApiOperation(value = "Retrieve a list of applications", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
+  @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
+  @PostFilter("hasPermission(filterObject.get('name'), 'APPLICATION', 'READ')")
   List<HashMap<String, Object>> getAllApplications(
     @ApiParam(name = "account", required = false, value = "filters results to only include applications deployed in the specified account")
     @RequestParam(value = "account", required = false) String account,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -26,21 +26,16 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
-import org.springframework.web.bind.annotation.ExceptionHandler
 import retrofit.RetrofitError
 import retrofit.converter.ConversionException
-import rx.Observable
-import rx.Scheduler
-import rx.schedulers.Schedulers
 
-import javax.annotation.PostConstruct
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 @CompileStatic
@@ -48,8 +43,6 @@ import java.util.concurrent.atomic.AtomicReference
 @Slf4j
 class ApplicationService {
   private static final String GROUP = "applications"
-
-  private Scheduler scheduler = Schedulers.io()
 
   @Autowired
   ServiceConfiguration serviceConfiguration
@@ -65,20 +58,15 @@ class ApplicationService {
 
   private AtomicReference<List<Map>> allApplicationsCache = new AtomicReference<>([])
 
-  @PostConstruct
-  void startMonitoring() {
-    Observable
-      .timer(60, TimeUnit.SECONDS, scheduler)
-      .repeat()
-      .subscribe({ Long interval ->
-      try {
-        log.debug("Refreshing Application List")
-        allApplicationsCache.set(tick(true))
-        log.debug("Refreshed Application List")
-      } catch (e) {
-        log.error("Unable to refresh application list, reason: ${e.message}")
-      }
-    })
+  @Scheduled(fixedDelayString = '${services.front50.applicationRefreshIntervalMs:5000}')
+  void refreshApplicationsCache() {
+    try {
+      log.debug("Refreshing Application List")
+      allApplicationsCache.set(tick(true))
+      log.debug("Refreshed Application List (applications: {})", allApplicationsCache.get().size())
+    } catch (e) {
+      log.error("Unable to refresh application list, reason: ${e.message}")
+    }
   }
 
   /**
@@ -88,8 +76,7 @@ class ApplicationService {
    * As a trade-off, we'll fetch cluster details on the background refresh loop and merge in the
    * account details when applications are requested on-demand.
    *
-   * @param expandClusterNames Should cluster details (for each application) be fetched from
-   * clouddriver
+   * @param expandClusterNames Should cluster details (for each application) be fetched from clouddriver
    * @return Applications
    */
   List<Map<String, Object>> tick(boolean expandClusterNames = true) {
@@ -108,17 +95,6 @@ class ApplicationService {
   }
 
   List<Map> getAllApplications() {
-    try {
-      def applicationsByName = allApplicationsCache.get().groupBy { it.name }
-      return tick(false).collect { Map application ->
-        applicationsByName[application.name.toString()]?.each { Map cacheApplication ->
-          application.accounts = mergeAccounts(application.accounts as String, cacheApplication.accounts as String)
-        }
-        application
-      } as List<Map>
-    } catch (e) {
-      log.error("Unable to fetch all applications, returning most recently cached version", e)
-    }
     return allApplicationsCache.get()
   }
 
@@ -263,7 +239,7 @@ class ApplicationService {
       HystrixFactory.newListCommand(GROUP, "getApplicationsFromFront50", {
         AuthenticatedRequest.propagate({
           try {
-            return front50.getAllApplications()
+            return front50.getAllApplicationsUnrestricted()
           } catch (RetrofitError e) {
             if (e.response?.status == 404) {
               return []

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -27,8 +27,8 @@ interface Front50Service {
   //
   // Application-related
   //
-  @GET('/v2/applications')
-  List<Map> getAllApplications()
+  @GET('/v2/applications?restricted=false')
+  List<Map> getAllApplicationsUnrestricted()
 
   @GET('/v2/applications/{applicationName}')
   Map getApplication(@Path('applicationName') String applicationName)

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -189,28 +189,18 @@ class ApplicationServiceSpec extends Specification {
     def front50App = [name: name.toLowerCase(), email: email]
 
     when:
+    service.refreshApplicationsCache()
     def apps = service.getAllApplications()
 
     then:
-    1 * clouddriver.getApplications(false) >> [clouddriverApp]
-    1 * front50.getAllApplications() >> [front50App] >> { throw new SocketTimeoutException() }
+    1 * clouddriver.getApplications(true) >> [clouddriverApp]
+    1 * front50.getAllApplicationsUnrestricted() >> [front50App]
 
     1 == apps.size()
-    service.allApplicationsCache.set(apps)
     apps[0].email == email
     apps[0].name == name
     apps[0].clusters == null
-
-    when: "should return last known good values if an exception is thrown"
-    def allApps = service.getAllApplications()
-    def singleApp = service.getApplication(name, true)
-
-    then:
-    1 * front50.getApplication(name) >> { throw new SocketTimeoutException() }
-    1 * front50.getAllApplications() >> { throw new SocketTimeoutException() }
-
-    1 == allApps.size()
-    singleApp.name == allApps[0].name
+    apps[0].accounts == "prod"
 
     where:
     name = "foo"


### PR DESCRIPTION
A revised take on spinnaker/gate#603 that applies a `@PostFilter`
authorization check.

Depends on spinnaker/front50#375
