### PR TITLE
chore(API): Removes 'responseContainer' in favor of Lists in swagger …

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -98,7 +98,7 @@ class ApplicationController {
     result
   }
 
-  @ApiOperation(value = "Retrieve a list of an application's configuration revision history", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of an application's configuration revision history", response = List.class)
   @RequestMapping(value = "/{application}/history", method = RequestMethod.GET)
   List<Map> getApplicationHistory(@PathVariable("application") String application,
                                   @RequestParam(value = "limit", defaultValue = "20") int limit) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
@@ -38,7 +38,7 @@ public class ArtifactController {
   @Autowired
   private ArtifactService artifactService;
 
-  @ApiOperation(value = "Retrieve the list of artifact accounts configured in Clouddriver.", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve the list of artifact accounts configured in Clouddriver.", response = List.class)
   @RequestMapping(method = RequestMethod.GET, value = "/credentials")
   List<Map> all(@RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     return artifactService.getArtifactCredentials(sourceApp);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ClusterController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ClusterController.groovy
@@ -42,7 +42,7 @@ class ClusterController {
     clusterService.getClusters(app, sourceApp)
   }
 
-  @ApiOperation(value = "Retrieve a list of clusters for an account", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of clusters for an account", response = List.class)
   @RequestMapping(value = "/{account}", method = RequestMethod.GET)
   List<Map> getClusters(@PathVariable("application") String app,
                         @PathVariable("account") String account,
@@ -69,7 +69,7 @@ class ClusterController {
     loadBalancerService.getClusterLoadBalancers(applicationName, account, type, clusterName, sourceApp)
   }
 
-  @ApiOperation(value = "Retrieve a list of server groups for a cluster", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of server groups for a cluster", response = List.class)
   @RequestMapping(value = "/{account}/{clusterName}/serverGroups", method = RequestMethod.GET)
   List<Map> getServerGroups(@PathVariable("application") String app,
                             @PathVariable("account") String account,
@@ -78,7 +78,7 @@ class ClusterController {
     clusterService.getClusterServerGroups(app, account, clusterName, sourceApp)
   }
 
-  @ApiOperation(value = "Retrieve a list of scaling activities for a server group", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of scaling activities for a server group", response = List.class)
   @RequestMapping(value = "/{account}/{clusterName}/serverGroups/{serverGroupName}/scalingActivities", method = RequestMethod.GET)
   List<Map> getScalingActivities(@PathVariable("application") String app,
                                  @PathVariable("account") String account,
@@ -91,7 +91,7 @@ class ClusterController {
   }
 
   @CompileStatic(TypeCheckingMode.SKIP)
-  @ApiOperation(value = "Retrieve a server group's details", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a server group's details", response = List.class)
   @RequestMapping(value = "/{account}/{clusterName}/serverGroups/{serverGroupName:.+}", method = RequestMethod.GET)
   List<Map> getServerGroups(@PathVariable("application") String app,
                             @PathVariable("account") String account,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ImageController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ImageController.groovy
@@ -30,7 +30,7 @@ class ImageController {
   @Autowired
   ImageService imageService
 
-  @ApiOperation(value = "Get image details", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get image details", response = List.class)
   @RequestMapping(value = "/{account}/{region}/{imageId:.+}", method = RequestMethod.GET)
   List<Map> getImageDetails(@PathVariable(value = "account") String account,
                             @PathVariable(value = "region") String region,
@@ -42,8 +42,7 @@ class ImageController {
 
   @ApiOperation(value = "Retrieve a list of images, filtered by cloud provider, region, and account",
                 notes = "The query parameter `q` filters the list of images by image name",
-                response = HashMap.class,
-                responseContainer = "List")
+                response = List.class)
   @RequestMapping(value = "/find", method = RequestMethod.GET)
   List<Map> findImages(@RequestParam(value = "provider", defaultValue = "aws", required = false) String provider,
                        @RequestParam(value = "q", required = false) String query,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoadBalancerController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoadBalancerController.groovy
@@ -45,8 +45,7 @@ class LoadBalancerController {
   }
 
   @ApiOperation(value = "Retrieve a load balancer's details as a single element list for a given account, region, cloud provider and load balancer name",
-                response = HashMap.class,
-                responseContainer = "List")
+                response = List.class)
   @RequestMapping(value = "/loadBalancers/{account}/{region}/{name:.+}", method = RequestMethod.GET)
   List<Map> getLoadBalancerDetails(@PathVariable String account,
                                    @PathVariable String region,
@@ -57,8 +56,7 @@ class LoadBalancerController {
   }
 
   @ApiOperation(value = "Retrieve a list of load balancers for a given application",
-                response = HashMap.class,
-                responseContainer = "List")
+                response = List.class)
   @RequestMapping(value = '/applications/{application}/loadBalancers', method = RequestMethod.GET)
   List<Map> getApplicationLoadBalancers(@PathVariable String application,
                                         @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NetworkController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NetworkController.groovy
@@ -38,7 +38,7 @@ class NetworkController {
     networkService.getNetworks(sourceApp)
   }
 
-  @ApiOperation(value = "Retrieve a list of networks for a given cloud provider", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of networks for a given cloud provider", response = List.class)
   @RequestMapping(value = "/{cloudProvider}", method = RequestMethod.GET)
   List<Map> allByCloudProvider(@PathVariable String cloudProvider,
                                @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineConfigController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineConfigController.groovy
@@ -41,7 +41,7 @@ class PipelineConfigController {
   @Autowired
   OrcaServiceSelector orcaServiceSelector
 
-  @ApiOperation(value = "Get all pipeline configs.", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get all pipeline configs.", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
   Collection<Map> getAllPipelineConfigs() {
     return HystrixFactory.newListCommand(HYSTRIX_GROUP, "getAllPipelineConfigs") {
@@ -49,7 +49,7 @@ class PipelineConfigController {
     }.execute()
   }
 
-  @ApiOperation(value = "Get pipeline config history.", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get pipeline config history.", response = List.class)
   @RequestMapping(value = "/{pipelineConfigId}/history", method = RequestMethod.GET)
   Collection<Map> getPipelineConfigHistory(@PathVariable("pipelineConfigId") String pipelineConfigId,
                                            @RequestParam(value = "limit", defaultValue = "20") int limit) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -137,7 +137,7 @@ class PipelineController {
     return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"), true)?.find { id == (String) it.get("id") }
   }
 
-  @ApiOperation(value = "Retrieve pipeline execution logs", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve pipeline execution logs", response = List.class)
   @RequestMapping(value = "{id}/logs", method = RequestMethod.GET)
   List<Map> getPipelineLogs(@PathVariable("id") String id) {
     try {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineTemplatesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineTemplatesController.java
@@ -60,7 +60,7 @@ public class PipelineTemplatesController {
     this.objectMapper = objectMapper;
   }
 
-  @ApiOperation(value = "List pipeline templates.", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "List pipeline templates.", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
   public Collection<Map> list(@RequestParam(required = false) List<String> scopes) {
     return pipelineTemplateService.findByScope(scopes);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ProjectController.groovy
@@ -42,14 +42,14 @@ class ProjectController {
     return projectService.get(projectId)
   }
 
-  @ApiOperation(value = "Get a project's clusters", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get a project's clusters", response = List.class)
   @RequestMapping(value = "/{id}/clusters", method = RequestMethod.GET)
   List<Map> getClusters(@PathVariable("id") String projectId,
                         @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     return projectService.getClusters(projectId, sourceApp)
   }
 
-  @ApiOperation(value = "Get all pipelines for project", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get all pipelines for project", response = List.class)
   @RequestMapping(value = "/{id:.+}/pipelines", method = RequestMethod.GET)
   List<Map> allPipelinesForProject(@PathVariable("id") String projectId,
                                    @RequestParam(value = "limit", defaultValue = "5") int limit,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SearchController.groovy
@@ -29,7 +29,7 @@ class SearchController {
   @Autowired
   SearchService searchService
 
-  @ApiOperation(value = "Search infrastructure", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Search infrastructure", response = List.class)
   @RequestMapping(value = "/search", method = RequestMethod.GET)
   List<Map> search(@RequestParam(value = "q", defaultValue = "", required = false) String query,
                    @RequestParam(value = "type") String type,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupManagerController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ServerGroupManagerController.java
@@ -37,7 +37,7 @@ public class ServerGroupManagerController {
     this.serverGroupManagerService = serverGroupManagerService;
   }
 
-  @ApiOperation(value = "Retrieve a list of server group managers for an application", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of server group managers for an application", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
   public List<Map> getServerGroupManagersForApplication(@PathVariable String application) {
     return this.serverGroupManagerService.getServerGroupManagersForApplication(application);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SnapshotController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SnapshotController.groovy
@@ -39,7 +39,7 @@ class SnapshotController {
     snapshotService.getCurrent(application, account)
   }
 
-  @ApiOperation(value = "Get snapshot history", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get snapshot history", response = List.class)
   @RequestMapping(value = "/{application}/snapshots/{account}/history", method = RequestMethod.GET)
   List<Map> getSnapshotHistory(@PathVariable("application") String application,
                                @PathVariable("account") String account,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SubnetController.groovy
@@ -28,7 +28,7 @@ class SubnetController {
   @Autowired
   ClouddriverServiceSelector clouddriverServiceSelector
 
-  @ApiOperation(value = "Retrieve a list of subnets for a given cloud provider", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Retrieve a list of subnets for a given cloud provider", response = List.class)
   @RequestMapping(value = "/{cloudProvider}", method = RequestMethod.GET)
   List<Map> allByCloudProvider(@PathVariable String cloudProvider,
                                @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2PipelineTemplatesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2PipelineTemplatesController.java
@@ -69,8 +69,7 @@ public class V2PipelineTemplatesController {
     this.objectMapper = objectMapper;
   }
 
-  // TODO(jacobkiefer): Un-stub
-  @ApiOperation(value = "List pipeline templates.", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "List pipeline templates.", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
   public Collection<Map> list(@RequestParam(required = false) List<String> scopes) {
     return v2PipelineTemplateService.findByScope(scopes);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/aws/AmazonInfrastructureController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/aws/AmazonInfrastructureController.groovy
@@ -29,26 +29,26 @@ class AmazonInfrastructureController {
   @Autowired
   InfrastructureService infrastructureService
 
-  @ApiOperation(value = "Get instance types", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get instance types", response = List.class)
   @RequestMapping(value = "/instanceTypes", method = RequestMethod.GET)
   List<Map> instanceTypes() {
     infrastructureService.instanceTypes
   }
 
-  @ApiOperation(value = "Get key pairs", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get key pairs", response = List.class)
   @RequestMapping(value = "/keyPairs", method = RequestMethod.GET)
   List<Map> keyPairs() {
     infrastructureService.keyPairs
   }
 
-  @ApiOperation(value = "Get subnets", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get subnets", response = List.class)
   @RequestMapping(value = "/subnets", method = RequestMethod.GET)
   List<Map> subnets() {
     infrastructureService.subnets
   }
 
   @Deprecated
-  @ApiOperation(value = "Get VPCs", response = HashMap.class, responseContainer = "List")
+  @ApiOperation(value = "Get VPCs", response = List.class)
   @RequestMapping(value = "/vpcs", method = RequestMethod.GET)
   List<Map> vpcs() {
     infrastructureService.vpcs


### PR DESCRIPTION
…specs.

API client libraries generated via swagger-codegen (like spin CLI) receive a list container of empty dicts when the endpoint swagger specs are defined with responseContainers. The behavior is as expected (i.e. the values are present) when the responseContainers are swapped for normal list classes.