### PR TITLE
feat(clean): expose list of marked and deleted

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CleanupController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -19,7 +20,7 @@ public class CleanupController {
     this.cleanupService = cleanupService;
   }
 
-  @ApiOperation(value = "Opt out of clean up for a marked resource.", response = String.class)
+  @ApiOperation(value = "Opt out of clean up for a marked resource.", response = Map.class)
   @RequestMapping(method = RequestMethod.GET,
                   value = "/resources/{namespace}/{resourceId}/optOut",
                   produces = "application/json")
@@ -33,10 +34,10 @@ public class CleanupController {
     return getJsonWithMessage(namespace, resourceId, "Resource has been restored, and opted out of future deletion!");
   }
 
-  @ApiOperation(value = "Get information about a marked resource.", response = String.class)
+  @ApiOperation(value = "Get information about a marked resource.", response = Map.class)
   @RequestMapping(method = RequestMethod.GET,
-                  value = "/resources/{namespace}/{resourceId}",
-                  produces = "application/json")
+    value = "/resources/{namespace}/{resourceId}",
+    produces = "application/json")
   Map getMarkedResource(@PathVariable String namespace,
                         @PathVariable String resourceId) {
     Map markedResource = cleanupService.get(namespace, resourceId);
@@ -46,18 +47,16 @@ public class CleanupController {
     return markedResource;
   }
 
-  // todo eb: expose once AWS gives us soft delete
-//  @ApiOperation(value = "Restore a resource that has been soft deleted.", response = HashMap.class)
-//  @RequestMapping(method = RequestMethod.PUT,
-//                  value = "/resources/{namespace}/{resourceId}/restore",
-//                  produces= "text/html")
-  Map restore(String namespace, String resourceId) {
-    String status = cleanupService.restore(namespace, resourceId);
-    if (status.equals("404")) {
-      return getJsonWithMessage(namespace, resourceId, "Resource does not exist. Please try a valid resource.");
-    }
+  @ApiOperation(value = "Get all marked resources.", response = List.class)
+  @RequestMapping(method = RequestMethod.GET, value = "/resources/marked", produces = "application/json")
+  List getAllMarkedResources() {
+    return cleanupService.getMarkedList();
+  }
 
-    return getJsonWithMessage(namespace, resourceId, "Resource has been opted out!");
+  @ApiOperation(value = "Get all deleted resources.", response = List.class)
+  @RequestMapping(method = RequestMethod.GET, value = "/resources/deleted", produces = "application/json")
+  List getAllDeletedResources() {
+    return cleanupService.getDeletedList();
   }
 
   private Map<String, String> getJsonWithMessage(String namespace, String resourceId, String message) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 import retrofit.RetrofitError;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -70,5 +71,13 @@ public class CleanupService {
       return "200";
      }).execute();
     return "200";
+  }
+
+  public List getMarkedList() {
+    return (List) HystrixFactory.newListCommand(GROUP, "get", () -> swabbieService.getMarkedList(true)).execute();
+  }
+
+  public List getDeletedList() {
+    return (List) HystrixFactory.newListCommand(GROUP, "get", () -> swabbieService.getDeletedList()).execute();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/SwabbieService.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.services.internal;
 
 import retrofit.http.*;
 
+import java.util.List;
 import java.util.Map;
 
 public interface SwabbieService {
@@ -37,4 +38,12 @@ public interface SwabbieService {
   @GET("/resources/marked/{namespace}/{resourceId}")
   Map get(@Path("namespace") String namespace,
           @Path("resourceId") String resourceId);
+
+  @Headers("Accept: application/json")
+  @GET("/resources/marked")
+  List getMarkedList(@Query("list") Boolean list);
+
+  @Headers("Accept: application/json")
+  @GET("/resources/deleted")
+  List getDeletedList();
 }


### PR DESCRIPTION
Exposing lists of marked and deleted resources through gate.

Each list is of the form 
```json
[{
"name": "thename",
"namespace": "aws:account:region:image",
"resourceId": "ami-000"
}]
```