### PR TITLE
feat(md): move model classes to gate, update artifacts

### DIFF
--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/DeliveryConfig.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/DeliveryConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config.manageddelivery;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class DeliveryConfig {
+  String name;
+  String application;
+  Collection<Map<String, Object>> artifacts;
+  Collection<Environment> environments;
+}

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Environment.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Environment.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config.manageddelivery;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class Environment {
+  String name;
+  Collection<Resource> resources;
+  Collection<Map<String, Object>> constraints;
+  Collection<Notification> notifications;
+}

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Notification.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Notification.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config.manageddelivery;
+
+import lombok.Data;
+
+@Data
+public class Notification {
+  String type;
+  String address;
+  String frequency;
+}

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Resource.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/manageddelivery/Resource.java
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.gate.config.manageddelivery;
+
+import java.util.Map;
+import lombok.Data;
+
+/**
+ * The container for declaratively managed resources.
+ *
+ * <p>[apiVersion] which plugin and version of that plugin handles this resource [kind] what kind of
+ * resource this is [metadata] information about the resource, including name, uid, and
+ * serviceAccount [spec] the actual resource
+ */
+@Data
+public class Resource {
+  String apiVersion;
+  String kind;
+  Map<String, Object> metadata;
+  Map<String, Object> spec;
+}


### PR DESCRIPTION
Moving md model classes to gate, the only place they're used (@robfletcher is this an ok directory for them?). Removal of models from kork is in this pr: https://github.com/spinnaker/kork/pull/447.

Loosening the type of artifacts to be a map so we can support other properties on the artifact.