### PR TITLE
feat(triggers): Add autocompletion APIs for Concourse trigger

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Pivotal Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.internal.IgorService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/concourse")
+public class ConcourseController {
+  private final IgorService igorService;
+
+  public ConcourseController(IgorService igorService) {
+    this.igorService = igorService;
+  }
+
+  @ApiOperation(value = "Retrieve the list of team names available to triggers", response = List.class)
+  @GetMapping(value = "/{buildMaster}/teams")
+  List<String> teams(@PathVariable("buildMaster") String buildMaster) {
+    return igorService.getConcourseTeams(buildMaster);
+  }
+
+  @ApiOperation(value = "Retrieve the list of pipeline names for a given team available to triggers", response = List.class)
+  @GetMapping(value = "/{buildMaster}/teams/{team}/pipelines")
+  List<String> pipelines(@PathVariable("buildMaster") String buildMaster,
+                         @PathVariable("team") String team) {
+    return igorService.getConcoursePipelines(buildMaster, team);
+  }
+
+  @ApiOperation(value = "Retrieve the list of job names for a given pipeline available to triggers", response = List.class)
+  @GetMapping(value = "/{buildMaster}/teams/{team}/pipelines/{pipeline}/jobs")
+  List<String> jobs(@PathVariable("buildMaster") String buildMaster,
+                    @PathVariable("team") String team,
+                    @PathVariable("pipeline") String pipeline) {
+    return igorService.getConcourseJobs(buildMaster, team, pipeline);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
@@ -54,4 +54,13 @@ interface IgorService {
 
   @GET('/artifactory/names')
   List<String> getArtifactoryNames()
+
+  @GET('/concourse/{buildMaster}/teams')
+  List<String> getConcourseTeams(@Path("buildMaster") String buildMaster)
+
+  @GET('/concourse/{buildMaster}/teams/{team}/pipelines')
+  List<String> getConcoursePipelines(@Path("buildMaster") String buildMaster, @Path("team") String team);
+
+  @GET('/concourse/{buildMaster}/teams/{team}/pipelines/{pipeline}/jobs')
+  List<String> getConcourseJobs(@Path("buildMaster") String buildMaster, @Path("team") String team, @Path("pipeline") String pipeline);
 }


### PR DESCRIPTION
These endpoints help fill out selection boxes for the various parts of the Concourse trigger definition:

![image](https://user-images.githubusercontent.com/1697736/54387026-4fbf7000-4668-11e9-9241-edc86853a821.png)
