### PR TITLE
feat(delivery): get all deliverys and single delivery config

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -143,4 +143,13 @@ interface Front50Service {
 
   @GET('/serviceAccounts')
   List<ServiceAccount> getServiceAccounts()
+
+  //
+  // Delivery-related
+  //
+  @GET('/deliveries')
+  List<Map> getDeliveries()
+
+  @GET('/deliveries/{id}')
+  Map getDelivery(@Path('id') String id)
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DeliveryController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/DeliveryController.java
@@ -1,0 +1,42 @@
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import groovy.util.logging.Slf4j;
+import io.swagger.annotations.ApiOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequestMapping("/deliveryConfigs")
+@RestController
+@Slf4j
+public class DeliveryController {
+
+  private final static Logger log = LoggerFactory.getLogger(DeliveryController.class);
+  private final Front50Service front50Service;
+
+  @Autowired
+  public DeliveryController(Front50Service front50Service) {
+    this.front50Service = front50Service;
+  }
+
+  @ApiOperation(value = "Get all delivery configs", response = HashMap.class)
+  @RequestMapping(value = "", method = RequestMethod.GET)
+  List<Map> getDeliveries() {
+    return front50Service.getDeliveries();
+  }
+
+  @ApiOperation(value = "Get a delivery config", response = HashMap.class)
+  @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+  Map getDeliveryConfig(@PathVariable("id") String id) {
+    return front50Service.getDelivery(id);
+  }
+}


### PR DESCRIPTION
Reading delivery configs from front50. Exposing as `Map`s for now, because we are not sure about the typing. Upsert/delete is done through an orca task. Auth _should_ be controlled on the front50 end with fiat.