### PR TITLE
fix(ldap): Disable the broken LdapHealthIndicatorAutoConfiguration

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate
 
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorConfig
+import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
@@ -32,7 +33,7 @@ import org.springframework.scheduling.annotation.EnableAsync
 @EnableConfigurationProperties
 @Import([HystrixSpectatorConfig])
 @ComponentScan(["com.netflix.spinnaker.gate", "com.netflix.spinnaker.config"])
-@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration])
+@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration, LdapHealthIndicatorAutoConfiguration])
 class Main {
 
   static final Map<String, String> DEFAULT_PROPS = [

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -41,6 +41,7 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
 import org.springframework.boot.SpringApplication
+import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
@@ -253,7 +254,7 @@ class FunctionalSpec extends Specification {
   }
 
   @Order(10)
-  @EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration])
+  @EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration, LdapHealthIndicatorAutoConfiguration])
   private static class FunctionalConfiguration extends WebSecurityConfigurerAdapter {
 
     @Bean


### PR DESCRIPTION
We can reenable it once we upgrade to a version of spring-boot with the
fix for spring-projects/spring-ldap#473
