### PR TITLE
feat(web): Include `requestUserAgent` and `requestPort` in request log

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestLoggingInterceptor.java
@@ -44,6 +44,9 @@ public class RequestLoggingInterceptor extends HandlerInterceptorAdapter {
     // 127.0.0.1 "GET /limecat.jpg HTTP/1.0" 200 2326
     try {
       MDC.put("requestDuration", getRequestDuration(request));
+      MDC.put("requestUserAgent", request.getHeader("User-Agent"));
+      MDC.put("requestPort", String.valueOf(request.getServerPort()));
+
       log.debug(
           "{} \"{} {} {}\" {} {}",
           value("sourceIp", sourceIpAddress(request)),
@@ -54,6 +57,8 @@ public class RequestLoggingInterceptor extends HandlerInterceptorAdapter {
           value("responseSize", getResponseSize(response)));
     } finally {
       MDC.remove("requestDuration");
+      MDC.remove("requestUserAgent");
+      MDC.remove("requestPort");
     }
   }
 


### PR DESCRIPTION
This will make it easier to track down particular client libraries
when multiple connectors are being used.
