### PR TITLE
Feat (GATE): Enable white labeling logo in default Spinnaker login page #5290

### DIFF
--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -15,6 +15,7 @@
  */
 
 dependencies {
+  api "org.springframework.boot:spring-boot-starter-thymeleaf"
   api "org.springframework.boot:spring-boot-starter-web"
   api "org.springframework.boot:spring-boot-starter-actuator"
   api "org.springframework.boot:spring-boot-starter-security"

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -75,6 +75,8 @@ class AuthConfig {
     http
       .requestMatcher(requestMatcherProvider.requestMatcher())
       .authorizeRequests()
+        .antMatchers('/images/**').permitAll()
+        .antMatchers('/image/**').permitAll()
         .antMatchers('/**/favicon.ico').permitAll()
         .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
         .antMatchers(PermissionRevokingLogoutSuccessHandler.LOGGED_OUT_URL).permitAll()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateLoginImageConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateLoginImageConfigProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 OpsMX, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.Data;
+
+@ConditionalOnExpression("${security.login.image.enabled:false}")
+@Data
+@ConfigurationProperties("security.login.image.style")
+public class GateLoginImageConfigProperties {
+	String maxWidth;
+	String width;
+	String position;
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateLoginLogoConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateLoginLogoConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 OpsMX, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(GateLoginImageConfigProperties.class)
+public class GateLoginLogoConfig {
+   
+	  private GateLoginImageConfigProperties gateLoginImageConfigProperties;
+
+	  @Autowired
+	  public GateLoginLogoConfig(GateLoginImageConfigProperties gateLoginImageConfigProperties) {
+	    this.gateLoginImageConfigProperties = gateLoginImageConfigProperties; 
+	  }	
+
+	  
+	}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebLoginImageConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebLoginImageConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 OpsMX, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.netflix.spinnaker.gate.services.LoginImageService;
+
+@ConditionalOnExpression("${security.login.image.enabled:false}")
+@Configuration
+@EnableConfigurationProperties(GateLoginImageConfigProperties.class)
+public class GateWebLoginImageConfig implements WebMvcConfigurer {
+
+  private static final Logger log = LoggerFactory.getLogger(GateWebLoginImageConfig.class);
+
+
+  @Value("${security.login.image.resourcepath:/opt/spinnaker/config/}")
+  private String imageResourcePath; 
+
+  @Value("${security.login.image.url:image.png}")
+  private String imageUrl;
+
+  @Autowired(required = false)
+  LoginImageService loginImageService;
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {  
+
+    if (imageResourcePath != null) {
+      registry.addResourceHandler("/images/**").addResourceLocations("file:" + imageResourcePath)
+      .setCachePeriod(0); 
+      log.info("Login form image Resource path : " + imageResourcePath);
+    }
+    if(!imageUrl.equalsIgnoreCase("image.png")){  
+    	log.info("Login form image Resource URL : " + imageUrl);    	
+    	loginImageService.saveImage(imageUrl,imageResourcePath+"logo.png" );
+	}
+
+    log.info("Image ResourcePath is registered with Resource Handler");
+  } 
+
+} 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoginImageController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/LoginImageController.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 OpsMX, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.netflix.spinnaker.gate.config.GateLoginImageConfigProperties;
+
+import io.swagger.annotations.ApiOperation;
+
+@RestController
+@RequestMapping("/image")
+public class LoginImageController {
+	  
+	  @Autowired
+	  GateLoginImageConfigProperties gateLoginLogoConfigProperties;
+	  
+	  @ApiOperation(value = "Login Logo Positions", response = Map.class)
+	  @RequestMapping(value = "/loginlogo", method = RequestMethod.GET)
+	  GateLoginImageConfigProperties loginPosition() {
+		  return gateLoginLogoConfigProperties;
+	  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoginImageService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoginImageService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 OpsMX, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.services;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import groovy.transform.CompileStatic;
+
+@CompileStatic
+@Component
+public class LoginImageService {
+	private static final Logger log = LoggerFactory.getLogger(LoginImageService.class);
+ public void saveImage(String imageUrl, String destinationFile) {
+	 try {
+		URL url = new URL(imageUrl);
+		InputStream is = url.openStream();
+		OutputStream os = new FileOutputStream(destinationFile);
+
+		byte[] b = new byte[2048];
+		int length;
+
+		while ((length = is.read(b)) != -1) {
+			os.write(b, 0, length);
+		}
+     
+		is.close();
+		os.close();
+	 } catch (IOException e) {
+        log.info("the image is not found or failed to save :" +imageUrl);
+     }
+	}
+}


### PR DESCRIPTION
To enable the logo on the login page, add below configuration in gate-local.yml file
`````
security:
  login:
    image:
      enabled: true
      resourcepath: /home/opsmx/images/
      url: https://www.opsmx.com/images/logo.png
      style:
        maxWidth: 300
        width: 300
        position: center
