### PR TITLE
chore(release): Use the alpine containers instead of openjdk

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,7 +1,7 @@
-FROM openjdk:8-jre-alpine
+FROM alpine:3.10
 MAINTAINER delivery-engineering@netflix.com
 COPY --from=compile /compiled_sources/gate-web/build/install/gate /opt/gate
-RUN apk --no-cache add --update bash
+RUN apk --no-cache add --update bash openjdk8-jre
 RUN adduser -D -S spinnaker
 USER spinnaker
 CMD ["/opt/gate/bin/gate"]


### PR DESCRIPTION
The container we had been using hasn't been updated in months. See
spinnaker/spinnaker#5204.