### PR TITLE
fix(json): json is returned as the default for controllers

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/converters/JsonHttpMessageConverter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/converters/JsonHttpMessageConverter.java
@@ -15,15 +15,17 @@
  * limitations under the License.
  *
  */
-package com.netflix.spinnaker.gate.yaml;
+package com.netflix.spinnaker.gate.converters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 
-public class YamlHttpMessageConverter extends AbstractJackson2HttpMessageConverter {
-
-  public YamlHttpMessageConverter(ObjectMapper objectMapper, MediaType... supportedMediaTypes) {
-    super(objectMapper, supportedMediaTypes);
+public class JsonHttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+  public JsonHttpMessageConverter(ObjectMapper objectMapper) {
+    super(
+        objectMapper,
+        MediaType.parseMediaType("application/json"),
+        MediaType.parseMediaType("application/json;charset=UTF-8"));
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/converters/YamlHttpMessageConverter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/converters/YamlHttpMessageConverter.java
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.gate.converters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+
+public class YamlHttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+  public YamlHttpMessageConverter(ObjectMapper objectMapper) {
+    super(
+        objectMapper,
+        MediaType.parseMediaType("application/x-yaml"),
+        MediaType.parseMediaType("application/x-yaml;charset=UTF-8"));
+  }
+}


### PR DESCRIPTION
For some reason if you specify a yaml converter and not a json one (or, before a json one) then the default response is yaml. This PR fixes that unfortunate weird behavior.