### PR TITLE
fix(igor): Remove igor as a requirement for artifactory and concourse

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactoryController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactoryController.java
@@ -24,18 +24,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/artifactory")
 public class ArtifactoryController {
 
-  @Autowired(required = false)
-  private IgorService igorService;
+  private Optional<IgorService> igorService;
+
+  @Autowired
+  public ArtifactoryController(Optional<IgorService> igorService) {
+    this.igorService = igorService;
+  }
 
 
   @ApiOperation(value = "Retrieve the list of artifactory names available to triggers", response = List.class)
   @GetMapping(value = "/names")
   List<String> names() {
-    return igorService.getArtifactoryNames();
+    return igorService.get().getArtifactoryNames();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactoryController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactoryController.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.controllers;
 
 import com.netflix.spinnaker.gate.services.internal.IgorService;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,11 +29,9 @@ import java.util.List;
 @RequestMapping("/artifactory")
 public class ArtifactoryController {
 
+  @Autowired(required = false)
   private IgorService igorService;
 
-  public ArtifactoryController(IgorService igorService) {
-    this.igorService = igorService;
-  }
 
   @ApiOperation(value = "Retrieve the list of artifactory names available to triggers", response = List.class)
   @GetMapping(value = "/names")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
@@ -25,25 +25,30 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/concourse")
 public class ConcourseController {
 
-  @Autowired(required = false)
-  private IgorService igorService;
+  private Optional<IgorService> igorService;
+
+  @Autowired
+  public ConcourseController(Optional<IgorService> igorService) {
+    this.igorService = igorService;
+  }
 
   @ApiOperation(value = "Retrieve the list of team names available to triggers", response = List.class)
   @GetMapping(value = "/{buildMaster}/teams")
   List<String> teams(@PathVariable("buildMaster") String buildMaster) {
-    return igorService.getConcourseTeams(buildMaster);
+    return igorService.get().getConcourseTeams(buildMaster);
   }
 
   @ApiOperation(value = "Retrieve the list of pipeline names for a given team available to triggers", response = List.class)
   @GetMapping(value = "/{buildMaster}/teams/{team}/pipelines")
   List<String> pipelines(@PathVariable("buildMaster") String buildMaster,
                          @PathVariable("team") String team) {
-    return igorService.getConcoursePipelines(buildMaster, team);
+    return igorService.get().getConcoursePipelines(buildMaster, team);
   }
 
   @ApiOperation(value = "Retrieve the list of job names for a given pipeline available to triggers", response = List.class)
@@ -51,6 +56,6 @@ public class ConcourseController {
   List<String> jobs(@PathVariable("buildMaster") String buildMaster,
                     @PathVariable("team") String team,
                     @PathVariable("pipeline") String pipeline) {
-    return igorService.getConcourseJobs(buildMaster, team, pipeline);
+    return igorService.get().getConcourseJobs(buildMaster, team, pipeline);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ConcourseController.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.controllers;
 
 import com.netflix.spinnaker.gate.services.internal.IgorService;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,11 +29,9 @@ import java.util.List;
 @RestController
 @RequestMapping("/concourse")
 public class ConcourseController {
-  private final IgorService igorService;
 
-  public ConcourseController(IgorService igorService) {
-    this.igorService = igorService;
-  }
+  @Autowired(required = false)
+  private IgorService igorService;
 
   @ApiOperation(value = "Retrieve the list of team names available to triggers", response = List.class)
   @GetMapping(value = "/{buildMaster}/teams")


### PR DESCRIPTION
Motivation: Gate fails to start if Igor is not enabled. This may impact many users since Igor is not enabled by default in Gate. 

This PR removes Igor as a requirement.