### PR TITLE
fix(tags): expose params for better searching

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import org.springframework.web.bind.annotation.RequestParam
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.GET
@@ -304,6 +305,18 @@ interface ClouddriverService {
 
   @GET('/tags')
   List<Map> listEntityTags(@QueryMap Map allParameters)
+
+  @GET('/tags')
+  List<Map> listEntityTags(@RequestParam(value = "cloudProvider", required = false) String cloudProvider,
+                           @RequestParam(value = "application", required = false) String application,
+                           @RequestParam(value = "entityType", required = false) String entityType,
+                           @RequestParam(value = "entityId", required = false) String entityId,
+                           @RequestParam(value = "idPrefix", required = false) String idPrefix,
+                           @RequestParam(value = "account", required = false) String account,
+                           @RequestParam(value = "region", required = false) String region,
+                           @RequestParam(value = "namespace", required = false) String namespace,
+                           @RequestParam(value = "maxResults", required = false, defaultValue = "5000") int maxResults,
+                           @QueryMap Map allParameters)
 
   @GET('/tags/{id}')
   Map getEntityTags(@Path('id') String id)

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
-import org.springframework.web.bind.annotation.RequestParam
 import retrofit.client.Response
 import retrofit.http.Body
 import retrofit.http.GET
@@ -305,18 +304,6 @@ interface ClouddriverService {
 
   @GET('/tags')
   List<Map> listEntityTags(@QueryMap Map allParameters)
-
-  @GET('/tags')
-  List<Map> listEntityTags(@RequestParam(value = "cloudProvider", required = false) String cloudProvider,
-                           @RequestParam(value = "application", required = false) String application,
-                           @RequestParam(value = "entityType", required = false) String entityType,
-                           @RequestParam(value = "entityId", required = false) String entityId,
-                           @RequestParam(value = "idPrefix", required = false) String idPrefix,
-                           @RequestParam(value = "account", required = false) String account,
-                           @RequestParam(value = "region", required = false) String region,
-                           @RequestParam(value = "namespace", required = false) String namespace,
-                           @RequestParam(value = "maxResults", required = false, defaultValue = "5000") int maxResults,
-                           @QueryMap Map allParameters)
 
   @GET('/tags/{id}')
   Map getEntityTags(@Path('id') String id)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EntityTagsController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/EntityTagsController.java
@@ -20,6 +20,7 @@ import com.netflix.frigga.Names;
 import com.netflix.spinnaker.gate.services.EntityTagsService;
 import com.netflix.spinnaker.gate.services.TaskService;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,7 +54,10 @@ public class EntityTagsController {
 
   @RequestMapping(method = RequestMethod.GET)
   public Collection<Map> list(
-      @RequestParam Map<String, Object> allParameters,
+      @ApiParam(
+              "Any parameters to filter by, passed as individual parameters. Options are: \n  cloudProvider, application, entityType, entityId, idPrefix, account, region, namespace, maxResults")
+          @RequestParam
+          Map<String, Object> allParameters,
       @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     return entityTagsService.list(allParameters, sourceApp);
   }


### PR DESCRIPTION
The clouddriver [entityTagsController](https://github.com/spinnaker/clouddriver/blob/d15d7f775c30056510aca016c712e1d68c16d51a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/EntityTagsController.java#L53) has all these options that we don't expose when we expose entity tagging through gate. Adding an api that exposes these also so it's easy to grab a subset of entity tags.