### PR TITLE
feat(oauth2): Allow implementation to provide roles from OAuth2 

### DIFF
--- a/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -115,6 +115,7 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
     String lastName = "family_name"
     String username = "email"
     String serviceAccountEmail = "client_email"
+    String roles = "roles"
   }
 
   @Component

--- a/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
+++ b/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
@@ -59,7 +59,7 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
   CredentialsService credentialsService
 
   @Autowired
-  OAuth2SsoConfig.UserInfoMapping userInfoMapping
+  protected OAuth2SsoConfig.UserInfoMapping userInfoMapping
 
   @Autowired
   OAuth2SsoConfig.UserInfoRequirements userInfoRequirements
@@ -97,11 +97,15 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
     }
 
     def username = details[userInfoMapping.username] as String
-    def roles = []
+    def roles = getRoles(details)
 
     // Service accounts are already logged in.
     if (!isServiceAccount) {
-      permissionService.login(username)
+      if (roles.isEmpty()) {
+        permissionService.login(username)
+      } else {
+        permissionService.loginWithRoles(username, roles)
+      }
     }
 
     User spinnakerUser = new User(
@@ -177,5 +181,9 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
   static String mutateRegexPattern(String val) {
     // "/expr/" -> "expr"
     val.substring(1, val.length() - 1)
+  }
+
+  protected List<String> getRoles(Map<String, String> details) {
+    return []
   }
 }


### PR DESCRIPTION
Change to make SpinnakerUserInfoTokenServices role handling extensible. Our use case is for OpenID Connect that can provide additional information without hitting the userInfoUri - although the change doesn't assume that.

This is related (and complimentary?) to the work done in #688.