### PR TITLE
feat(plugins): Deck plugin asset proxy

### DIFF
--- a/gate-deck-plugins/gate-deck-plugins.gradle
+++ b/gate-deck-plugins/gate-deck-plugins.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: "${project.rootDir}/gradle/kotlin.gradle"
+apply from: "${project.rootDir}/gradle/kotlin-test.gradle"
+
+dependencies {
+  implementation project(":gate-core")
+
+  implementation "com.netflix.spinnaker.kork:kork-plugins"
+  implementation "com.netflix.spinnaker.kork:kork-swagger"
+  implementation "com.netflix.spinnaker.kork:kork-web"
+
+  implementation "org.springframework:spring-web"
+  implementation "org.pf4j:pf4j-update"
+}

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/CacheNotReadyException.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/CacheNotReadyException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+/**
+ * Thrown when the local cache has not been populated yet, but an external request has been made to get a manifest
+ * or asset. Clients should retry the request.
+ */
+class CacheNotReadyException : SystemException("Deck plugin cache has not been populated yet") {
+  override fun getRetryable(): Boolean? = true
+}

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCache.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCache.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
+import org.pf4j.update.PluginInfo
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Responsible for keeping an up-to-date cache of all plugins that Deck needs to know about.
+ *
+ * TODO(rz): Currently downloads all plugins and inspects the extracted files to determine if a plugin has deck assets.
+ *  This is pretty inefficient - would be better to have a metadata file shipped alongside a bundle.
+ * TODO(rz): Downloads all plugins to an isolated temp directory, so if Gate itself has plugins, this cache will be
+ *  downloading an intersection of plugins twice.
+ */
+class DeckPluginCache(
+  private val updateManager: SpinnakerUpdateManager,
+  private val updateService: PluginUpdateService,
+  private val pluginBundleExtractor: PluginBundleExtractor,
+  private val registry: Registry
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val cache: MutableSet<PluginCacheEntry> = mutableSetOf()
+  private var cachePopulated: Boolean = false
+
+  private val versionsId = registry.createId("plugins.deckCache.versions")
+  private val hitsId = registry.createId("plugins.deckCache.hits")
+  private val missesId = registry.createId("plugins.deckCache.misses")
+  private val downloadDurationId = registry.createId("plugins.deckCache.downloadDuration")
+  private val refreshDurationId = registry.createId("plugins.deckCache.refreshDuration")
+
+  /**
+   * Refreshes the local file cache of _current_ plugins. Should Deck need plugin assets from an older plugin release
+   * version, it will be downloaded and cached on-demand.
+   *
+   * The default refresh interval is 5 minutes.
+   */
+  @Scheduled(
+    fixedDelayString = "\${spinnaker.extensibility.deck-proxy.cache-refresh-interval-ms:300000}",
+    initialDelay = 0
+  )
+  internal fun refresh() {
+    registry.timer(refreshDurationId).record {
+      log.info("Refreshing plugin cache")
+
+      updateManager.refresh()
+
+      val newCache = updateManager.plugins
+        .map {
+          val plugin = DeckPluginVersion(it.id, selectPluginVersion(it))
+          val path = getOrDownload(plugin.id, plugin.version)
+          PluginCacheEntry(plugin, path)
+        }
+        .filter {
+          // TODO(rz): Once bundles support manifest artifacts, we can just inspect those
+          //  for a deck plugin rather than downloading everything and seeing if a
+          //  index.js file exists.
+          it.path.resolve("index.js").toFile().exists()
+        }
+
+      cache.removeIf { !newCache.contains(it) }
+      cache.addAll(newCache)
+
+      cache.forEach {
+        registry.counter(versionsId.withPluginTags(it.plugin.id, it.plugin.version)).increment()
+      }
+
+      cachePopulated = true
+      log.info("Cached ${cache.size} deck plugins")
+    }
+  }
+
+  fun isCachePopulated(): Boolean = cachePopulated
+
+  fun getCache(): Set<PluginCacheEntry> {
+    return cache.toSet()
+  }
+
+  /**
+   * Get a previously downloaded plugin path, or download the plugin and cache the artifacts for subsequent requests.
+   */
+  fun getOrDownload(pluginId: String, pluginVersion: String): Path {
+    val cachePath = CACHE_ROOT_PATH.resolve("$pluginId/$pluginVersion")
+    if (!cachePath.toFile().isDirectory) {
+      registry.timer(downloadDurationId.withPluginTags(pluginId, pluginVersion)).record {
+        log.info("Downloading plugin '$pluginId@$pluginVersion'")
+        val deckPluginPath = pluginBundleExtractor.extractService(
+          updateService.download(pluginId, pluginVersion),
+          "deck"
+        )
+
+        log.info("Adding plugin '$pluginId@$pluginVersion' to local cache: $cachePath")
+        Files.createDirectories(cachePath)
+        Files.move(deckPluginPath, cachePath, StandardCopyOption.REPLACE_EXISTING)
+      }
+      registry.counter(missesId.withPluginTags(pluginId, pluginVersion)).increment()
+    } else {
+      registry.counter(hitsId.withPluginTags(pluginId, pluginVersion)).increment()
+    }
+    return cachePath
+  }
+
+  private fun selectPluginVersion(pluginInfo: PluginInfo): String {
+    return updateManager.getLastPluginRelease(pluginInfo.id).version
+  }
+
+  private fun Id.withPluginTags(pluginId: String, version: String): Id =
+    withTags("pluginId", pluginId, "version", version)
+
+  /**
+   * @param plugin The plugin version metadata
+   * @param path The path to the local file cache of the plugin
+   */
+  data class PluginCacheEntry(
+    val plugin: DeckPluginVersion,
+    val path: Path
+  )
+
+  companion object {
+    internal val CACHE_ROOT_PATH = Files.createTempDirectory("downloaded-plugin-cache")
+  }
+}

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginConfiguration.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginConfiguration.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@ConditionalOnProperty("spinnaker.extensibility.deck-proxy.enabled", matchIfMissing = true)
+@ComponentScan("com.netflix.spinnaker.gate.plugins")
+@EnableScheduling
+open class DeckPluginConfiguration {
+  @Bean
+  open fun deckPluginCache(
+    updateManager: SpinnakerUpdateManager,
+    updateService: PluginUpdateService,
+    registry: Registry
+  ): DeckPluginCache =
+    DeckPluginCache(updateManager, updateService, PluginBundleExtractor(), registry)
+
+  @Bean
+  open fun deckPluginService(
+    pluginCache: DeckPluginCache,
+    registry: Registry
+  ): DeckPluginService = DeckPluginService(pluginCache, registry)
+
+  @Bean
+  open fun deckPluginsController(pluginService: DeckPluginService): DeckPluginsController =
+    DeckPluginsController(pluginService)
+}

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginService.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginService.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spectator.api.Registry
+import org.slf4j.LoggerFactory
+
+/**
+ * Provides Deck with means of discovering what plugins it needs to download and a standard interface for
+ * retrieving plugin assets.
+ */
+class DeckPluginService(
+  private val pluginCache: DeckPluginCache,
+  private val registry: Registry
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val assetHitsId = registry.createId("plugins.deckAssets.hits")
+  private val assetMissesId = registry.createId("plugins.deckAssets.misses")
+
+  /**
+   * Returns a list of all plugin versions that Deck should know how to load.
+   *
+   * Deck will be responsible for taking this manifest and requesting the `index.js` file inside of a plugin version
+   * and dynamically resolving any needed assets as it goes along.
+   */
+  fun getPluginsManifests(): List<DeckPluginVersion> {
+    if (!pluginCache.isCachePopulated()) {
+      throw CacheNotReadyException()
+    }
+    return pluginCache.getCache().map { it.plugin }
+  }
+
+  /**
+   * Get an individual plugin's asset by version.
+   *
+   * If the plugin does not exist on the filesystem, it will be downloaded and cached to a standard location so that
+   * subsequent asset requests for the plugin version will be faster.
+   */
+  fun getPluginAsset(pluginId: String, pluginVersion: String, assetPath: String): String? {
+    if (!pluginCache.isCachePopulated()) {
+      throw CacheNotReadyException()
+    }
+
+    val sanitizedAssetPath = if (assetPath.startsWith("/")) assetPath.substring(1) else assetPath
+
+    val localAsset = pluginCache.getOrDownload(pluginId, pluginVersion).resolve(sanitizedAssetPath).toFile()
+    if (!localAsset.exists()) {
+      log.error("Unable to find requested plugin asset '$assetPath' for '$pluginId@$pluginVersion'")
+      registry.counter(assetMissesId).increment()
+      return null
+    }
+    registry.counter(assetHitsId).increment()
+
+    return localAsset.readText()
+  }
+}

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginVersion.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginVersion.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+/**
+ * A plugin manifest used by Deck to know what plugins should be installed and at what version.
+ *
+ * @param id The plugin ID
+ * @param version The plugin version
+ */
+data class DeckPluginVersion(
+  val id: String,
+  val version: String
+)

--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginsController.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginsController.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import io.swagger.annotations.ApiOperation
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@RestController
+@RequestMapping("/plugins/deck")
+class DeckPluginsController(
+  private val deckPluginService: DeckPluginService
+) {
+
+  @ApiOperation(value = "Retrieve a plugin manifest")
+  @GetMapping
+  fun getPluginManifest(): List<DeckPluginVersion> {
+    return deckPluginService.getPluginsManifests()
+  }
+
+  @ApiOperation(value = "Retrieve a single plugin asset by version")
+  @GetMapping("/{pluginId}/{pluginVersion}/{asset:.*}")
+  fun getPluginAsset(
+    @PathVariable pluginId: String,
+    @PathVariable pluginVersion: String,
+    @PathVariable asset: String
+  ): String {
+    return deckPluginService.getPluginAsset(pluginId, pluginVersion, asset)
+      ?: throw NotFoundException("Unable to find asset for plugin version")
+  }
+
+  @ExceptionHandler(CacheNotReadyException::class)
+  fun handleCacheNotReadyException(
+    e: Exception,
+    response: HttpServletResponse,
+    request: HttpServletRequest?
+  ) {
+    response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value(), e.message)
+  }
+}

--- a/gate-deck-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCacheTest.kt
+++ b/gate-deck-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCacheTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.plugins
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
+import com.netflix.spinnaker.kork.plugins.update.PluginUpdateService
+import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.pf4j.update.PluginInfo
+import strikt.api.expectThat
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DeckPluginCacheTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("caching") {
+      test("latest plugin releases with deck artifacts are added to cache") {
+        subject.refresh()
+
+        expectThat(subject.getCache())
+          .hasSize(2)
+          .and {
+            get { first().plugin }.and {
+              get { id }.isEqualTo("io.spinnaker.hello")
+              get { version }.isEqualTo("1.1.0")
+            }
+            get { last().plugin }.and {
+              get { id }.isEqualTo("io.spinnaker.goodbye")
+              get { version }.isEqualTo("2.0.1")
+            }
+          }
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val updateManager: SpinnakerUpdateManager = mockk(relaxed = true)
+    val updateService: PluginUpdateService = mockk(relaxed = true)
+    val pluginBundleExtractor: PluginBundleExtractor = mockk(relaxed = true)
+    val registry: Registry = NoopRegistry()
+    val subject = DeckPluginCache(updateManager, updateService, pluginBundleExtractor, registry)
+
+    init {
+      val plugins = listOf(
+        PluginInfo().apply {
+          id = "io.spinnaker.hello"
+          releases = listOf(
+            PluginInfo.PluginRelease().apply {
+              version = "1.0.0"
+            },
+            PluginInfo.PluginRelease().apply {
+              version = "1.1.0"
+            }
+          )
+        },
+        PluginInfo().apply {
+          id = "io.spinnaker.goodbye"
+          releases = listOf(
+            PluginInfo.PluginRelease().apply {
+              version = "2.0.0"
+            },
+            PluginInfo.PluginRelease().apply {
+              version = "2.0.1"
+            }
+          )
+        }
+      )
+
+      every { updateManager.plugins } returns plugins
+
+      val pluginIdSlot = slot<String>()
+      every { updateManager.getLastPluginRelease(capture(pluginIdSlot)) } answers {
+        PluginInfo.PluginRelease().apply {
+          version = plugins.find { it.id == pluginIdSlot.captured }!!.releases.last().version
+        }
+      }
+
+      every { updateService.download(any(), any()) } returns Paths.get("/dev/null")
+
+      every { pluginBundleExtractor.extractService(any(), any()) } answers {
+        val temp = Files.createTempDirectory("downloaded-plugins")
+        temp.resolve("index.js").also {
+          it.toFile().writeText("")
+        }
+        temp
+      }
+    }
+  }
+}

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
   implementation project(":gate-core")
   implementation project(":gate-proxy")
+  implementation project(":gate-deck-plugins")
   implementation project(":gate-integrations-gremlin")
 
   implementation "com.squareup.retrofit:retrofit"
@@ -33,12 +34,13 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
 
+  implementation "com.netflix.spinnaker.kork:kork-core"
+  implementation "com.netflix.spinnaker.kork:kork-plugins"
+  implementation "com.netflix.spinnaker.kork:kork-secrets-aws"
+  implementation "com.netflix.spinnaker.kork:kork-secrets-gcp"
   implementation "com.netflix.spinnaker.kork:kork-stackdriver"
   implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "com.netflix.spinnaker.kork:kork-web"
-  implementation "com.netflix.spinnaker.kork:kork-secrets-aws"
-  implementation "com.netflix.spinnaker.kork:kork-secrets-gcp"
-  implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.frigga:frigga"
   implementation "redis.clients:jedis"
   implementation "com.netflix.hystrix:hystrix-core"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
+import com.netflix.spinnaker.config.PluginsAutoConfiguration
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
@@ -33,6 +34,7 @@ import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
 import com.netflix.spinnaker.gate.filters.CorsFilter
 import com.netflix.spinnaker.gate.filters.GateOriginValidator
 import com.netflix.spinnaker.gate.filters.OriginValidator
+import com.netflix.spinnaker.gate.plugins.DeckPluginConfiguration
 import com.netflix.spinnaker.gate.retrofit.EurekaOkClient
 import com.netflix.spinnaker.gate.retrofit.Slf4jRetrofitLogger
 import com.netflix.spinnaker.gate.services.EurekaLookupService
@@ -55,6 +57,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
 import org.springframework.core.Ordered
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
@@ -80,6 +83,7 @@ import static retrofit.Endpoints.newFixedEndpoint
 @Configuration
 @Slf4j
 @EnableConfigurationProperties(FiatClientConfigurationProperties)
+@Import([PluginsAutoConfiguration, DeckPluginConfiguration])
 class GateConfig extends RedisHttpSessionConfiguration {
 
   @Value('${server.session.timeout-in-seconds:3600}')

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "kotlin"
+
+dependencies {
+  testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "io.strikt:strikt-core"
+  testImplementation "dev.minutest:minutest"
+  testImplementation "io.mockk:mockk"
+
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines "junit-jupiter"
+  }
+}
+
+compileTestKotlin {
+  kotlinOptions {
+    languageVersion = "1.3"
+    jvmTarget = "1.8"
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@
 rootProject.name = "gate"
 
 include "gate-core",
+  "gate-deck-plugins",
   "gate-basic",
   "gate-bom",
   "gate-iap",


### PR DESCRIPTION
Depends on https://github.com/spinnaker/kork/pull/477

Adds support for serving Deck plugin assets, fixes spinnaker/spinnaker#5242.

All configured repositories (`spinnaker.extensibility.repositories`) are scanned for plugins and their latest release is downloaded and checked for deck plugin assets. Any plugin that has a deck component (`deck/index.js`) will be cached and returned when Deck requests a manifest or plugin asset.

Gate will return a `503 Service Unavailable` if these plugin endpoints are hit prior to the cache being populated. It's expected that Deck would retry on this error code.