### PR TITLE
feat(artifacts): add optional release status param to fetching artifacts

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
@@ -73,10 +73,13 @@ public class ArtifactController {
   }
 
   @ApiOperation(
-      value = "Retrieve the available artifact versions for an artifact provider and package name")
+      value = "Retrieve the available artifact versions for an artifact provider and package name",
+      notes = "releaseStatus is an optional comma separated list of statuses to filter on.")
   @RequestMapping(value = "/{provider}/{packageName}", method = RequestMethod.GET)
   List<String> getVersionsOfArtifactForProvider(
-      @PathVariable String provider, @PathVariable String packageName) {
-    return artifactService.getVersionsOfArtifactForProvider(provider, packageName);
+      @PathVariable String provider,
+      @PathVariable String packageName,
+      @RequestParam(required = false) String releaseStatus) {
+    return artifactService.getVersionsOfArtifactForProvider(provider, packageName, releaseStatus);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
@@ -98,7 +98,8 @@ public class ArtifactService {
         .execute();
   }
 
-  public List<String> getVersionsOfArtifactForProvider(String provider, String packageName) {
+  public List<String> getVersionsOfArtifactForProvider(
+      String provider, String packageName, String releaseStatus) {
     if (!igorService.isPresent()) {
       throw new IllegalStateException(
           "Cannot fetch artifact versions because Igor is not enabled.");
@@ -106,7 +107,7 @@ public class ArtifactService {
 
     return stringListCommand(
             "artifactVersionsByProvider",
-            () -> igorService.get().getArtifactVersions(provider, packageName))
+            () -> igorService.get().getArtifactVersions(provider, packageName, releaseStatus))
         .execute();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
@@ -69,7 +69,8 @@ interface IgorService {
 
   @GET('/artifacts/{provider}/{packageName}')
   List<String> getArtifactVersions(@Path("provider") String provider,
-                                   @Path("packageName") String packageName);
+                                   @Path("packageName") String packageName,
+                                   @Query("releaseStatus") String releaseStatus);
 
   @GET('/concourse/{buildMaster}/teams/{team}/pipelines/{pipeline}/resources')
   List<String> getConcourseResources(@Path("buildMaster") String buildMaster, @Path("team") String team, @Path("pipeline") String pipeline);


### PR DESCRIPTION
Adding this optional parameter so that artifact providers can have more information on what artifacts to return.

For example, you could specify 
`provider/my-artifact?releaseStatus=snapshot` to get only candidate artifacts.