### PR TITLE
test(core): Basic startup test

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
@@ -1,0 +1,18 @@
+package com.netflix.spinnaker.gate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {Main.class})
+@TestPropertySource(properties = {"spring.config.location=classpath:gate-test.yml"})
+public class MainSpec {
+  @Test
+  public void startupTest(){
+
+  }
+}

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -1,0 +1,23 @@
+services:
+  clouddriver.baseUrl: "http://localhost:7002"
+
+  deck.baseUrl: "http://localhost:9000"
+
+  echo.enabled: false
+
+  fiat.enabled: false
+
+  front50.baseUrl: "http://localhost:8080"
+
+  igor.enabled: false
+
+  kayenta.enabled: false
+
+  rosco.enabled: false
+
+  orca.baseUrl: "http://localhost:8083"
+
+  mine.enabled: false
+
+  swabbie.enabled: false
+


### PR DESCRIPTION
Starts up fiat with only the `baseUrl` for required services.

Similar to https://github.com/spinnaker/orca/pull/2685