### PR TITLE
fix(oauth): remove samesite cookie attribute

### DIFF
--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -1,6 +1,7 @@
 dependencies {
   implementation project(":gate-core")
   implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
+  implementation "org.springframework.session:spring-session-core"
   implementation "com.squareup.retrofit:converter-simplexml"
   implementation "com.netflix.spinnaker.kork:kork-security"
 }

--- a/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
+++ b/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy
@@ -36,6 +36,7 @@ import org.springframework.security.oauth2.client.token.grant.code.Authorization
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter
+import org.springframework.session.web.http.DefaultCookieSerializer
 import org.springframework.stereotype.Component
 
 import javax.servlet.http.HttpServletRequest
@@ -60,6 +61,9 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   ExternalSslAwareEntryPoint entryPoint
 
+  @Autowired
+  DefaultCookieSerializer defaultCookieSerializer
+
   @Primary
   @Bean
   ResourceServerTokenServices spinnakerUserInfoTokenServices() {
@@ -73,6 +77,7 @@ class OAuth2SsoConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   void configure(HttpSecurity http) throws Exception {
+    defaultCookieSerializer.setSameSite(null)
     authConfig.configure(http)
 
     http.exceptionHandling().authenticationEntryPoint(entryPoint)


### PR DESCRIPTION
Similar to #801 when using oauth removes the samesite attribute from
the session cookie.

I don't 100% know this is necessary but [this post](http://blog.64p.org/entry/2018/11/09/180956) sort of implies it is and a [user report of redirect URI issues that may be related](https://github.com/spinnaker/gate/commit/271bfab61d1f44d8ff7d4f546ec2a8efbb9b1a47#commitcomment-33558040)


