### PR TITLE
feat(provider/oauth): Load role information from OAuth provider if available

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -141,11 +141,15 @@ security:
       clientAuthenticationScheme: query
     resource:
       userInfoUri: https://graph.windows.net/me?api-version=1.6
+      userRoleInfoUri: https://graph.windows.net/me/getMemberGroups?api-version=1.6
+      userRoleInfoRequestPayload: "{securityEnabledOnly: true}"
     userInfoMapping:
       username: userPrincipalName
       email: userPrincipalName
       firstName: givenName
       lastName: surname
+    userRoleInfoMapping: value
+
 
 ---
 


### PR DESCRIPTION
OAuth provider provide endpoints to query user's roles. With this PR the application checks for a `userRoleInfoUri` configuration and queries it for roles, if `userRoleInfoUri` is set. The received groups get added to the Spinnaker user.

Additionally added default configuration for Azure.