### PR TITLE
feat(keel): add yaml processing

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -9,7 +9,7 @@ run {
   systemProperty('spring.config.additional-location', project.springConfigLocation)
   systemProperty('spring.profiles.active', project.springProfiles)
 }
-mainClassName='com.netflix.spinnaker.gate.Main'
+mainClassName = 'com.netflix.spinnaker.gate.Main'
 
 repositories {
   maven {
@@ -24,6 +24,8 @@ dependencies {
 
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.okhttp:okhttp-apache"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/yaml/YamlHttpMessageConverter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/yaml/YamlHttpMessageConverter.java
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.gate.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+
+public class YamlHttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+  public YamlHttpMessageConverter(ObjectMapper objectMapper, MediaType... supportedMediaTypes) {
+    super(objectMapper, supportedMediaTypes);
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 fiatVersion=1.1.0
 enablePublishing=false
 spinnakerGradleVersion=6.5.0
-korkVersion=5.7.1
+korkVersion=5.8.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
 org.gradle.parallel=true


### PR DESCRIPTION
Gate needs to accept yaml, because we want to support both json and yaml in keel.