### PR TITLE
fix(core): Add type parameter to ListCommand

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/HystrixFactory.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/commands/HystrixFactory.groovy
@@ -30,10 +30,10 @@ class HystrixFactory {
     HystrixCommandGroupKey.Factory.asKey(name)
   }
 
-  public static <T> ListCommand newListCommand(String groupKey,
-                                           String commandKey,
-                                           Callable<List<T>> work,
-                                           Callable<List<T>> fallback = { null }) {
+  public static <T> ListCommand<T> newListCommand(String groupKey,
+                                                  String commandKey,
+                                                  Callable<List<T>> work,
+                                                  Callable<List<T>> fallback = { null }) {
     new ListCommand(groupKey, commandKey, propagate(work, false), fallback)
   }
 


### PR DESCRIPTION
The HystrixFactory newListCommand function returns an unqualified ListCommand instead of a typed ListCommand<T>, which is causing downstream unchecked cast exceptions.