### PR TITLE
Revert "feat(halconfig): adds server config for proxies"

### DIFF
--- a/halconfig/gate.yml
+++ b/halconfig/gate.yml
@@ -2,10 +2,3 @@
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
-
-server:
-  tomcat:
-    protocolHeader: X-Forwarded-Proto
-    remoteIpHeader: X-Forwarded-For
-    internalProxies: .*
-    httpsServerPort: X-Forwarded-Port


### PR DESCRIPTION
Reverts spinnaker/gate#700

This causes an issue with halyard where the `server` block is already being defined. Sample `gate.yml`


```
## WARNING
## This file was autogenerated, and _will_ be overwritten by Halyard.
## Any edits you make here _will_ be lost.

spectator:
  applicationName: ${spring.application.name}
  webEndpoint:
    enabled: true

server:
  ssl:
    enabled: false
  port: '8084'
  address: 0.0.0.0
security:
  basic:
    enabled: true
  user: {}
cors: {}
google: {}

# halconfig

redis:
  connection: ${services.redis.baseUrl:redis://localhost:6379}

server:
  tomcat:
    protocolHeader: X-Forwarded-Proto
    remoteIpHeader: X-Forwarded-For
    internalProxies: .*
    httpsServerPort: X-Forwarded-Port
```