### PR TITLE
feat(displayNameBaseOs): Add displayName to baseOS

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/BakeService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/BakeService.groovy
@@ -72,6 +72,7 @@ class BakeService {
     String id
     String shortDescription
     String detailedDescription
+    String displayName
     String packageType
     List<String> vmTypes
   }


### PR DESCRIPTION
Adding a display name field to base image properties, for cases when the bakery expects specific value and we want to have a custom name.