### PR TITLE
refactor(managed): switch from veto -> pause APIs

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -63,11 +63,11 @@ public interface KeelService {
   Map getApplicationDetails(
       @Path("application") String application, @Query("includeDetails") Boolean includeDetails);
 
-  @POST("/vetos/{name}")
-  Response passVetoMessage(@Path("name") String name, @Body Map<String, Object> message);
+  @POST("/application/{application}/pause")
+  Response pauseApplication(@Path("application") String application, @Body Map requestBody);
 
-  @GET("/vetos/{name}/rejections")
-  List<String> getVetoRejections(@Path("name") String name);
+  @DELETE("/application/{application}/pause")
+  Response resumeApplication(@Path("application") String application);
 
   @GET("/export/{cloudProvider}/{account}/{type}/{name}")
   Resource exportResource(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.kork.manageddelivery.model.Resource;
 import groovy.util.logging.Slf4j;
 import io.swagger.annotations.ApiOperation;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,17 +136,16 @@ public class ManagedController {
     return keelService.getApplicationDetails(application, includeDetails);
   }
 
-  @ApiOperation(value = "Pass a message to a veto plugin", response = Map.class)
-  @PostMapping(path = "/vetos/{name}")
-  void passVetoMessage(
-      @PathVariable("name") String name, @RequestBody Map<String, Object> message) {
-    keelService.passVetoMessage(name, message);
+  @ApiOperation(value = "Pause management of an entire application")
+  @PostMapping(path = "/application/{application}/pause")
+  void pauseApplication(@PathVariable("application") String application) {
+    keelService.pauseApplication(application, Collections.emptyMap());
   }
 
-  @ApiOperation(value = "Get everything a specific veto plugin will reject", response = List.class)
-  @GetMapping(path = "/vetos/{name}/rejections")
-  List<String> getVetoRejections(@PathVariable("name") String name) {
-    return keelService.getVetoRejections(name);
+  @ApiOperation(value = "Resume management of an entire application")
+  @DeleteMapping(path = "/application/{application}/pause")
+  void resumeApplication(@PathVariable("application") String application) {
+    keelService.resumeApplication(application);
   }
 
   @ExceptionHandler


### PR DESCRIPTION
This sets up `ManagedController` to reflect the paused-related changes in https://github.com/spinnaker/keel/pull/644.

I yanked out the veto-related endpoints for now because they don't have a use, but would be happy to throw them back in if desired.