### PR TITLE
fix(authn/saml): Fix extra [] in username

### DIFF
--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -206,7 +206,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
         def userAttributeMapping = samlSecurityConfigProperties.userAttributeMapping
 
         def email = assertion.getSubject().nameID.value
-        String username = attributes[userAttributeMapping.username] ?: email
+        String username = attributes[userAttributeMapping.username]?.get(0) ?: email
         def roles = extractRoles(email, attributes, userAttributeMapping)
 
         if (samlSecurityConfigProperties.requiredRoles) {


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/4106

The username extracted contains extra [].

`attributes` map contains a `List<String>` as values.  To extract the value correctly, get the first item from the list instead of return the `List`.