### PR TITLE
fix(exceptionhandler): Remove exception handler from the controller s…

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.gate.controllers;
 
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.netflix.spinnaker.gate.model.manageddelivery.DeliveryConfig;
@@ -13,8 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,8 +28,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import retrofit.RetrofitError;
-import retrofit.client.Header;
 
 @RequestMapping("/managed")
 @RestController
@@ -154,24 +148,5 @@ public class ManagedController {
   @DeleteMapping(path = "/application/{application}/pause")
   void resumeApplication(@PathVariable("application") String application) {
     keelService.resumeApplication(application);
-  }
-
-  @ExceptionHandler
-  void passthroughRetrofitErrors(RetrofitError e, HttpServletResponse response) {
-    try {
-      response.setStatus(e.getResponse().getStatus());
-      response.setHeader(
-          CONTENT_TYPE,
-          e.getResponse().getHeaders().stream()
-              .filter(it -> it.getName().equals(CONTENT_TYPE))
-              .map(Header::getValue)
-              .findFirst()
-              .orElse("text/plain"));
-      IOUtils.copy(e.getResponse().getBody().in(), response.getOutputStream());
-    } catch (Exception ex) {
-      log.error(
-          "Error reading response body when translating exception from downstream keelService: ",
-          ex);
-    }
   }
 }


### PR DESCRIPTION
- Remove exception handler from the controller since we have a generic handler in Kork.
- Since we have dup. exception handlers, anything that gets wired up last will be used in processing that exception and in this particular scenario it was logging messages related to this controller though they were not related to keel. 