### PR TITLE
feat(keel): add diff endpoints

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -44,6 +44,9 @@ public interface KeelService {
   @POST("/resources")
   Resource upsertResource(@Body Resource resource);
 
+  @POST("/resources/diff")
+  Map diffResource(@Body Resource resource);
+
   @DELETE("/resources/{name}")
   Resource deleteResource(@Path("name") String name);
 
@@ -52,6 +55,9 @@ public interface KeelService {
 
   @POST("/delivery-configs")
   DeliveryConfig upsertManifest(@Body DeliveryConfig manifest);
+
+  @POST("/delivery-configs/diff")
+  Map diffManifest(@Body DeliveryConfig manifest);
 
   @GET("/application/{application}")
   Map getApplicationDetails(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -62,6 +62,12 @@ public class ManagedController {
     return keelService.upsertResource(resource);
   }
 
+  @ApiOperation(value = "Ad-hoc validate and diff a resource", response = Resource.class)
+  @RequestMapping(value = "/resources/diff", method = POST)
+  Map diffResource(@RequestBody Resource resource) {
+    return keelService.diffResource(resource);
+  }
+
   @ApiOperation(value = "Delete a resource", response = Resource.class)
   @RequestMapping(value = "/resources/{name}", method = DELETE)
   Resource deleteResource(@PathVariable("name") String name) {
@@ -80,6 +86,14 @@ public class ManagedController {
   @RequestMapping(value = "/delivery-configs", method = POST)
   DeliveryConfig upsertManifest(@RequestBody DeliveryConfig manifest) {
     return keelService.upsertManifest(manifest);
+  }
+
+  @ApiOperation(
+      value = "Ad-hoc validate and diff a config manifest",
+      response = DeliveryConfig.class)
+  @RequestMapping(value = "/delivery-configs", method = POST)
+  Map diffManifest(@RequestBody DeliveryConfig manifest) {
+    return keelService.diffManifest(manifest);
   }
 
   @ApiOperation(value = "Get managed details about an application", response = Map.class)


### PR DESCRIPTION
Exposing the ad-hoc diff endpoints through gate. They're exposed as a map right now, until we decide that this format is okay. Then I'll create a real object in kork.

Implemented in keel in https://github.com/spinnaker/keel/pull/512 and https://github.com/spinnaker/keel/pull/513.