### PR TITLE
feat(dev): provide ad-hoc response code endpoint for testing

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DevController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DevController.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/dev")
+public class DevController {
+
+  @RequestMapping(value = "/statusCode/{statusCode}")
+  public ResponseEntity errorCode(@PathVariable String statusCode) {
+    HttpStatus status = HttpStatus.valueOf(Integer.parseInt(statusCode));
+    return ResponseEntity.status(status).body(status.getReasonPhrase());
+  }
+}


### PR DESCRIPTION
Allows a developer to get a specific type of response, e.g. 429, without throttling themselves...