### PR TITLE
chore(core): replace runtime with runtimeOnly in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
 
     implementation "org.codehaus.groovy:groovy-all"
     implementation "net.logstash.logback:logstash-logback-encoder"
-    runtime "org.springframework.boot:spring-boot-properties-migrator"
+    runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
     testRuntime "org.springframework.boot:spring-boot-properties-migrator"
 
     testImplementation "org.spockframework:spock-core"


### PR DESCRIPTION
according to [gradle docs](https://docs.gradle.org/5.3.1/userguide/java_plugin.html#sec:java_plugin_and_dependency_management)

`runtime` is a deprecated scope and we should be using `runtimeOnly`