### PR TITLE
fix(jobcontroller): correct API calls to clouddriver and remove invalid EP

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -155,10 +155,6 @@ interface ClouddriverService {
                        @Query("cloudProvider") String cloudProvider)
 
   @Headers("Accept: application/json")
-  @GET("/applications/{name}/jobs")
-  List getJobs(@Path("name") String name, @Query("expand") String expand)
-
-  @Headers("Accept: application/json")
   @POST("/applications/{name}/jobs/{account}/{region}/{jobName}")
   Map getJobDetails(@Path("name") String name,
                     @Path("account") String account,

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -25,6 +25,7 @@ import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.GET
 import retrofit.http.Headers
+import retrofit.http.POST
 import retrofit.http.PUT
 import retrofit.http.Path
 import retrofit.http.Query
@@ -158,11 +159,12 @@ interface ClouddriverService {
   List getJobs(@Path("name") String name, @Query("expand") String expand)
 
   @Headers("Accept: application/json")
-  @GET("/applications/{name}/jobs/{account}/{region}/{jobName}")
+  @POST("/applications/{name}/jobs/{account}/{region}/{jobName}")
   Map getJobDetails(@Path("name") String name,
                     @Path("account") String account,
                     @Path("region") String region,
-                    @Path("jobName") String jobName)
+                    @Path("jobName") String jobName,
+                    @Body String emptyStringForRetrofit)
 
   @Headers("Accept: application/json")
   @GET("/applications/{name}/serverGroups/{account}/{region}/{serverGroupName}")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/JobController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/JobController.groovy
@@ -29,14 +29,6 @@ class JobController {
   @Autowired
   JobService jobService
 
-  @ApiOperation(value = "Get jobs", response = List.class)
-  @RequestMapping(value = "/applications/{applicationName}/jobs", method = RequestMethod.GET)
-  List getJobs(@PathVariable String applicationName,
-               @RequestParam(required = false, value = 'expand', defaultValue = 'false') String expand,
-               @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
-    jobService.getForApplication(applicationName, expand, sourceApp)
-  }
-
   @ApiOperation(value = "Get job", response = HashMap.class)
   @RequestMapping(value = "/applications/{applicationName}/jobs/{account}/{region}/{name}", method = RequestMethod.GET)
   Map getJob(@PathVariable String applicationName, @PathVariable String account,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
@@ -62,7 +62,7 @@ class JobService {
     HystrixFactory.newMapCommand(GROUP, "getJobsForApplicationAccountAndRegion-${providerLookupService.providerForAccount(account)}", {
       try {
         def context = getContext(applicationName, account, region, name)
-        return clouddriverServiceSelector.select(selectorKey).getJobDetails(applicationName, account, region, name) + [
+        return clouddriverServiceSelector.select(selectorKey).getJobDetails(applicationName, account, region, name, "") + [
             "insightActions": insightConfiguration.job.collect { it.applyContext(context) }
         ]
       } catch (RetrofitError e) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/JobService.groovy
@@ -44,13 +44,6 @@ class JobService {
   @Autowired
   ProviderLookupService providerLookupService
 
-  List getForApplication(String applicationName, String expand, String selectorKey) {
-    String commandKey = Boolean.valueOf(expand) ? "getExpandedJobsForApplication" : "getJobsForApplication"
-    HystrixFactory.newListCommand(GROUP, commandKey) {
-      clouddriverServiceSelector.select(selectorKey).getJobs(applicationName, expand)
-    } execute()
-  }
-
   List getPreconfiguredJobs() {
     RequestContext requestContext = RequestContext.get()
     HystrixFactory.newListCommand(GROUP, "getPreconfiguredJobs") {


### PR DESCRIPTION
* **fix(jobcontroller):** getJobDetails must use a POST not a GET to clouddriver
Currenty, calls to /applications/{app}/jobs/{account}/{region}/{name} (in `gate`) will fail
with an error from `clouddriver` that method is not supported because `gate` uses `GET` but
`POST` is expected on the `clouddriver` [side](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy#L44)


* **fix(jobcontroller):** remove un-used, non-existent API
``/applications/{appName}/jobs` API is not used (as best as I can tell)
And even if it were used, it would fail because it calls to a non-existent
`clouddriver` API
