### PR TITLE
feat(saml): add prefix to saml files if not present

### DIFF
--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -97,23 +97,23 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
      */
     @PostConstruct
     void validate() {
-      def keyStoreToValidate = keyStore
-      if (!keyStoreToValidate) {
-        return
+      if (metadataUrl && metadataUrl.startsWith("/")) {
+        metadataUrl = "file:" + metadataUrl
       }
 
-      if (!keyStoreToValidate.startsWith("file:")) {
-        keyStoreToValidate = "file:" + keyStoreToValidate
-      }
+      if (keyStore) {
+        if (!keyStore.startsWith("file:")) {
+          keyStore = "file:" + keyStore
+        }
+        new File(new URI(keyStore)).withInputStream { is ->
+          def keystore = KeyStore.getInstance(KeyStore.getDefaultType())
 
-      new File(new URI(keyStoreToValidate)).withInputStream { is ->
-        def keystore = KeyStore.getInstance(KeyStore.getDefaultType())
+          // will throw an exception if `keyStorePassword` is invalid
+          keystore.load(is, keyStorePassword.toCharArray())
 
-        // will throw an exception if `keyStorePassword` is invalid
-        keystore.load(is, keyStorePassword.toCharArray());
-
-        if (keyStoreAliasName && !keystore.aliases().find { it.equalsIgnoreCase(keyStoreAliasName) }) {
-          throw new IllegalStateException("Keystore '${keyStore}' does not contain alias '${keyStoreAliasName}'")
+          if (keyStoreAliasName && !keystore.aliases().find { it.equalsIgnoreCase(keyStoreAliasName) }) {
+            throw new IllegalStateException("Keystore '${keyStore}' does not contain alias '${keyStoreAliasName}'")
+          }
         }
       }
     }


### PR DESCRIPTION
Both the SAML metadata and keystore files need to be prefixed with "file:". This simply adds that prefix if it isn't already there.

@cfieber this would help clean up the logic around secret file decryption in the services (along with kork PR: https://github.com/spinnaker/kork/pull/388)