### PR TITLE
fix(authn/saml): Make saml email address configurable

### DIFF
--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -125,6 +125,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
     String roles = "memberOf"
     String rolesDelimiter = ";"
     String username
+    String email
   }
 
   @Autowired
@@ -212,8 +213,9 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
         def attributes = extractAttributes(assertion)
         def userAttributeMapping = samlSecurityConfigProperties.userAttributeMapping
 
-        def email = assertion.getSubject().nameID.value
-        String username = attributes[userAttributeMapping.username]?.get(0) ?: email
+        def subjectNameId = assertion.getSubject().nameID.value
+        def email = attributes[userAttributeMapping.email]?.get(0) ?: subjectNameId
+        String username = attributes[userAttributeMapping.username]?.get(0) ?: subjectNameId
         def roles = extractRoles(email, attributes, userAttributeMapping)
 
         if (samlSecurityConfigProperties.requiredRoles) {


### PR DESCRIPTION
Fixes: https://github.com/spinnaker/spinnaker/issues/4924 by making email address lookup from the SAML assertion configurable for when SAML is configured to NOT use email as the subject nameId.