### PR TITLE
fix(ldap): Fix an issue where LDAP logins using SameSite cookies

### DIFF
--- a/gate-ldap/gate-ldap.gradle
+++ b/gate-ldap/gate-ldap.gradle
@@ -3,4 +3,6 @@ dependencies {
   implementation "org.springframework.security:spring-security-ldap"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "org.apache.commons:commons-lang3"
+  implementation "org.springframework.session:spring-session-core"
+
 }

--- a/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -39,6 +39,7 @@ import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+import org.springframework.session.web.http.DefaultCookieSerializer
 import org.springframework.stereotype.Component
 
 @ConditionalOnExpression('${ldap.enabled:false}')
@@ -86,8 +87,12 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
     }
   }
 
+  @Autowired
+  DefaultCookieSerializer defaultCookieSerializer
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
+    defaultCookieSerializer.setSameSite(null)
     http.formLogin()
     authConfig.configure(http)
     http.addFilterBefore(new BasicAuthenticationFilter(authenticationManager()), UsernamePasswordAuthenticationFilter)

--- a/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
+++ b/gate-ldap/src/main/groovy/com/netflix/spinnaker/gate/security/ldap/LdapSsoConfig.groovy
@@ -60,6 +60,9 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   SecurityProperties securityProperties
 
+  @Autowired
+  DefaultCookieSerializer defaultCookieSerializer
+
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
 
@@ -86,9 +89,6 @@ class LdapSsoConfig extends WebSecurityConfigurerAdapter {
       ldapConfigurer.userSearchFilter(ldapConfigProps.userSearchFilter)
     }
   }
-
-  @Autowired
-  DefaultCookieSerializer defaultCookieSerializer
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {


### PR DESCRIPTION
LDAP Logins when creating a cookie session don't set the samesite entry to null, thus LDAP logins are restricted to what are determined to be "Same sites".  This means when using AWS Load balanced hosts, you end up in an infinite loop.  This fixes this to match SAML & OAUTH configurations.