### PR TITLE
chore(dependencies): fix for intellij groovy compiler

### DIFF
--- a/gate-saml/gate-saml.gradle
+++ b/gate-saml/gate-saml.gradle
@@ -5,7 +5,9 @@ dependencies{
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.netflix.spectator:spectator-api"
+  implementation 'org.springframework:spring-context'
   implementation 'org.springframework.session:spring-session-core'
+  implementation 'org.springframework.boot:spring-boot-autoconfigure'
 
   implementation "org.springframework.security.extensions:spring-security-saml2-core"
   implementation "org.springframework.security.extensions:spring-security-saml-dsl-core"


### PR DESCRIPTION
Adds some explicit references to transitive dependencies that were
causing a groovy compiler error on the gate-saml module
