### PR TITLE
fix(gremlin): Remove Gremlin config template and let Halyard write it from scratch

### DIFF
--- a/halconfig/gate.yml
+++ b/halconfig/gate.yml
@@ -2,8 +2,3 @@
 
 redis:
   connection: ${services.redis.baseUrl:redis://localhost:6379}
-
-integrations:
-  gremlin:
-    enabled: ${features.gremlin:false}
-    baseUrl: https://api.gremlin.com/v1


### PR DESCRIPTION
Related Halyard PR: https://github.com/spinnaker/halyard/pull/1293

I previously had the wrong idea about how Halyard was propagating config. This should put all of the burden onto Halyard to do it programatically.