### PR TITLE
feat(artifact): expose endpoint for manual artifact triggers

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.gate.services.ArtifactService;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -74,5 +73,14 @@ public class ArtifactController {
     @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp
   ) {
     return artifactService.getArtifactVersions(sourceApp, accountName, type, artifactName);
+  }
+
+  @ApiOperation(value = "Retrieve the available artifact versions for an artifact provider and package name")
+  @RequestMapping(value = "/{provider}/{packageName}", method = RequestMethod.GET)
+  List<String> getVersionsOfArtifactForProvider(
+    @PathVariable String provider,
+    @PathVariable String packageName
+  ) {
+    return artifactService.getVersionsOfArtifactForProvider(provider, packageName);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
@@ -66,4 +66,8 @@ interface IgorService {
 
   @GET('/gcb/accounts')
   List<String> getGoogleCloudBuildAccounts();
+
+  @GET('/artifacts/{provider}/{packageName}')
+  List<String> getArtifactVersions(@Path("provider") String provider,
+                                   @Path("packageName") String packageName);
 }


### PR DESCRIPTION
This endpoint will be used for the manual trigger dropdown for artifact triggers to populate the list of available versions.