### PR TITLE
fix(iap/basicauth): Configure the BasicAuth auth manager for IAP.

### DIFF
--- a/gate-iap/src/main/java/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilter.java
+++ b/gate-iap/src/main/java/com/netflix/spinnaker/gate/security/iap/IAPAuthenticationFilter.java
@@ -136,7 +136,7 @@ public class IAPAuthenticationFilter extends OncePerRequestFilter {
       }
       return false;
     } catch (RetrofitError re) {
-      logger.warn("Could not get list of service accounts.", re);
+      log.warn("Could not get list of service accounts.", re);
     }
     return false;
   }
@@ -195,7 +195,7 @@ public class IAPAuthenticationFilter extends OncePerRequestFilter {
    */
   @Scheduled(fixedDelay = 18000000L)
   void clearKeyCache() {
-    logger.debug("Clearing IAP public key cache.");
+    log.debug("Clearing IAP public key cache.");
     keyCache.clear();
   }
 }

--- a/gate-iap/src/main/java/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
+++ b/gate-iap/src/main/java/com/netflix/spinnaker/gate/security/iap/IAPSsoConfig.java
@@ -26,15 +26,16 @@ import com.netflix.spinnaker.gate.services.PermissionService;
 import com.netflix.spinnaker.gate.services.internal.Front50Service;
 import java.util.List;
 import lombok.Data;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -47,10 +48,12 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
  * This Web Security configuration supports the Google Cloud Identity-Aware Proxy authentication
  * model.
  */
+@Slf4j
 @Configuration
 @SpinnakerAuthConfig
 @EnableWebSecurity
 @ConditionalOnExpression("${google.iap.enabled:false}")
+@Import(SecurityAutoConfiguration.class)
 @SuppportsMultiAuth
 @EnableConfigurationProperties(IAPSecurityConfigProperties.class)
 @Order(Ordered.LOWEST_PRECEDENCE)
@@ -94,11 +97,9 @@ public class IAPSsoConfig extends WebSecurityConfigurerAdapter {
     String iapVerifyKeyUrl = "https://www.gstatic.com/iap/verify/public_key-jwk";
   }
 
-  private final Logger logger = LoggerFactory.getLogger(IAPSsoConfig.class);
-
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    logger.info("IAP JWT token verification is enabled.");
+    log.info("IAP JWT token verification is enabled.");
 
     Preconditions.checkNotNull(configProperties.getAudience(), "Please set the "
       + "Audience field. You can retrieve this field from the IAP console: "


### PR DESCRIPTION
This fix allows the http basic auth flow to work. You can configure the basic auth in the gate config:

```
security:
  basic:
    enabled: true
  user:
    name: stew
    password: chen
```