### PR TITLE
fix(saml): ensure session cookie survives idp redirect

### DIFF
--- a/gate-saml/gate-saml.gradle
+++ b/gate-saml/gate-saml.gradle
@@ -5,6 +5,7 @@ dependencies{
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spectator:spectator-api"
+  implementation 'org.springframework.session:spring-session-core'
 
   implementation "org.springframework.security.extensions:spring-security-saml2-core"
   implementation "org.springframework.security.extensions:spring-security-saml-dsl-core"

--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -44,10 +44,10 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.extensions.saml2.config.SAMLConfigurer
 import org.springframework.security.saml.SAMLCredential
-import org.springframework.security.saml.storage.EmptyStorageFactory
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService
 import org.springframework.security.web.authentication.RememberMeServices
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices
+import org.springframework.session.web.http.DefaultCookieSerializer
 import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
@@ -64,6 +64,9 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired
   ServerProperties serverProperties
+
+  @Autowired
+  DefaultCookieSerializer defaultCookieSerializer
 
   @Autowired
   AuthConfig authConfig
@@ -130,6 +133,8 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   void configure(HttpSecurity http) {
+    //We need our session cookie to come across when we get redirected back from the IdP:
+    defaultCookieSerializer.setSameSite(null)
     authConfig.configure(http)
 
     http
@@ -149,7 +154,6 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           .protocol(samlSecurityConfigProperties.redirectProtocol)
           .hostname(samlSecurityConfigProperties.redirectHostname ?: serverProperties?.address?.hostName)
           .basePath(samlSecurityConfigProperties.redirectBasePath)
-          .storageFactory(new EmptyStorageFactory())
           .keyStore()
           .storeFilePath(samlSecurityConfigProperties.keyStore)
           .password(samlSecurityConfigProperties.keyStorePassword)


### PR DESCRIPTION
Fixes an issue where the session cookie was being marked SameSite by the boot2 upgrade
and as a result we would lose an existing session / start a new session after redirect
back from the IdP.

No longer requires EmptyStorageFactory (went in as a workaround for this issue initially),
and fixes redirect after login back to the original request URI being busted.
