### PR TITLE
fix(ldap): allow http basic credentials for LDAP auth

### DIFF
--- a/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -37,6 +37,8 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
 import org.springframework.stereotype.Component
 
 @ConditionalOnExpression('${ldap.enabled:false}')
@@ -88,6 +90,7 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http.formLogin()
     authConfig.configure(http)
+    http.addFilterBefore(new BasicAuthenticationFilter(authenticationManager()), UsernamePasswordAuthenticationFilter)
   }
 
   @Override

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -51,6 +51,7 @@ dependencies {
   testImplementation "com.squareup.okhttp:mockwebserver"
 
   testImplementation "com.squareup.retrofit:retrofit-mock"
+  testImplementation "org.springframework.security:spring-security-test"
   testImplementation "org.springframework.security:spring-security-ldap"
   testImplementation "com.unboundid:unboundid-ldapsdk"
   testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
@@ -43,6 +43,7 @@ import javax.servlet.http.Cookie
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic
 
 @Slf4j
 @GateSystemTest
@@ -57,6 +58,19 @@ class LdapAuthSpec extends Specification {
 
   @Autowired
   MockMvc mockMvc
+
+  def "should allow http-basic authentication"() {
+    when:
+    def result = mockMvc.perform(
+      get("/credentials")
+        .with(httpBasic("batman", "batman")))
+      .andDo(print())
+      .andExpect(status().isOk())
+      .andReturn()
+
+    then:
+    result.response.contentAsString.contains("foo")
+  }
 
   def "should do ldap authentication"() {
     setup:


### PR DESCRIPTION
Allows but does not require http basic authentication credentials.
If not present or invalid, will redirect to the login form, but
this will allow API callers to supply credentials via an
Authentication HTTP header.
