### PR TITLE
feat(plugins): New API's to support plugin metadata CRUD operations

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -156,4 +156,8 @@ interface Front50Service {
 
   @GET('/deliveries/{id}')
   Map getDelivery(@Path('id') String id)
+
+  // Plugins related
+  @GET('/pluginArtifacts')
+  List<Map> getPluginArtifacts(@Query("service") String service)
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -158,6 +158,6 @@ interface Front50Service {
   Map getDelivery(@Path('id') String id)
 
   // Plugins related
-  @GET('/pluginArtifacts')
+  @GET('/pluginInfo')
   List<Map> getPluginArtifacts(@Query("service") String service)
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/Front50Service.groovy
@@ -159,5 +159,5 @@ interface Front50Service {
 
   // Plugins related
   @GET('/pluginInfo')
-  List<Map> getPluginArtifacts(@Query("service") String service)
+  List<Map> getPluginInfo(@Query("service") String service)
 }

--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -74,7 +74,6 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Component
   @ConfigurationProperties("saml")
-  @ConditionalOnExpression('${saml.enabled:false}')
   static class SAMLSecurityConfigProperties {
     String keyStore
     String keyStorePassword

--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -74,6 +74,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
 
   @Component
   @ConfigurationProperties("saml")
+  @ConditionalOnExpression('${saml.enabled:false}')
   static class SAMLSecurityConfigProperties {
     String keyStore
     String keyStorePassword

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.controllers;
 
+import com.netflix.spinnaker.gate.config.SpinnakerExtensionsConfigProperties;
 import com.netflix.spinnaker.gate.services.TaskService;
 import com.netflix.spinnaker.gate.services.internal.Front50Service;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
@@ -24,9 +25,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,23 +39,39 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * EndPoints supporting CRUD operations for PluginInfo objects.
+ *
+ * <p>TODO: Currently write operations are secured using application as a resource and in future we
+ * need to move more concrete security model with a specific resource type for plugin management.
+ */
 @RestController
 @RequestMapping(value = "/pluginInfo")
+@Slf4j
 public class PluginController {
 
-  // TODO: Make it configurable.
-  private static final String DEFAULT_APPLICATION = "spinnaker";
+  /**
+   * If not configured, this application will be used to record orca tasks against, plus also used
+   * to verify permissions against.
+   */
+  private static final String DEFAULT_APPLICATION_NAME = "spinnakerplugins";
 
   private TaskService taskService;
   private Front50Service front50Service;
+  private SpinnakerExtensionsConfigProperties spinnakerExtensionsConfigProperties;
 
   @Autowired
-  public PluginController(TaskService taskService, Front50Service front50Service) {
+  public PluginController(
+      TaskService taskService,
+      Front50Service front50Service,
+      SpinnakerExtensionsConfigProperties spinnakerExtensionsConfigProperties) {
     this.taskService = taskService;
     this.front50Service = front50Service;
+    this.spinnakerExtensionsConfigProperties = spinnakerExtensionsConfigProperties;
   }
 
-  @ApiOperation(value = "Persist plugin artifact information")
+  @ApiOperation(value = "Persist plugin metadata information")
+  @PreAuthorize("hasPermission(#this.this.appName, 'APPLICATION', 'WRITE')")
   @RequestMapping(
       method = {RequestMethod.POST, RequestMethod.PUT},
       consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -64,10 +84,11 @@ public class PluginController {
     job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     jobs.add(job);
 
-    return initiateTask("Create/Update plugin with Id: " + pluginInfo.get("Id"), jobs);
+    return initiateTask("Upsert plugin info with Id: " + pluginInfo.get("Id"), jobs);
   }
 
-  @ApiOperation(value = "Delete plugin artifact info with the provided Id")
+  @ApiOperation(value = "Delete plugin info with the provided Id")
+  @PreAuthorize("hasPermission(#this.this.appName, 'APPLICATION', 'WRITE')")
   @RequestMapping(
       value = "/{id}",
       method = {RequestMethod.DELETE},
@@ -81,10 +102,10 @@ public class PluginController {
     job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     jobs.add(job);
 
-    return initiateTask("Delete Plugin metadata with Id: " + id, jobs);
+    return initiateTask("Delete Plugin info with Id: " + id, jobs);
   }
 
-  @ApiOperation(value = "Get all plugin artifacts info.")
+  @ApiOperation(value = "Get all plugin info objects")
   @RequestMapping(method = RequestMethod.GET)
   List<Map> getAllPluginInfo(@RequestParam(value = "service", required = false) String service) {
     return front50Service.getPluginInfo(service);
@@ -93,8 +114,16 @@ public class PluginController {
   private Map initiateTask(String description, List<Map<String, Object>> jobs) {
     Map<String, Object> operation = new HashMap<>();
     operation.put("description", description);
-    operation.put("application", DEFAULT_APPLICATION);
+    operation.put("application", getAppName());
     operation.put("job", jobs);
     return taskService.create(operation);
+  }
+
+  String getAppName() {
+    String applicationName = spinnakerExtensionsConfigProperties.getApplicationName();
+    if (StringUtils.isEmpty(applicationName)) {
+      applicationName = DEFAULT_APPLICATION_NAME;
+    }
+    return applicationName;
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -82,11 +82,6 @@ public class PluginController {
     job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     jobs.add(job);
 
-    Map<String, Object> operation = new HashMap<>();
-    operation.put("description", "Delete Plugin metadata");
-    operation.put("application", DEFAULT_APPLICATION);
-    operation.put("job", jobs);
-
     initiateTask("Delete Plugin metadata", jobs);
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.TaskService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import io.swagger.annotations.ApiOperation;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/pluginArtifacts")
+public class PluginController {
+
+  // TODO: configurable.
+  private static final String DEFAULT_APPLICATION = "spinnaker";
+
+  private TaskService taskService;
+  private Front50Service front50Service;
+
+  @Autowired
+  public PluginController(TaskService taskService, Front50Service front50Service) {
+    this.taskService = taskService;
+    this.front50Service = front50Service;
+  }
+
+  @ApiOperation(value = "Persist plugin metadata")
+  @RequestMapping(
+      method = {RequestMethod.POST, RequestMethod.PUT},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @ResponseStatus(value = HttpStatus.OK)
+  void persistPluginMetadata(@RequestBody Map pluginMetaData) {
+    List<Map<String, Object>> jobs = new ArrayList<>();
+    Map<String, Object> job = new HashMap<>();
+    job.put("type", "upsertPluginArtifact");
+    job.put("pluginArtifact", pluginMetaData);
+    job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
+    jobs.add(job);
+
+    initiateTask("Create/Update plugin", jobs);
+  }
+
+  @ApiOperation(value = "Delete plugin metadata with the provided Id")
+  @RequestMapping(
+      value = "/{Id}",
+      method = {RequestMethod.DELETE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @ResponseStatus(value = HttpStatus.NO_CONTENT)
+  void deletePluginMetadata(@PathVariable String Id) {
+    List<Map<String, Object>> jobs = new ArrayList<>();
+    Map<String, Object> job = new HashMap<>();
+    job.put("type", "deletePluginArtifact");
+    job.put("pluginArtifactId", Id);
+    job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
+    jobs.add(job);
+
+    Map<String, Object> operation = new HashMap<>();
+    operation.put("description", "Delete Plugin metadata");
+    operation.put("application", DEFAULT_APPLICATION);
+    operation.put("job", jobs);
+
+    initiateTask("Delete Plugin metadata", jobs);
+  }
+
+  @ApiOperation(value = "Get all plugin metadata")
+  @RequestMapping(method = RequestMethod.GET)
+  List<Map> getAllPluginMetadata(
+      @RequestParam(value = "service", required = false) String service) {
+    return front50Service.getPluginArtifacts(service);
+  }
+
+  private void initiateTask(String description, List<Map<String, Object>> jobs) {
+    Map<String, Object> operation = new HashMap<>();
+    operation.put("description", "Delete Plugin metadata");
+    operation.put("application", DEFAULT_APPLICATION);
+    operation.put("job", jobs);
+    Map result = taskService.createAndWaitForCompletion(operation);
+    String resultStatus = (String) result.get("status");
+
+    if (!"SUCCEEDED".equalsIgnoreCase(resultStatus)) {
+      throw new InvalidRequestException(
+          "Operation: '" + description + "' failed with Status: " + resultStatus);
+    }
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -56,15 +56,15 @@ public class PluginController {
       method = {RequestMethod.POST, RequestMethod.PUT},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(value = HttpStatus.ACCEPTED)
-  Map persistPluginArtifactInfo(@RequestBody Map pluginArtifactData) {
+  Map persistPluginInfo(@RequestBody Map pluginInfo) {
     List<Map<String, Object>> jobs = new ArrayList<>();
     Map<String, Object> job = new HashMap<>();
-    job.put("type", "upsertPluginArtifact");
-    job.put("pluginArtifact", pluginArtifactData);
+    job.put("type", "upsertPluginInfo");
+    job.put("pluginInfo", pluginInfo);
     job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     jobs.add(job);
 
-    return initiateTask("Create/Update plugin with Id: " + pluginArtifactData.get("Id"), jobs);
+    return initiateTask("Create/Update plugin with Id: " + pluginInfo.get("Id"), jobs);
   }
 
   @ApiOperation(value = "Delete plugin artifact info with the provided Id")
@@ -73,11 +73,11 @@ public class PluginController {
       method = {RequestMethod.DELETE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(value = HttpStatus.ACCEPTED)
-  Map deletePluginArtifactInfo(@PathVariable String id) {
+  Map deletePluginInfo(@PathVariable String id) {
     List<Map<String, Object>> jobs = new ArrayList<>();
     Map<String, Object> job = new HashMap<>();
-    job.put("type", "deletePluginArtifact");
-    job.put("pluginArtifactId", id);
+    job.put("type", "deletePluginInfo");
+    job.put("pluginInfoId", id);
     job.put("user", AuthenticatedRequest.getSpinnakerUser().orElse("anonymous"));
     jobs.add(job);
 
@@ -86,9 +86,8 @@ public class PluginController {
 
   @ApiOperation(value = "Get all plugin artifacts info.")
   @RequestMapping(method = RequestMethod.GET)
-  List<Map> getAllPluginArtifactsInfo(
-      @RequestParam(value = "service", required = false) String service) {
-    return front50Service.getPluginArtifacts(service);
+  List<Map> getAllPluginInfo(@RequestParam(value = "service", required = false) String service) {
+    return front50Service.getPluginInfo(service);
   }
 
   private Map initiateTask(String description, List<Map<String, Object>> jobs) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "/pluginArtifacts")
+@RequestMapping(value = "/pluginInfo")
 public class PluginController {
 
   // TODO: Make it configurable.
@@ -86,7 +86,7 @@ public class PluginController {
 
   @ApiOperation(value = "Get all plugin artifacts info.")
   @RequestMapping(method = RequestMethod.GET)
-  List<Map> getAllPluginArtifacts(
+  List<Map> getAllPluginArtifactsInfo(
       @RequestParam(value = "service", required = false) String service) {
     return front50Service.getPluginArtifacts(service);
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PluginController.java
@@ -94,7 +94,7 @@ public class PluginController {
 
   private void initiateTask(String description, List<Map<String, Object>> jobs) {
     Map<String, Object> operation = new HashMap<>();
-    operation.put("description", "Delete Plugin metadata");
+    operation.put("description", description);
     operation.put("application", DEFAULT_APPLICATION);
     operation.put("job", jobs);
     Map result = taskService.createAndWaitForCompletion(operation);

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SpinnakerExtensionsConfigProperties.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SpinnakerExtensionsConfigProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties("spinnaker.extensions")
+public class SpinnakerExtensionsConfigProperties {
+
+  /**
+   * Application to which the user should have write permissions to upsert or delete plugin info and
+   * also used to tie all orca tasks to.
+   */
+  String applicationName;
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
@@ -93,7 +93,7 @@ class PluginControllerSpec extends Specification {
 
   def 'get api should succeed'() {
     setup:
-    when(front50Service.getPluginArtifacts(any())).thenReturn([['Id': 'test-plugin-id']])
+    when(front50Service.getPluginInfo(any())).thenReturn([['Id': 'test-plugin-id']])
 
     expect:
     this.mockMvc.perform(MockMvcRequestBuilders.get("/pluginInfo")

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
@@ -17,15 +17,18 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.gate.config.SpinnakerExtensionsConfigProperties
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import spock.lang.Specification
@@ -36,8 +39,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = [PluginController])
 @AutoConfigureMockMvc(addFilters = false)
-@ContextConfiguration(classes = [PluginController, GenericExceptionHandlers])
+@ContextConfiguration(classes = [PluginController, GenericExceptionHandlers, SpinnakerExtensionsConfigProperties])
 @ActiveProfiles("test")
+@TestPropertySource(properties = ["spring.config.location=classpath:gate-test.yml"])
 class PluginControllerSpec extends Specification {
 
   @Autowired
@@ -46,6 +50,9 @@ class PluginControllerSpec extends Specification {
   @Autowired
   ObjectMapper objectMapper
 
+  @Autowired
+  SpinnakerExtensionsConfigProperties spinnakerExtensionsConfigProperties
+
   @MockBean
   private TaskService taskService
 
@@ -53,6 +60,11 @@ class PluginControllerSpec extends Specification {
   private Front50Service front50Service
 
   private Map requestContent = ['name': 'test plugin', provider: 'Test Co']
+
+  def 'should load configuration bean with expected values'() {
+    expect:
+    spinnakerExtensionsConfigProperties.applicationName == 'spinnakerpluginstest'
+  }
 
   def 'upsert api should fail when sent no content'() {
     expect:

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
@@ -61,50 +61,39 @@ class PluginControllerSpec extends Specification {
 
   def 'upsert api should succeed when sent content'() {
     setup:
-    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+    when(taskService.create(any())).thenReturn(['ref': 'tasks/ref/1'])
 
     expect:
     this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")
                 .header('Content-Type', "application/json")
                 .content(objectMapper.writeValueAsString(requestContent)))
-                .andExpect(status().isOk())
-  }
-
-  def 'upsert api should fail when sent content and api call fails'() {
-    setup:
-    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'TERMINAL'])
-
-    expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")
-      .header('Content-Type', "application/json")
-      .content(objectMapper.writeValueAsString(requestContent)))
-      .andExpect(status().isBadRequest())
+                .andExpect(status().isAccepted())
   }
 
   def 'upsert api should succeed with put method'() {
     setup:
-    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+    when(taskService.create(any())).thenReturn(['ref': 'tasks/ref/2'])
 
     expect:
     this.mockMvc.perform(MockMvcRequestBuilders.put("/pluginArtifacts")
       .header('Content-Type', "application/json")
       .content(objectMapper.writeValueAsString(requestContent)))
-      .andExpect(status().isOk())
+      .andExpect(status().isAccepted())
   }
 
   def 'delete api should succeed'() {
     setup:
-    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+    when(taskService.createAndWaitForCompletion(any())).thenReturn(['ref': '/tasks/ref/3'])
 
     expect:
     this.mockMvc.perform(MockMvcRequestBuilders.delete("/pluginArtifacts/testPlugin")
       .header('Content-Type', "application/json"))
-      .andExpect(status().isNoContent())
+      .andExpect(status().isAccepted())
   }
 
   def 'get api should succeed'() {
     setup:
-    when(front50Service.getPluginArtifacts(any())).thenReturn([['status': 'SUCCEEDED']])
+    when(front50Service.getPluginArtifacts(any())).thenReturn([['Id': 'test-plugin-id']])
 
     expect:
     this.mockMvc.perform(MockMvcRequestBuilders.get("/pluginArtifacts")

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.gate.services.TaskService
+import com.netflix.spinnaker.gate.services.internal.Front50Service
+import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import spock.lang.Specification
+
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.Mockito.when
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [PluginController])
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = [PluginController, GenericExceptionHandlers])
+@ActiveProfiles("test")
+class PluginControllerSpec extends Specification {
+
+  @Autowired
+  private MockMvc mockMvc
+
+  @Autowired
+  ObjectMapper objectMapper
+
+  @MockBean
+  private TaskService taskService
+
+  @MockBean
+  private Front50Service front50Service
+
+  private Map requestContent = ['name': 'test plugin', provider: 'Test Co']
+
+  def 'upsert api should fail when sent no content'() {
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")).andExpect(status().isInternalServerError())
+  }
+
+  def 'upsert api should succeed when sent content'() {
+    setup:
+    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")
+                .header('Content-Type', "application/json")
+                .content(objectMapper.writeValueAsString(requestContent)))
+                .andExpect(status().isOk())
+  }
+
+  def 'upsert api should fail when sent content and api call fails'() {
+    setup:
+    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'TERMINAL'])
+
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")
+      .header('Content-Type', "application/json")
+      .content(objectMapper.writeValueAsString(requestContent)))
+      .andExpect(status().isBadRequest())
+  }
+
+  def 'upsert api should succeed with put method'() {
+    setup:
+    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.put("/pluginArtifacts")
+      .header('Content-Type', "application/json")
+      .content(objectMapper.writeValueAsString(requestContent)))
+      .andExpect(status().isOk())
+  }
+
+  def 'delete api should succeed'() {
+    setup:
+    when(taskService.createAndWaitForCompletion(any())).thenReturn(['status': 'SUCCEEDED'])
+
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.delete("/pluginArtifacts/testPlugin")
+      .header('Content-Type', "application/json"))
+      .andExpect(status().isNoContent())
+  }
+
+  def 'get api should succeed'() {
+    setup:
+    when(front50Service.getPluginArtifacts(any())).thenReturn([['status': 'SUCCEEDED']])
+
+    expect:
+    this.mockMvc.perform(MockMvcRequestBuilders.get("/pluginArtifacts")
+      .header('Content-Type', "application/json"))
+      .andExpect(status().isOk())
+  }
+
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PluginControllerSpec.groovy
@@ -56,7 +56,7 @@ class PluginControllerSpec extends Specification {
 
   def 'upsert api should fail when sent no content'() {
     expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")).andExpect(status().isInternalServerError())
+    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginInfo")).andExpect(status().isInternalServerError())
   }
 
   def 'upsert api should succeed when sent content'() {
@@ -64,7 +64,7 @@ class PluginControllerSpec extends Specification {
     when(taskService.create(any())).thenReturn(['ref': 'tasks/ref/1'])
 
     expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginArtifacts")
+    this.mockMvc.perform(MockMvcRequestBuilders.post("/pluginInfo")
                 .header('Content-Type', "application/json")
                 .content(objectMapper.writeValueAsString(requestContent)))
                 .andExpect(status().isAccepted())
@@ -75,7 +75,7 @@ class PluginControllerSpec extends Specification {
     when(taskService.create(any())).thenReturn(['ref': 'tasks/ref/2'])
 
     expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.put("/pluginArtifacts")
+    this.mockMvc.perform(MockMvcRequestBuilders.put("/pluginInfo")
       .header('Content-Type', "application/json")
       .content(objectMapper.writeValueAsString(requestContent)))
       .andExpect(status().isAccepted())
@@ -86,7 +86,7 @@ class PluginControllerSpec extends Specification {
     when(taskService.createAndWaitForCompletion(any())).thenReturn(['ref': '/tasks/ref/3'])
 
     expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.delete("/pluginArtifacts/testPlugin")
+    this.mockMvc.perform(MockMvcRequestBuilders.delete("/pluginInfo/testPlugin")
       .header('Content-Type', "application/json"))
       .andExpect(status().isAccepted())
   }
@@ -96,7 +96,7 @@ class PluginControllerSpec extends Specification {
     when(front50Service.getPluginArtifacts(any())).thenReturn([['Id': 'test-plugin-id']])
 
     expect:
-    this.mockMvc.perform(MockMvcRequestBuilders.get("/pluginArtifacts")
+    this.mockMvc.perform(MockMvcRequestBuilders.get("/pluginInfo")
       .header('Content-Type', "application/json"))
       .andExpect(status().isOk())
   }

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -40,3 +40,12 @@ spring:
 cors:
   allowedOriginsPattern: '^https?://(?:localhost|[^/]+\.somewhere\.net)(?::[1-9]\d*)?/?$'
   expectLocalhost: true
+
+---
+
+spring:
+  profiles: test
+
+spinnaker:
+  extensions:
+    applicationName: spinnakerpluginstest


### PR DESCRIPTION
- New API's to support Plugin metadata CRUD operations.
- All writes go through Orca (orchestration API's) 
- Read hits Front50.