### PR TITLE
refactor(auth): Move multi-auth support to a common interface

### DIFF
--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/MultiAuthConfigurer.java
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/MultiAuthConfigurer.java
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.gate.security.iap;
+package com.netflix.spinnaker.gate.security;
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
-public interface IAPSsoConfigurer {
+/**
+ * Allows configuring multiple authentication mechanisms e.g. X509 + SAML
+ *
+ */
+public interface MultiAuthConfigurer {
   void configure(HttpSecurity http) throws Exception;
 }

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/SuppportsMultiAuth.java
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/SuppportsMultiAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Netflix, Inc.
+ * Copyright 2018 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.gate.security.saml
+package com.netflix.spinnaker.gate.security;
 
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-/**
- * Allows the use of additional authentication mechanisms to be tried before the SAML login.
- */
-interface SamlSsoConfigurer {
-
-  void configure(HttpSecurity http) throws Exception
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SuppportsMultiAuth {
 }

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.gate.security.iap;
 
 import com.google.common.base.Preconditions;
 import com.netflix.spinnaker.gate.config.AuthConfig;
+import com.netflix.spinnaker.gate.security.MultiAuthConfigurer;
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig;
+import com.netflix.spinnaker.gate.security.SuppportsMultiAuth;
 import com.netflix.spinnaker.gate.security.iap.IAPSsoConfig.IAPSecurityConfigProperties;
 import com.netflix.spinnaker.gate.services.PermissionService;
 import com.netflix.spinnaker.gate.services.internal.Front50Service;
@@ -49,6 +51,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 @SpinnakerAuthConfig
 @EnableWebSecurity
 @ConditionalOnExpression("${google.iap.enabled:false}")
+@SuppportsMultiAuth
 @EnableConfigurationProperties(IAPSecurityConfigProperties.class)
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class IAPSsoConfig extends WebSecurityConfigurerAdapter {
@@ -79,7 +82,7 @@ public class IAPSsoConfig extends WebSecurityConfigurerAdapter {
   }
 
   @Autowired(required = false)
-  List<IAPSsoConfigurer> configurers;
+  List<MultiAuthConfigurer> additionalAuthProviders;
 
   @ConfigurationProperties("google.iap")
   @Data
@@ -104,9 +107,9 @@ public class IAPSsoConfig extends WebSecurityConfigurerAdapter {
     authConfig.configure(http);
     http.addFilterBefore(iapAuthenticationFilter(), BasicAuthenticationFilter.class);
 
-    if (configurers != null) {
-      for (IAPSsoConfigurer configurer : configurers) {
-        configurer.configure(http);
+    if (additionalAuthProviders != null) {
+      for (MultiAuthConfigurer provider : additionalAuthProviders) {
+        provider.configure(http);
       }
     }
   }

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.gate.security.ldap
 
+import com.netflix.spinnaker.gate.security.MultiAuthConfigurer
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.config.AuthConfig
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
+import com.netflix.spinnaker.gate.security.SuppportsMultiAuth
 import com.netflix.spinnaker.gate.services.PermissionService
 import com.netflix.spinnaker.security.User
 import org.apache.commons.lang3.StringUtils
@@ -44,6 +46,7 @@ import org.springframework.stereotype.Component
 @Configuration
 @SpinnakerAuthConfig
 @EnableWebSecurity
+@SuppportsMultiAuth
 @Order(Ordered.LOWEST_PRECEDENCE)
 class LdapSsoConfig extends WebSecurityConfigurerAdapter {
 
@@ -57,7 +60,7 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
   LdapUserContextMapper ldapUserContextMapper
 
   @Autowired(required = false)
-  List<LdapSsoConfigurer> configurers
+  List<MultiAuthConfigurer> additionalAuthProviders
 
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
@@ -89,9 +92,9 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http.formLogin()
     authConfig.configure(http)
-      configurers?.each {
-          it.configure(http)
-      }
+    additionalAuthProviders?.each {
+      it.configure(http)
+    }
   }
 
   @Override

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfigurer.groovy
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfigurer.groovy
@@ -1,7 +1,0 @@
-package com.netflix.spinnaker.gate.security.ldap
-
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-
-interface LdapSsoConfigurer {
-    void configure(HttpSecurity http) throws Exception
-}

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -17,7 +17,9 @@
 package com.netflix.spinnaker.gate.security.oauth2
 
 import com.netflix.spinnaker.gate.config.AuthConfig
+import com.netflix.spinnaker.gate.security.MultiAuthConfigurer
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
+import com.netflix.spinnaker.gate.security.SuppportsMultiAuth
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration
@@ -51,6 +53,7 @@ import javax.servlet.http.HttpServletResponse
 @Import(SecurityAutoConfiguration)
 @EnableOAuth2Sso
 @EnableConfigurationProperties
+@SuppportsMultiAuth
 @Order(Ordered.LOWEST_PRECEDENCE)
 // Note the 4 single-quotes below - this is a raw groovy string, because SpEL and groovy
 // string syntax overlap!
@@ -67,7 +70,7 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
   ExternalSslAwareEntryPoint entryPoint
 
   @Autowired(required = false)
-  List<OAuthSsoConfigurer> configurers
+  List<MultiAuthConfigurer> additionalAuthProviders
 
   @Primary
   @Bean
@@ -92,7 +95,7 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
     http.exceptionHandling().authenticationEntryPoint(entryPoint)
     http.addFilterBefore(externalAuthTokenFilter, AbstractPreAuthenticatedProcessingFilter.class)
 
-    configurers?.each {
+    additionalAuthProviders?.each {
       it.configure(http)
     }
   }

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuthSsoConfigurer.groovy
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuthSsoConfigurer.groovy
@@ -1,7 +1,0 @@
-package com.netflix.spinnaker.gate.security.oauth2;
-
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-
-interface OAuthSsoConfigurer {
-  void configure(HttpSecurity http) throws Exception
-}

--- a/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-security/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.gate.security.saml
 
+import com.netflix.spinnaker.gate.security.MultiAuthConfigurer
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.config.AuthConfig
 import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig
+import com.netflix.spinnaker.gate.security.SuppportsMultiAuth
 import com.netflix.spinnaker.gate.services.PermissionService
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.security.User
@@ -60,6 +62,7 @@ import static org.springframework.security.extensions.saml2.config.SAMLConfigure
 @SpinnakerAuthConfig
 @EnableWebSecurity
 @Import(SecurityAutoConfiguration)
+@SuppportsMultiAuth
 @Slf4j
 @Order(Ordered.LOWEST_PRECEDENCE)
 class SamlSsoConfig extends WebSecurityConfigurerAdapter {
@@ -130,7 +133,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
   SAMLUserDetailsService samlUserDetailsService
 
   @Autowired(required = false)
-  List<SamlSsoConfigurer> configurers
+  List<MultiAuthConfigurer> additionalAuthProviders
 
   @Override
   void configure(HttpSecurity http) {
@@ -165,7 +168,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
     // (if enabled) auth window might appear in the browser before the SAML filter is hit.
     authConfig.configure(http)
 
-    configurers?.each {
+    additionalAuthProviders?.each {
       it.configure(http)
     }
   }


### PR DESCRIPTION
This avoids having the X509 provider depend on all the other ones. Simplifies the refactor of each auth provider into its own package.

Part of spinnaker/spinnaker#3498