### PR TITLE
fix(slack): Increase delay between scheduled calls to Slack API

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
@@ -8,5 +8,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SlackConfigProperties {
   String token;
   String baseUrl;
-  Long channelRefreshIntervalInMs;
+  Long channelRefreshIntervalMillis;
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
@@ -8,5 +8,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SlackConfigProperties {
   String token;
   String baseUrl;
-  Integer channelRefreshIntervalInMs;
+  Long channelRefreshIntervalInMs;
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/SlackConfigProperties.java
@@ -8,4 +8,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SlackConfigProperties {
   String token;
   String baseUrl;
+  Integer channelRefreshIntervalInMs;
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -47,7 +47,6 @@ public class SlackController {
 
   private final SlackConfigProperties slackConfigProperties;
   private final SlackService slackService;
-  private final Integer refreshDelay;
 
   @Autowired
   public SlackController(
@@ -55,7 +54,6 @@ public class SlackController {
     this.slackService = slackService;
     this.slackConfigProperties = slackConfigProperties;
     this.registry = registry;
-    this.refreshDelay = slackConfigProperties.getChannelRefreshIntervalInMs();
   }
 
   @ApiOperation("Retrieve a list of public slack channels")
@@ -66,7 +64,7 @@ public class SlackController {
 
   @Scheduled(
       fixedDelayString = "${slack.channelRefreshIntervalInMs:1200000}",
-      initialDelayString = "${random.int(1200000)}")
+      initialDelayString = "${random.int(300000)}")x
   void refreshSlack() {
     try {
       log.info("Refreshing Slack channels list");
@@ -75,7 +73,7 @@ public class SlackController {
       slackChannelsCache.set(channels);
     } catch (Exception e) {
       registry.counter("slack.channels.errors").increment();
-      log.error("Unable to refresh Slack service list", e);
+      log.error("Unable to refresh Slack channels list", e);
     }
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -63,7 +63,7 @@ public class SlackController {
   }
 
   @Scheduled(
-      fixedDelayString = "${slack.channelRefreshIntervalInMs:1200000}",
+      fixedDelayString = "${slack.channel-refresh-interval-millis:1200000}",
       initialDelayString = "${random.int(600000)}")
   void refreshSlack() {
     try {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -28,16 +28,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/slack")
-@ConditionalOnProperty(
-    prefix = "slack",
-    name = {"token", "baseUrl"})
 public class SlackController {
 
   private static final Logger log = LoggerFactory.getLogger(SlackController.class);
@@ -62,7 +58,7 @@ public class SlackController {
     return slackChannelsCache.get();
   }
 
-  @Scheduled(fixedDelay = 300000L)
+  @Scheduled(fixedDelay = 1800000L)
   void refreshSlack() {
     try {
       log.info("Refreshing Slack channels list");

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -28,12 +28,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/slack")
+@ConditionalOnProperty(
+    prefix = "slack",
+    name = {"token", "baseUrl"})
 public class SlackController {
 
   private static final Logger log = LoggerFactory.getLogger(SlackController.class);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -64,7 +64,7 @@ public class SlackController {
 
   @Scheduled(
       fixedDelayString = "${slack.channelRefreshIntervalInMs:1200000}",
-      initialDelayString = "${random.int(300000)}")x
+      initialDelayString = "${random.int(600000)}")
   void refreshSlack() {
     try {
       log.info("Refreshing Slack channels list");

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -47,6 +47,7 @@ public class SlackController {
 
   private final SlackConfigProperties slackConfigProperties;
   private final SlackService slackService;
+  private final Integer refreshDelay;
 
   @Autowired
   public SlackController(
@@ -54,6 +55,7 @@ public class SlackController {
     this.slackService = slackService;
     this.slackConfigProperties = slackConfigProperties;
     this.registry = registry;
+    this.refreshDelay = slackConfigProperties.getChannelRefreshIntervalInMs();
   }
 
   @ApiOperation("Retrieve a list of public slack channels")
@@ -62,7 +64,9 @@ public class SlackController {
     return slackChannelsCache.get();
   }
 
-  @Scheduled(fixedDelay = 1800000L)
+  @Scheduled(
+      fixedDelayString = "${slack.channelRefreshIntervalInMs:1200000}",
+      initialDelayString = "${random.int(1200000)}")
   void refreshSlack() {
     try {
       log.info("Refreshing Slack channels list");


### PR DESCRIPTION
Slack is rate limiting our requests, and the channels do not update frequently. This PR:
1. Increase time between calls
2. Randomize initial delay to stagger the calls between instances and prevent rate limiting from Slack's API