### PR TITLE
fix(web): Better merging of `/applications/{app}?expand=false` responses

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -107,10 +107,11 @@ class ApplicationService {
     } catch (ExecutionException ee) {
       throw ee.cause
     }
-    if (expand == false) {
+    if (!expand) {
       def cachedApplication = allApplicationsCache.get().find { name.equalsIgnoreCase(it.name as String) }
       if (cachedApplication) {
-        applications.add(cachedApplication)
+        // ensure that `cachedApplication` attributes are overridden by any previously fetched metadata from front50
+        applications.add(0, cachedApplication)
       }
     }
     List<Map> mergedApps = mergeApps(applications, serviceConfiguration.getService('front50'))

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -265,12 +265,23 @@ class ApplicationServiceSpec extends Specification {
     service.front50Service = front50
     service.clouddriverService = clouddriver
     service.executorService = Executors.newFixedThreadPool(1)
+    service.allApplicationsCache.set([
+        [name: name, email: "cached@email.com"]
+    ])
 
     when:
     def app = service.getApplication(name, false)
 
+
     then:
     0 * clouddriver.getApplication(name)
-    1 * front50.getApplication(name) >> null
+    1 * front50.getApplication(name) >> {
+      return [
+          name: name,
+          email: "updated@email.com"
+      ]
+    }
+
+    app.attributes.email == "updated@email.com"
   }
 }


### PR DESCRIPTION
Addresses an issue where the attributes of `cachedApplication` were
overriding the most recent values from `front50`.
