### PR TITLE
feat(halconfig): adds server config for proxies

### DIFF
--- a/halconfig/gate.yml
+++ b/halconfig/gate.yml
@@ -2,3 +2,10 @@
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
+
+server:
+  tomcat:
+    protocolHeader: X-Forwarded-Proto
+    remoteIpHeader: X-Forwarded-For
+    internalProxies: .*
+    httpsServerPort: X-Forwarded-Port


### PR DESCRIPTION
adds a `server` configuration for proxies by default. this is useful in
cases where you're terminating SSL at an external load balancer. without
this, Gate redirects you to HTTP even though incoming traffic is HTTPS.