### PR TITLE
feat(core): Update Gate to return Map of versioned pipeline templates

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -104,8 +104,12 @@ interface Front50Service {
                             @Query("tag") String tag,
                             @Query("digest") String digest)
 
+  // TODO(louisjimenez): Deprecated. Will be replaced with /versions endpoint starting with 1.19.
   @GET('/v2/pipelineTemplates')
   List<Map> getV2PipelineTemplates(@Query("scopes") String... scopes)
+
+  @GET('/v2/pipelineTemplates/versions')
+  Map<String, List<Map>> getV2PipelineTemplatesVersions(@Query("scopes") String... scopes)
 
   @GET("/v2/pipelineTemplates/{pipelineTemplateId}/dependentPipelines")
   List<Map<String, Object>> getV2PipelineTemplateDependents(@Path("pipelineTemplateId") String pipelineTemplateId)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2PipelineTemplatesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/V2PipelineTemplatesController.java
@@ -68,10 +68,17 @@ public class V2PipelineTemplatesController {
     this.objectMapper = objectMapper;
   }
 
+  // TODO(louisjimenez): Deprecated. Will be replaced with /versions endpoint starting with 1.19.
   @ApiOperation(value = "(ALPHA) List pipeline templates.", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
   public Collection<Map> list(@RequestParam(required = false) List<String> scopes) {
     return v2PipelineTemplateService.findByScope(scopes);
+  }
+
+  @ApiOperation(value = "List pipeline templates with versions", response = Map.class)
+  @RequestMapping(value = "/versions", method = RequestMethod.GET)
+  public Map<String, List<Map>> listVersions(@RequestParam(required = false) List<String> scopes) {
+    return v2PipelineTemplateService.findVersionsByScope(scopes);
   }
 
   @ApiOperation(value = "(ALPHA) Plan a pipeline template configuration.", response = HashMap.class)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2PipelineTemplateService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/V2PipelineTemplateService.java
@@ -50,8 +50,14 @@ public class V2PipelineTemplateService {
     return orcaServiceSelector.withContext(RequestContext.get()).plan(pipeline);
   }
 
+  // TODO(louisjimenez): Deprecated. Will be replaced with /versions endpoint starting with 1.19.
   public List<Map> findByScope(List<String> scopes) {
     return front50Service.getV2PipelineTemplates(
+        scopes == null ? null : (String[]) scopes.toArray());
+  }
+
+  public Map<String, List<Map>> findVersionsByScope(List<String> scopes) {
+    return front50Service.getV2PipelineTemplatesVersions(
         scopes == null ? null : (String[]) scopes.toArray());
   }
 


### PR DESCRIPTION
https://github.com/spinnaker/spinnaker/issues/4670

This is part of a larger set of changes to support displaying versioned templates in the UI and Spin.

Related PRs:
[Deck](https://github.com/spinnaker/deck/pull/7708)
[Front50](https://github.com/spinnaker/front50/pull/658)
[Spin](https://github.com/spinnaker/spin/pull/235)