### PR TITLE
fix(saml): Allow overriding maxAuthenticationAge

### DIFF
--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -43,6 +43,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.extensions.saml2.config.SAMLConfigurer
+import org.springframework.security.saml.websso.WebSSOProfileConsumerImpl
 import org.springframework.security.saml.SAMLCredential
 import org.springframework.security.saml.userdetails.SAMLUserDetailsService
 import org.springframework.security.web.authentication.RememberMeServices
@@ -89,6 +90,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
     List<String> requiredRoles
     UserAttributeMapping userAttributeMapping = new UserAttributeMapping()
+    long maxAuthenticationAge = 7200
 
     /**
      * Ensure that the keystore exists and can be accessed with the given keyStorePassword and keyStoreAliasName
@@ -149,6 +151,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           .metadataFilePath(samlSecurityConfigProperties.metadataUrl)
           .discoveryEnabled(false)
           .and()
+        .webSSOProfileConsumer(getWebSSOProfileConsumerImpl())
         .serviceProvider()
           .entityId(samlSecurityConfigProperties.issuerId)
           .protocol(samlSecurityConfigProperties.redirectProtocol)
@@ -168,6 +171,12 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   void configure(WebSecurity web) throws Exception {
     authConfig.configure(web)
+  }
+
+  public WebSSOProfileConsumerImpl getWebSSOProfileConsumerImpl() {
+    WebSSOProfileConsumerImpl profileConsumer = new WebSSOProfileConsumerImpl();
+    profileConsumer.setMaxAuthenticationAge(samlSecurityConfigProperties.maxAuthenticationAge);
+    return profileConsumer;
   }
 
   @Bean


### PR DESCRIPTION
The default  maxAuthenticationAge is 7200 in upstream spring module.  
This change allows configuring the maxAuthenticationAge as per any other SAMLSecurityConfigProperties entry.

Example gate-local.yaml:

```
saml:
  maxAuthenticationAge: 604800
```
This made by possible by the following stale PR, and replaces it:
https://github.com/spinnaker/gate/pull/550