### PR TITLE
fix(gate): fix startup with redis.configuration.secure

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -62,6 +62,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.core.Ordered
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer
 import org.springframework.session.data.redis.config.ConfigureRedisAction
@@ -125,6 +126,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
    * {@link PostConnectionConfiguringJedisConnectionFactory}.
    * */
   @Bean
+  @Primary
   ConfigureRedisAction springBootConfigureRedisAction() {
     return ConfigureRedisAction.NO_OP
   }


### PR DESCRIPTION
Apparently if an @AutoWired parameter has no @Qualifier, it will accept
both unqualified AND qualified beans. I assumed it worked like Guice,
which only matches unqualified beans with unqualified parameters.
Whoops.