### PR TITLE
feat(artifact): expose get single artifact

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
@@ -23,7 +23,13 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @RestController
@@ -81,5 +87,15 @@ public class ArtifactController {
       @PathVariable String packageName,
       @RequestParam(required = false) String releaseStatus) {
     return artifactService.getVersionsOfArtifactForProvider(provider, packageName, releaseStatus);
+  }
+
+  @ApiOperation(
+      value = "Retrieve the specified artifact version for an artifact provider and package name")
+  @RequestMapping(value = "/{provider}/{packageName}/{version:.+}", method = RequestMethod.GET)
+  Map<String, Object> getArtifact(
+      @PathVariable String provider,
+      @PathVariable String packageName,
+      @PathVariable String version) {
+    return artifactService.getArtifactByVersion(provider, packageName, version);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
@@ -59,6 +59,11 @@ public class ArtifactService {
     return HystrixFactory.newVoidCommand(GROUP, type, work);
   }
 
+  private static HystrixCommand<Map<String, Object>> mapCommand(
+      String type, Callable<Map<String, Object>> work) {
+    return HystrixFactory.newMapCommand(GROUP, type, work);
+  }
+
   public List<Map> getArtifactCredentials(String selectorKey) {
     return mapListCommand(
             "artifactCredentials",
@@ -108,6 +113,19 @@ public class ArtifactService {
     return stringListCommand(
             "artifactVersionsByProvider",
             () -> igorService.get().getArtifactVersions(provider, packageName, releaseStatus))
+        .execute();
+  }
+
+  public Map<String, Object> getArtifactByVersion(
+      String provider, String packageName, String version) {
+    if (!igorService.isPresent()) {
+      throw new IllegalStateException(
+          "Cannot fetch artifact versions because Igor is not enabled.");
+    }
+
+    return mapCommand(
+            "artifactFromVersion",
+            () -> igorService.get().getArtifactByVersion(provider, packageName, version))
         .execute();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/IgorService.groovy
@@ -18,6 +18,7 @@
 
 package com.netflix.spinnaker.gate.services.internal
 
+
 import retrofit.http.EncodedPath
 import retrofit.http.GET
 import retrofit.http.Path
@@ -74,6 +75,11 @@ interface IgorService {
   List<String> getArtifactVersions(@Path("provider") String provider,
                                    @Path("packageName") String packageName,
                                    @Query("releaseStatus") String releaseStatus);
+
+  @GET('/artifacts/{provider}/{packageName}/{version}')
+  Map<String, Object> getArtifactByVersion(@Path("provider") String provider,
+                                           @Path("packageName") String packageName,
+                                           @Path("version") String version);
 
   @GET('/concourse/{buildMaster}/teams/{team}/pipelines/{pipeline}/resources')
   List<String> getConcourseResources(@Path("buildMaster") String buildMaster, @Path("team") String team, @Path("pipeline") String pipeline);


### PR DESCRIPTION
This endpoint exists in igor, but wasn't exposed through the UI. It's not currently needed for anything but it's really helpful when debugging things like "can we actually fetch this artifact" or "what does an artifact look like".