### PR TITLE
fix(fiat/roles/sync): Fix exception in roles/sync

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -93,7 +93,7 @@ class PermissionService {
     if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "sync") {
         try {
-          fiatService.sync()
+          fiatService.sync(new ArrayList())
         } catch (RetrofitError e) {
           throw classifyError(e)
         }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/PermissionService.groovy
@@ -93,7 +93,7 @@ class PermissionService {
     if (fiatStatus.isEnabled()) {
       HystrixFactory.newVoidCommand(HYSTRIX_GROUP, "sync") {
         try {
-          fiatService.sync(new ArrayList())
+          fiatService.sync(Collections.emptyList())
         } catch (RetrofitError e) {
           throw classifyError(e)
         }


### PR DESCRIPTION
Retrofit does not support empty body requests.

This is a small change just to make syncs called from gate to work.

```
2018-11-16 13:22:13.300 ERROR 1765 --- [.0-8084-exec-12] c.n.s.g.s.c.AbstractHystrixCommand       : Downstream exception encountered (group: 'permission', command: 'sync')
retrofit.RetrofitError: method POST must have a request body.
	at retrofit.RetrofitError.unexpectedError(RetrofitError.java:44) ~[retrofit-1.9.0.jar:na]
	at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:400) ~[retrofit-1.9.0.jar:na]
	at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:240) ~[retrofit-1.9.0.jar:na]
	at com.sun.proxy.$Proxy98.sync(Unknown Source) ~[na:na]
	at com.netflix.spinnaker.fiat.shared.FiatService$sync$0.call(Unknown Source) ~[na:na]
	at com.netflix.spinnaker.gate.services.PermissionService$_sync_closure4.doCall(PermissionService.groovy:96) ~[gate-core-4.49.0.jar:4.49.0]
	at com.netflix.spinnaker.gate.services.PermissionService$_sync_closure4.doCall(PermissionService.groovy) ~[gate-core-4.49.0.jar:4.49.0]
	at sun.reflect.GeneratedMethodAccessor532.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_191]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_191]
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325) ~[groovy-all-2.4.13.jar:2.4.13]
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1022) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.Closure.call(Closure.java:414) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.Closure.call(Closure.java:408) ~[groovy-all-2.4.13.jar:2.4.13]
	at com.netflix.spinnaker.security.AuthenticatedRequest.lambda$propagate$0(AuthenticatedRequest.java:97) ~[kork-security-3.1.0.jar:3.1.0]
	at com.netflix.spinnaker.gate.services.commands.AbstractHystrixCommand.run(AbstractHystrixCommand.groovy:57) ~[gate-core-4.49.0.jar:4.49.0]
	at com.netflix.hystrix.HystrixCommand$1.call(HystrixCommand.java:294) ~[hystrix-core-1.4.20.jar:1.4.20]
	at com.netflix.hystrix.HystrixCommand$1.call(HystrixCommand.java:289) ~[hystrix-core-1.4.20.jar:1.4.20]
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.Observable.unsafeSubscribe(Observable.java:10327) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:41) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OnSubscribeDoOnEach.call(OnSubscribeDoOnEach.java:30) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.Observable.unsafeSubscribe(Observable.java:10327) ~[rxjava-1.3.8.jar:1.3.8]
	at com.netflix.hystrix.AbstractCommand$5.call(AbstractCommand.java:520) ~[hystrix-core-1.4.20.jar:1.4.20]
	at com.netflix.hystrix.AbstractCommand$5.call(AbstractCommand.java:495) ~[hystrix-core-1.4.20.jar:1.4.20]
	at rx.Observable.unsafeSubscribe(Observable.java:10327) ~[rxjava-1.3.8.jar:1.3.8]
	at rx.internal.operators.OperatorSubscribeOn$SubscribeOnSubscriber.call(OperatorSubscribeOn.java:100) ~[rxjava-1.3.8.jar:1.3.8]
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction$1.call(HystrixContexSchedulerAction.java:56) ~[hystrix-core-1.4.20.jar:1.4.20]
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction$1.call(HystrixContexSchedulerAction.java:47) ~[hystrix-core-1.4.20.jar:1.4.20]
	at com.netflix.hystrix.strategy.concurrency.HystrixContexSchedulerAction.call(HystrixContexSchedulerAction.java:69) ~[hystrix-core-1.4.20.jar:1.4.20]
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55) ~[rxjava-1.3.8.jar:1.3.8]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_191]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_191]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]
Caused by: java.lang.IllegalArgumentException: method POST must have a request body.
	at com.squareup.okhttp.Request$Builder.method(Request.java:259) ~[okhttp-2.7.0.jar:na]
	at retrofit.client.OkClient.createRequest(OkClient.java:59) ~[retrofit-1.9.0.jar:na]
	at retrofit.client.OkClient.execute(OkClient.java:53) ~[retrofit-1.9.0.jar:na]
	at com.netflix.spinnaker.gate.retrofit.EurekaOkClient.super$2$execute(EurekaOkClient.groovy) ~[gate-core-4.49.0.jar:4.49.0]
	at sun.reflect.GeneratedMethodAccessor184.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_191]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_191]
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325) ~[groovy-all-2.4.13.jar:2.4.13]
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1213) ~[groovy-all-2.4.13.jar:2.4.13]
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnSuperN(ScriptBytecodeAdapter.java:132) ~[groovy-all-2.4.13.jar:2.4.13]
	at com.netflix.spinnaker.gate.retrofit.EurekaOkClient.execute(EurekaOkClient.groovy:82) ~[gate-core-4.49.0.jar:4.49.0]
	at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:326) ~[retrofit-1.9.0.jar:na]
	... 39 common frames omitted
```
