### PR TITLE
chore(cleanup): Remove no-longer-supported API

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -139,18 +139,6 @@ class PipelineController {
     }
   }
 
-  @ApiOperation(value = "Retrieve pipeline execution logs", response = List.class)
-  @RequestMapping(value = "{id}/logs", method = RequestMethod.GET)
-  List<Map> getPipelineLogs(@PathVariable("id") String id) {
-    try {
-      pipelineService.getPipelineLogs(id)
-    } catch (RetrofitError e) {
-      if (e.response?.status == 404) {
-        throw new NotFoundException("Pipeline not found (id: ${id})")
-      }
-    }
-  }
-
   @ApiOperation(value = "Cancel a pipeline execution")
   @RequestMapping(value = "{id}/cancel", method = RequestMethod.PUT)
   void cancelPipeline(@PathVariable("id") String id,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -130,10 +130,6 @@ class PipelineService {
     orcaServiceSelector.withContext(RequestContext.get()).getPipeline(id)
   }
 
-  List<Map> getPipelineLogs(String id) {
-    orcaServiceSelector.withContext(RequestContext.get()).getPipelineLogs(id)
-  }
-
   Map cancelPipeline(String id, String reason, boolean force) {
     setApplicationForExecution(id)
     orcaServiceSelector.withContext(RequestContext.get()).cancelPipeline(id, reason, force, "")

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaService.groovy
@@ -77,10 +77,6 @@ interface OrcaService {
   Map getPipeline(@Path("id") String id)
 
   @Headers("Accept: application/json")
-  @GET("/pipelines/{id}/logs")
-  List<Map> getPipelineLogs(@Path("id") String id)
-
-  @Headers("Accept: application/json")
   @PUT("/pipelines/{id}/cancel")
   Map cancelPipeline(@Path("id") String id, @Query("reason") reason, @Query("force") force, @Body String ignored)
 


### PR DESCRIPTION
Orca no longer supports the /pipelines/<id>/logs endpoint, so this
proxy in gate _always_ returns 404, confusingly saying "Pipeline not
found".

Ref.
https://github.com/spinnaker/orca/commit/cb9d5da853c304635d83e7777b38b48d5b774c05

