### PR TITLE
fix(swagger): Enable canary config store for generating with swagger

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/swagger/GenerateSwaggerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/swagger/GenerateSwaggerSpec.groovy
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
   classes = [Main],
   initializers = YamlFileApplicationContextInitializer
 )
-@TestPropertySource(properties = "services.kayenta.enabled=true") // Enable Controllers we want to document in the spec here.
+@TestPropertySource(properties = [ "services.kayenta.enabled=true","services.kayenta.canary-config-store=true" ]) // Enable Controllers we want to document in the spec here.
 class GenerateSwaggerSpec extends Specification {
 
   @Autowired


### PR DESCRIPTION
Spin cli relies on the swagger.json file generated from this to create the gate client api. Without the canary config store set to true, the swagger.json omits the api endpoints defined in the [CanaryConfigController](https://github.com/spinnaker/gate/blob/master/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryConfigController.groovy#L32). This is because of the conditional bean on the CanaryConfigService.