### PR TITLE
chore(dependencies): Upgrade Spring Boot to 2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ allprojects {
 
       implementation "org.codehaus.groovy:groovy-all"
       implementation "net.logstash.logback:logstash-logback-encoder"
+      implementation "org.jetbrains.kotlin:kotlin-reflect"
       runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
       testRuntime "org.springframework.boot:spring-boot-properties-migrator"
 

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -58,6 +58,7 @@ dependencies {
   testImplementation "com.squareup.retrofit:retrofit-mock"
   testImplementation "org.springframework.security:spring-security-test"
   testImplementation "org.springframework.security:spring-security-ldap"
+  testImplementation "org.springframework.security:spring-security-oauth2-jose"
   testImplementation "com.unboundid:unboundid-ldapsdk"
   testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate
 
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorConfig
+import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthContributorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
@@ -32,7 +33,9 @@ import org.springframework.scheduling.annotation.EnableAsync
 @EnableConfigurationProperties
 @Import([HystrixSpectatorConfig])
 @ComponentScan(["com.netflix.spinnaker.gate", "com.netflix.spinnaker.config"])
-@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration])
+@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration,
+  GsonAutoConfiguration,
+  LdapHealthContributorAutoConfiguration])
 class Main {
 
   static final Map<String, String> DEFAULT_PROPS = [

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.gate
 
 import com.netflix.spinnaker.hystrix.spectator.HystrixSpectatorConfig
-import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
@@ -33,7 +32,7 @@ import org.springframework.scheduling.annotation.EnableAsync
 @EnableConfigurationProperties
 @Import([HystrixSpectatorConfig])
 @ComponentScan(["com.netflix.spinnaker.gate", "com.netflix.spinnaker.config"])
-@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration, LdapHealthIndicatorAutoConfiguration])
+@EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration])
 class Main {
 
   static final Map<String, String> DEFAULT_PROPS = [

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/health/RedisRelaxedHealthIndicator.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/health/RedisRelaxedHealthIndicator.groovy
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
 import org.springframework.util.Assert
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
-import redis.clients.util.Pool
+import redis.clients.jedis.util.Pool
 
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.ToDoubleFunction

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -41,7 +41,6 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
 import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
@@ -254,7 +253,7 @@ class FunctionalSpec extends Specification {
   }
 
   @Order(10)
-  @EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration, LdapHealthIndicatorAutoConfiguration])
+  @EnableAutoConfiguration(exclude = [GroovyTemplateAutoConfiguration, GsonAutoConfiguration])
   private static class FunctionalConfiguration extends WebSecurityConfigurerAdapter {
 
     @Bean

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 fiatVersion=1.9.1
 enablePublishing=false
 spinnakerGradleVersion=7.0.1
-korkVersion=6.22.2
+korkVersion=7.0.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
 org.gradle.parallel=true


### PR DESCRIPTION
- See spinnaker/spinnaker#5134
- Dependent on spinnaker/kork#419 for a Spring Boot dependency upgrade
- Kotlin's reflection facilities needed by Spring are shipped in a separate JAR - https://kotlinlang.org/docs/reference/reflection.html
- `LdapHealthIndicatorAutoConfiguration` is no longer available in Spring Boot to 2.2.1