### PR TITLE
feat(web): expose `/reorder` endpoints for pipelines and strategies

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ReorderPipelinesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ReorderPipelinesController.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.gate.services.PipelineService;
+import com.netflix.spinnaker.gate.services.TaskService;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import groovy.transform.CompileStatic;
+import groovy.util.logging.Slf4j;
+import io.swagger.annotations.ApiOperation;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@CompileStatic
+@RestController
+@RequestMapping("actions")
+public class ReorderPipelinesController {
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  PipelineService pipelineService;
+
+  @Autowired
+  TaskService taskService;
+
+  @ApiOperation(value = "Re-order pipelines")
+  @RequestMapping(value = "/pipelines/reorder", method = RequestMethod.POST)
+  public Map reorderPipelines(@RequestBody ReorderPipelinesCommand reorderPipelinesCommand) {
+    return handlePipelineReorder(reorderPipelinesCommand, false);
+  }
+
+  @ApiOperation(value = "Re-order pipeline strategies")
+  @RequestMapping(value = "/strategies/reorder", method = RequestMethod.POST)
+  public Map reorderPipelineStrategies(@RequestBody ReorderPipelinesCommand reorderPipelinesCommand) {
+    return handlePipelineReorder(reorderPipelinesCommand, true);
+  }
+
+  private Map handlePipelineReorder(ReorderPipelinesCommand reorderPipelinesCommand, Boolean isStrategy) {
+    Map<String, Integer> idsToIndices = reorderPipelinesCommand.getIdsToIndices();
+    String application = reorderPipelinesCommand.getApplication();
+
+    if (idsToIndices == null) {
+      throw new InvalidRequestException("`idsToIndices` is required field on request body");
+    }
+
+    if (application == null) {
+      throw new InvalidRequestException("`application` is required field on request body");
+    }
+
+    List<Map<String, Object>> jobs = new ArrayList<>();
+    Map<String, Object> job = new HashMap<>();
+    job.put("type", "reorderPipelines");
+    job.put("idsToIndices", encodeAsBase64(idsToIndices, objectMapper));
+    job.put("isStrategy", encodeAsBase64(isStrategy, objectMapper));
+    job.put("application", encodeAsBase64(application, objectMapper));
+    job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
+    jobs.add(job);
+
+    Map<String, Object> operation = new HashMap<>();
+    operation.put("description", "Reorder pipelines");
+    operation.put("application", application);
+    operation.put("job", jobs);
+
+    return taskService.createAndWaitForCompletion(operation);
+  }
+
+  @Data
+  private static class ReorderPipelinesCommand {
+    private Map<String, Integer> idsToIndices;
+    private String application;
+  }
+
+  static String encodeAsBase64(Object value, ObjectMapper objectMapper) {
+    try {
+      return Base64.getEncoder().encodeToString(objectMapper.writeValueAsString(value).getBytes());
+    } catch (Exception e) {
+      throw new RuntimeException("Could not encode value", e);
+    }
+  }
+}


### PR DESCRIPTION
Previously, Deck made one request per pipeline to be re-indexed after re-ordering or deleting a pipeline, which could flood the Tasks panel when an application contained many pipelines. This change exposes endpoints for re-ordering pipeline and strategy configs.

Corresponding PRs:
Deck: [spinnaker/deck#6519](https://github.com/spinnaker/deck/pull/6519)
Orca: [spinnaker/orca#2663](https://github.com/spinnaker/orca/pull/2663)
Front50: https://github.com/spinnaker/front50/pull/448