### PR TITLE
Added username mapping to Azure OAuth config

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -142,6 +142,7 @@ security:
     resource:
       userInfoUri: https://graph.windows.net/me?api-version=1.6
     userInfoMapping:
+      username: userPrincipalName
       email: userPrincipalName
       firstName: givenName
       lastName: surname


### PR DESCRIPTION
**Problem**
When enabling file based authz and having Azure as OAuth provider enabled, this [line of code](https://github.com/spinnaker/gate/blob/master/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy#L99) tries to use the unset variable `username`. This results in a 500 from Spin Deck and the following log entry in Spin Gate `java.lang.IllegalArgumentException: Path parameter "userId" value must not be null`.

There are others having the same issue: https://github.com/spinnaker/spinnaker/issues/2565

**Temporary fix** 
To fix the issue the following gate-local.yml has to be provided.
```
security:
  oauth2:
    userInfoMapping:
      username: userPrincipalName
```

**Proposed solution**
Fix default mapping rules, as suggested by this PR.