### PR TITLE
feat(canary): Exposes API initiating canary given a config.

### DIFF
--- a/.idea/README.md
+++ b/.idea/README.md
@@ -7,4 +7,4 @@ you will need to undo that.
 
 ```bash
 $ git update-index --no-assume-unchanged $FILENAME
-``` 
+```

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2CanaryController.groovy
@@ -73,6 +73,20 @@ class V2CanaryController {
                                    configurationAccountName)
   }
 
+  @ApiOperation(value = 'Start a canary execution with the supplied canary config')
+  @RequestMapping(value = '/canary', method = RequestMethod.POST)
+  Map initiateCanaryWithConfig(@RequestBody Map adhocExecutionRequest,
+                               @RequestParam(value = 'application', required = false) String application,
+                               @RequestParam(value = 'parentPipelineExecutionId', required = false) String parentPipelineExecutionId,
+                               @RequestParam(value = 'metricsAccountName', required = false) String metricsAccountName,
+                               @RequestParam(value = 'storageAccountName', required = false) String storageAccountName) {
+    v2CanaryService.initiateCanaryWithConfig(adhocExecutionRequest,
+      application,
+      parentPipelineExecutionId,
+      metricsAccountName,
+      storageAccountName)
+  }
+
   @ApiOperation(value = 'Retrieve a canary result')
   @RequestMapping(value = '/canary/{canaryConfigId}/{canaryExecutionId}', method = RequestMethod.GET)
   Map getCanaryResult(@PathVariable String canaryConfigId,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2CanaryService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2CanaryService.groovy
@@ -66,6 +66,24 @@ class V2CanaryService {
     }).execute() as List
   }
 
+  Map initiateCanaryWithConfig(Map adhocExecutionRequest,
+                               String application,
+                               String parentPipelineExecutionId,
+                               String metricsAccountName,
+                               String storageAccountName) {
+    return HystrixFactory.newMapCommand(HYSTRIX_GROUP, "initiateCanaryWithConfig", {
+      try {
+        return kayentaService.initiateCanaryWithConfig(adhocExecutionRequest,
+          application,
+          parentPipelineExecutionId,
+          metricsAccountName,
+          storageAccountName)
+      } catch (RetrofitError error) {
+        throw classifyError(error)
+      }
+    }).execute() as Map
+  }
+
   Map initiateCanary(String canaryConfigId,
                      Map executionRequest,
                      String application,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KayentaService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KayentaService.groovy
@@ -51,6 +51,13 @@ interface KayentaService {
   @GET("/judges")
   List listJudges()
 
+  @POST("/canary")
+  Map initiateCanaryWithConfig(@Body Map adhocExecutionRequest,
+                               @Query("application") String application,
+                               @Query("parentPipelineExecutionId") String parentPipelineExecutionId,
+                               @Query("metricsAccountName") String metricsAccountName,
+                               @Query("storageAccountName") String storageAccountName)
+
   @POST("/canary/{canaryConfigId}")
   Map initiateCanary(@Path("canaryConfigId") String canaryConfigId,
                      @Body Map executionRequest,


### PR DESCRIPTION
Exposes Kayenta's API for running a canary execution given a supplied canary config. This is to enable dry-running canary configs via retrospective from spin CLI. This shortens the development loop when creating/updating canary configs.