### PR TITLE
Don't require Spinnaker credentials for Kayenta over https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
   apply plugin: 'groovy'
 
   ext {
-    spinnakerDependenciesVersion = '1.12.0'
+    spinnakerDependenciesVersion = '1.12.1'
     if (project.hasProperty('spinnakerDependenciesVersion')) {
       spinnakerDependenciesVersion = project.property('spinnakerDependenciesVersion')
     }


### PR DESCRIPTION
This change provides the option to remove the use of a Spinnaker key store for https communication with Kayenta.  It's controlled by a config setting, and must be explicitly enabled.  The default behavior is to use the standard configured keystore for Kayenta, just like all other internal Spinnaker services over https.