### PR TITLE
fix(auth): Basic auth was missing the cookie serializer like other auth mechanisms

### DIFF
--- a/gate-basic/gate-basic.gradle
+++ b/gate-basic/gate-basic.gradle
@@ -1,4 +1,5 @@
 dependencies {
   implementation project(":gate-core")
   implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "org.springframework.session:spring-session-core"
 }

--- a/gate-basic/src/main/java/com/netflix/spinnaker/gate/security/basic/BasicAuthConfig.java
+++ b/gate-basic/src/main/java/com/netflix/spinnaker/gate/security/basic/BasicAuthConfig.java
@@ -28,6 +28,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.session.web.http.DefaultCookieSerializer;
 
 @ConditionalOnExpression("${security.basicform.enabled:false}")
 @Configuration
@@ -38,6 +39,8 @@ public class BasicAuthConfig extends WebSecurityConfigurerAdapter {
   private final AuthConfig authConfig;
 
   private final BasicAuthProvider authProvider;
+
+  @Autowired DefaultCookieSerializer defaultCookieSerializer;
 
   @Autowired
   public BasicAuthConfig(AuthConfig authConfig, SecurityProperties securityProperties) {
@@ -52,6 +55,7 @@ public class BasicAuthConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
+    defaultCookieSerializer.setSameSite(null);
     http.formLogin()
         .and()
         .httpBasic()


### PR DESCRIPTION
Fixes same issue had with LDAP - was missing the cookie serializer, so when gate & deck come up with different ALB's, you can't login without getting into an infinite loop.  