### PR TITLE
feat(gremlin): Add Halyard config for Gremlin

### DIFF
--- a/halconfig/gate.yml
+++ b/halconfig/gate.yml
@@ -2,3 +2,8 @@
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
+
+integrations:
+  gremlin:
+    enabled: ${features.gremlin:false}
+    baseUrl: https://api.gremlin.com/v1


### PR DESCRIPTION
Set integrations.gremlin.enabled from the Halyard feature named --gremlin.
This will work once spinnaker/halyard#1261 is merged.