### PR TITLE
feat(swabbie): html endpoints for optOut and restore

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
@@ -20,9 +20,37 @@ public class CleanupController {
   }
 
   @ApiOperation(value = "Opt out of clean up for a marked resource.", response = HashMap.class)
-  @RequestMapping(method = RequestMethod.PUT, value = "/resources/{namespace}/{resourceId}/optOut")
-  Map optOut(@PathVariable String namespace,
+  @RequestMapping(method = RequestMethod.PUT,
+                  value = "/resources/{namespace}/{resourceId}/optOut",
+                  produces= "text/html")
+  String optOut(@PathVariable String namespace,
              @PathVariable String resourceId) {
-    return cleanupService.optOut(namespace, resourceId);
+    Map markedResource = cleanupService.optOut(namespace, resourceId);
+    if (markedResource.isEmpty()) {
+      return getHtmlWithMessage(namespace, resourceId, "Resource does not exist. Please try a valid resource.");
+    }
+
+    return getHtmlWithMessage(namespace, resourceId, "Resource has been restored, and opted out of future deletion!");
+  }
+
+  @ApiOperation(value = "Restore a resource that has been soft deleted.", response = HashMap.class)
+  @RequestMapping(method = RequestMethod.PUT,
+                  value = "/resources/{namespace}/{resourceId}/restore",
+                  produces= "text/html")
+  String restore(@PathVariable String namespace,
+             @PathVariable String resourceId) {
+    String status = cleanupService.restore(namespace, resourceId);
+    if (status.equals("404")) {
+      return getHtmlWithMessage(namespace, resourceId, "Resource does not exist. Please try a valid resource.");
+    }
+
+    return getHtmlWithMessage(namespace, resourceId, "Resource has been opted out!");
+  }
+
+  private String getHtmlWithMessage(String namespace, String resourceId, String message) {
+    return "<body>\n" +
+      "Swabbie Resource: [namespace=" + namespace + ", resourceId=" + resourceId + "] \n" +
+      "Message: " + message + "\n" +
+      "</body>";
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.gate.services.CleanupService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import retrofit.http.Query;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +25,7 @@ public class CleanupController {
                   value = "/resources/{namespace}/{resourceId}/optOut",
                   produces= "text/html")
   String optOut(@PathVariable String namespace,
-             @PathVariable String resourceId) {
+                @PathVariable String resourceId) {
     Map markedResource = cleanupService.optOut(namespace, resourceId);
     if (markedResource.isEmpty()) {
       return getHtmlWithMessage(namespace, resourceId, "Resource does not exist. Please try a valid resource.");
@@ -33,12 +34,21 @@ public class CleanupController {
     return getHtmlWithMessage(namespace, resourceId, "Resource has been restored, and opted out of future deletion!");
   }
 
-  @ApiOperation(value = "Restore a resource that has been soft deleted.", response = HashMap.class)
+  @ApiOperation(value = "Get information about a marked resource.", response = String.class)
   @RequestMapping(method = RequestMethod.PUT,
-                  value = "/resources/{namespace}/{resourceId}/restore",
-                  produces= "text/html")
-  String restore(@PathVariable String namespace,
-             @PathVariable String resourceId) {
+    value = "/resources/{namespace}/{resourceId}")
+  Map getMarkedResource(@PathVariable String namespace,
+                        @PathVariable String resourceId) {
+    Map markedResource = cleanupService.get(namespace, resourceId);
+    return markedResource;
+  }
+
+  // todo eb: expose once AWS gives us soft delete
+//  @ApiOperation(value = "Restore a resource that has been soft deleted.", response = HashMap.class)
+//  @RequestMapping(method = RequestMethod.PUT,
+//                  value = "/resources/{namespace}/{resourceId}/restore",
+//                  produces= "text/html")
+  String restore(String namespace, String resourceId) {
     String status = cleanupService.restore(namespace, resourceId);
     if (status.equals("404")) {
       return getHtmlWithMessage(namespace, resourceId, "Resource does not exist. Please try a valid resource.");
@@ -49,7 +59,7 @@ public class CleanupController {
 
   private String getHtmlWithMessage(String namespace, String resourceId, String message) {
     return "<body>\n" +
-      "Swabbie Resource: [namespace=" + namespace + ", resourceId=" + resourceId + "] \n" +
+      "Swabbie Resource: [namespace=" + namespace + ", resourceId=" + resourceId + "] <br>\n" +
       "Message: " + message + "\n" +
       "</body>";
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
@@ -20,7 +20,9 @@ import com.netflix.spinnaker.gate.services.commands.HystrixFactory;
 import com.netflix.spinnaker.gate.services.internal.SwabbieService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import retrofit.RetrofitError;
 
+import java.util.Collections;
 import java.util.Map;
 
 @Component
@@ -32,7 +34,27 @@ public class CleanupService {
 
   public Map optOut(String namespace, String resourceId) {
     return (Map) HystrixFactory.newMapCommand(GROUP, "optOut", () -> {
-      return swabbieService.optOut(namespace, resourceId, "");
+      try {
+        return swabbieService.optOut(namespace, resourceId, "");
+      } catch (RetrofitError e) {
+        if (e.getResponse().getStatus() == 404) {
+          return Collections.emptyMap();
+        } else {
+          throw e;
+        }
+      }
     }).execute();
+  }
+
+  public String restore(String namespace, String resourceId) {
+    HystrixFactory.newStringCommand(GROUP, "restore", () -> {
+      try {
+        swabbieService.restore(namespace, resourceId, "");
+      } catch (RetrofitError e) {
+        return Integer.toString(e.getResponse().getStatus());
+      }
+      return "200";
+     }).execute();
+    return "200";
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
@@ -46,6 +46,20 @@ public class CleanupService {
     }).execute();
   }
 
+  public Map get(String namespace, String resourceId) {
+    return (Map) HystrixFactory.newMapCommand(GROUP, "get", () -> {
+      try {
+        return swabbieService.get(namespace, resourceId);
+      } catch (RetrofitError e) {
+        if (e.getResponse().getStatus() == 404) {
+          return Collections.emptyMap();
+        } else {
+          throw e;
+        }
+      }
+    }).execute();
+  }
+
   public String restore(String namespace, String resourceId) {
     HystrixFactory.newStringCommand(GROUP, "restore", () -> {
       try {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
@@ -29,4 +29,12 @@ public interface SwabbieService {
   Map optOut(@Path("namespace") String namespace,
              @Path("resourceId") String resourceId,
              @Body String ignored);
+
+  @Headers("Accept: application/json")
+  @PUT("/resources/state/{namespace}/{resourceId}/restore")
+  void restore(@Path("namespace") String namespace,
+               @Path("resourceId") String resourceId,
+               @Body String ignored);
+
+  // todo eb: add method to get the state of a resource by namespace/resourceId
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
@@ -16,10 +16,7 @@
 
 package com.netflix.spinnaker.gate.services.internal;
 
-import retrofit.http.Body;
-import retrofit.http.Headers;
-import retrofit.http.PUT;
-import retrofit.http.Path;
+import retrofit.http.*;
 
 import java.util.Map;
 
@@ -36,5 +33,8 @@ public interface SwabbieService {
                @Path("resourceId") String resourceId,
                @Body String ignored);
 
-  // todo eb: add method to get the state of a resource by namespace/resourceId
+  @Headers("Accept: application/json")
+  @GET("/resources/marked/{namespace}/{resourceId}")
+  Map get(@Path("namespace") String namespace,
+          @Path("resourceId") String resourceId);
 }


### PR DESCRIPTION
Adding an html response for opt out.
Adding an endpoint for getting a resource.
Adding the framework for a restore endpoint, but holding off on exposing it until aws gives us soft delete. If that won't happen, I'll remove the endpoint.