### PR TITLE
fix(managed): Use RequestParam instead of Query so Swagger UI does it right

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import retrofit.RetrofitError;
 import retrofit.client.Header;
-import retrofit.http.Query;
 
 @RequestMapping("/managed")
 @RestController
@@ -84,7 +83,7 @@ public class ManagedController {
       @PathVariable("account") String account,
       @PathVariable("type") String type,
       @PathVariable("name") String name,
-      @Query("serviceAccount") String serviceAccount) {
+      @RequestParam("serviceAccount") String serviceAccount) {
     return keelService.exportResource(cloudProvider, account, type, name, serviceAccount);
   }
 


### PR DESCRIPTION
Spring + Swagger is, as usual, totally impossible to predict. There are two different ways of annotating query parameters (`@Query` and `@RequestParam`) and while I cannot for the life of me tell the difference between the two or why they exist, it appears the Swagger UI supports `RequestParam` and not `Query`. This resulted in the UI playground for this endpoint choosing to type/present the `serviceAccount` parameter as the request body, which is not only wrong but would never work because it's a GET. This just switches to the other one, which I confirmed works as expected in the Swagger UI.