### PR TITLE
fix(swagger): add explicit http methods

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
@@ -23,6 +23,7 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
@@ -40,7 +41,7 @@ class PagerDutyController {
   @Autowired
   PagerDutyService pagerDutyService
 
-  @RequestMapping(value = "/services", method = RequestMethod.GET)
+  @GetMapping("/services")
   List<Map> getServices() {
     return pagerDutyServicesCache.get().collect {
       def policyId = it.escalation_policy != null ? it["escalation_policy"]["id"] : null
@@ -59,7 +60,7 @@ class PagerDutyController {
     return (service.integrations as List<Map>).find { it.type == "generic_events_api_inbound_integration" }?.integration_key
   }
 
-  @RequestMapping(value = "/oncalls", method = RequestMethod.GET)
+  @GetMapping("/oncalls")
   Map<String, List<Map>> getOnCalls() {
     // Map by escalation policy
     Map<String, List<Map>> groupedByPolicy = pagerDutyOnCallCache.get().groupBy { (it.escalation_policy as Map)?.id as String }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 import java.util.concurrent.atomic.AtomicReference
 
@@ -39,7 +40,7 @@ class PagerDutyController {
   @Autowired
   PagerDutyService pagerDutyService
 
-  @RequestMapping("/services")
+  @RequestMapping(value = "/services", method = RequestMethod.GET)
   List<Map> getServices() {
     return pagerDutyServicesCache.get().collect {
       def policyId = it.escalation_policy != null ? it["escalation_policy"]["id"] : null
@@ -58,7 +59,7 @@ class PagerDutyController {
     return (service.integrations as List<Map>).find { it.type == "generic_events_api_inbound_integration" }?.integration_key
   }
 
-  @RequestMapping("/oncalls")
+  @RequestMapping(value = "/oncalls", method = RequestMethod.GET)
   Map<String, List<Map>> getOnCalls() {
     // Map by escalation policy
     Map<String, List<Map>> groupedByPolicy = pagerDutyOnCallCache.get().groupBy { (it.escalation_policy as Map)?.id as String }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -232,7 +232,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/evaluateExpression")
+  @RequestMapping(value = "{id}/evaluateExpression", method = RequestMethod.GET)
   Map evaluateExpressionForExecution(@PathVariable("id") String id,
                                      @RequestParam("expression") String pipelineExpression) {
     try {
@@ -258,7 +258,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression at a specific stage using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/{stageId}/evaluateExpression")
+  @RequestMapping(value = "{id}/{stageId}/evaluateExpression", method = RequestMethod.GET)
   Map evaluateExpressionForExecutionAtStage(@PathVariable("id") String id,
                                             @PathVariable("stageId") String stageId,
                                             @RequestParam("expression") String pipelineExpression) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -60,14 +60,14 @@ class PipelineController {
   ObjectMapper objectMapper
 
   @ApiOperation(value = "Delete a pipeline definition")
-  @RequestMapping(value = "/{application}/{pipelineName:.+}", method = RequestMethod.DELETE)
+  @DeleteMapping("/{application}/{pipelineName:.+}")
   void deletePipeline(@PathVariable String application, @PathVariable String pipelineName) {
     pipelineService.deleteForApplication(application, pipelineName)
   }
 
   @CompileDynamic
   @ApiOperation(value = "Save a pipeline definition")
-  @RequestMapping(value = '', method = RequestMethod.POST)
+  @PostMapping('')
   void savePipeline(@RequestBody Map pipeline) {
     def operation = [
       description: (String) "Save pipeline '${pipeline.get("name") ?: "Unknown"}'",
@@ -92,13 +92,13 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Rename a pipeline definition")
-  @RequestMapping(value = 'move', method = RequestMethod.POST)
+  @PostMapping('move')
   void renamePipeline(@RequestBody Map renameCommand) {
     pipelineService.move(renameCommand)
   }
 
   @ApiOperation(value = "Retrieve a pipeline execution")
-  @RequestMapping(value = "{id}", method = RequestMethod.GET)
+  @GetMapping("{id}")
   Map getPipeline(@PathVariable("id") String id) {
     try {
       pipelineService.getPipeline(id)
@@ -111,7 +111,7 @@ class PipelineController {
 
   @CompileDynamic
   @ApiOperation(value = "Update a pipeline definition", response = HashMap.class)
-  @RequestMapping(value = "{id}", method = RequestMethod.PUT)
+  @PutMapping("{id}")
   Map updatePipeline(@PathVariable("id") String id, @RequestBody Map pipeline) {
     def operation = [
       description: (String) "Update pipeline '${pipeline.get("name") ?: 'Unknown'}'",
@@ -141,7 +141,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Cancel a pipeline execution")
-  @RequestMapping(value = "{id}/cancel", method = RequestMethod.PUT)
+  @PutMapping("{id}/cancel")
   void cancelPipeline(@PathVariable("id") String id,
                       @RequestParam(required = false) String reason,
                       @RequestParam(defaultValue = "false") boolean force) {
@@ -149,37 +149,37 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Pause a pipeline execution")
-  @RequestMapping(value = "{id}/pause", method = RequestMethod.PUT)
+  @PutMapping("{id}/pause")
   void pausePipeline(@PathVariable("id") String id) {
     pipelineService.pausePipeline(id)
   }
 
   @ApiOperation(value = "Resume a pipeline execution", response = HashMap.class)
-  @RequestMapping(value = "{id}/resume", method = RequestMethod.PUT)
+  @PutMapping("{id}/resume")
   void resumePipeline(@PathVariable("id") String id) {
     pipelineService.resumePipeline(id)
   }
 
   @ApiOperation(value = "Update a stage execution", response = HashMap.class)
-  @RequestMapping(value = "/{id}/stages/{stageId}", method = RequestMethod.PATCH)
+  @PatchMapping("/{id}/stages/{stageId}")
   Map updateStage(@PathVariable("id") String id, @PathVariable("stageId") String stageId, @RequestBody Map context) {
     pipelineService.updatePipelineStage(id, stageId, context)
   }
 
   @ApiOperation(value = "Restart a stage execution", response = HashMap.class)
-  @RequestMapping(value = "/{id}/stages/{stageId}/restart", method = RequestMethod.PUT)
+  @PutMapping("/{id}/stages/{stageId}/restart")
   Map restartStage(@PathVariable("id") String id, @PathVariable("stageId") String stageId, @RequestBody Map context) {
     pipelineService.restartPipelineStage(id, stageId, context)
   }
 
   @ApiOperation(value = "Delete a pipeline execution", response = HashMap.class)
-  @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
+  @DeleteMapping("{id}")
   Map deletePipeline(@PathVariable("id") String id) {
     pipelineService.deletePipeline(id);
   }
 
   @ApiOperation(value = "Initiate a pipeline execution")
-  @RequestMapping(value = '/start', method = RequestMethod.POST)
+  @PostMapping('/start')
   ResponseEntity start(@RequestBody Map map) {
     if (map.containsKey("application")) {
       RequestContext.setApplication(map.get("application").toString())
@@ -191,7 +191,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Trigger a pipeline execution")
-  @RequestMapping(value = "/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
+  @PostMapping("/{application}/{pipelineNameOrId:.+}")
   @ResponseBody
   @ResponseStatus(HttpStatus.ACCEPTED)
   Map invokePipelineConfig(@PathVariable("application") String application,
@@ -215,7 +215,7 @@ class PipelineController {
 
   @ApiOperation(value = "Trigger a pipeline execution")
   @PreAuthorize("hasPermission(#application, 'APPLICATION', 'EXECUTE')")
-  @RequestMapping(value = "/v2/{application}/{pipelineNameOrId:.+}", method = RequestMethod.POST)
+  @PostMapping("/v2/{application}/{pipelineNameOrId:.+}")
   HttpEntity invokePipelineConfigViaEcho(@PathVariable("application") String application,
                                          @PathVariable("pipelineNameOrId") String pipelineNameOrId,
                                          @RequestBody(required = false) Map trigger) {
@@ -232,7 +232,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/evaluateExpression", method = RequestMethod.GET)
+  @GetMapping("{id}/evaluateExpression")
   Map evaluateExpressionForExecution(@PathVariable("id") String id,
                                      @RequestParam("expression") String pipelineExpression) {
     try {
@@ -245,7 +245,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/evaluateExpression", method = RequestMethod.POST, consumes = "text/plain")
+  @PostMapping(value = "{id}/evaluateExpression", consumes = "text/plain")
   Map evaluateExpressionForExecutionViaPOST(@PathVariable("id") String id,
                                             @RequestBody String pipelineExpression) {
     try {
@@ -258,7 +258,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression at a specific stage using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/{stageId}/evaluateExpression", method = RequestMethod.GET)
+  @GetMapping("{id}/{stageId}/evaluateExpression")
   Map evaluateExpressionForExecutionAtStage(@PathVariable("id") String id,
                                             @PathVariable("stageId") String stageId,
                                             @RequestParam("expression") String pipelineExpression) {
@@ -272,7 +272,7 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Evaluate a pipeline expression using the provided execution as context", response = HashMap.class)
-  @RequestMapping(value = "{id}/evaluateExpression", method = RequestMethod.POST, consumes = "application/json")
+  @PostMapping(value = "{id}/evaluateExpression", consumes = "application/json")
   Map evaluateExpressionForExecutionViaPOST(@PathVariable("id") String id,
                                             @RequestBody Map pipelineExpression) {
     try {


### PR DESCRIPTION
Add http methods to pipeline and pagerduty controllers so that we don't have all the possible http methods show up in swagger
