### PR TITLE
feat(keel): add veto-related endpoints

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.kork.manageddelivery.model.DeliveryConfig;
 import com.netflix.spinnaker.kork.manageddelivery.model.Resource;
 import java.util.List;
 import java.util.Map;
+import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
@@ -57,7 +58,7 @@ public interface KeelService {
       @Path("application") String application, @Query("includeDetails") Boolean includeDetails);
 
   @POST("/vetos/{name}")
-  Map passVetoMessage(@Path("name") String name, @Body Map<String, Object> message);
+  Response passVetoMessage(@Path("name") String name, @Body Map<String, Object> message);
 
   @GET("/vetos/{name}/rejections")
   List<String> getVetoRejections(@Path("name") String name);

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -55,4 +55,10 @@ public interface KeelService {
   @GET("/application/{application}")
   Map getApplicationDetails(
       @Path("application") String application, @Query("includeDetails") Boolean includeDetails);
+
+  @POST("/vetos/{name}")
+  Map passVetoMessage(@Path("name") String name, @Body Map<String, Object> message);
+
+  @GET("/vetos/{name}/rejections")
+  List<String> getVetoRejections(@Path("name") String name);
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -87,8 +87,9 @@ public class ManagedController {
 
   @ApiOperation(value = "Pass a message to a veto plugin", response = Map.class)
   @RequestMapping(value = "/vetos/{name}", method = POST)
-  Map passVetoMessage(@PathVariable("name") String name, @RequestBody Map<String, Object> message) {
-    return keelService.passVetoMessage(name, message);
+  void passVetoMessage(
+      @PathVariable("name") String name, @RequestBody Map<String, Object> message) {
+    keelService.passVetoMessage(name, message);
   }
 
   @ApiOperation(value = "Get everything a specific veto plugin will reject", response = List.class)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.kork.manageddelivery.model.Resource;
 import groovy.util.logging.Slf4j;
 import io.swagger.annotations.ApiOperation;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,5 +83,17 @@ public class ManagedController {
       @RequestParam(value = "includeDetails", required = false, defaultValue = "false")
           Boolean includeDetails) {
     return keelService.getApplicationDetails(application, includeDetails);
+  }
+
+  @ApiOperation(value = "Pass a message to a veto plugin", response = Map.class)
+  @RequestMapping(value = "/vetos/{name}", method = POST)
+  Map passVetoMessage(@PathVariable("name") String name, @RequestBody Map<String, Object> message) {
+    return keelService.passVetoMessage(name, message);
+  }
+
+  @ApiOperation(value = "Get everything a specific veto plugin will reject", response = List.class)
+  @RequestMapping(value = "/vetos/{name}/rejections", method = GET)
+  List<String> getVetoRejections(@PathVariable("name") String name) {
+    return keelService.getVetoRejections(name);
   }
 }


### PR DESCRIPTION
Wiring up the endpoints in keel related to 'veto' plugins (https://github.com/spinnaker/keel/pull/348) so we can start letting folks opt out of keel management in the UI.