### PR TITLE
fix(ratelimit): replace broken use of gauge with a counter

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RateLimitingInterceptor.java
@@ -168,6 +168,6 @@ public class RateLimitingInterceptor extends HandlerInterceptorAdapter {
     if (rate.isThrottled()) {
       registry.counter("rateLimit.principal.throttled", tags).increment();
     }
-    registry.gauge("rateLimit.principal.remaining", tags, rate.remaining);
+    registry.counter("rateLimit.principal.requests", tags).increment();
   }
 }


### PR DESCRIPTION
registry.gauge() actually tells the registry to regularly poll the value
of the passed number, which is clearly not the intent.

Replaces the (broken) rateLimit.principal.remaining gauge with a
rateLimit.principal.requests counter tagged by principal, which
should be more helpful in debugging rate limiting complaints.