### PR TITLE
fix(plugins): Call refresh on each update repository, rather than from UpdateManager.refresh()

### DIFF
--- a/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCache.kt
+++ b/gate-deck-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/DeckPluginCache.kt
@@ -59,7 +59,9 @@ class DeckPluginCache(
     registry.timer(refreshDurationId).record {
       log.info("Refreshing plugin cache")
 
-      updateManager.refresh()
+      // TODO(jonsie): Switch back to calling just `updateManager.refresh() after
+      // github.com/pf4j/pf4j-update/pull/48 is released
+      updateManager.repositories.forEach { it.refresh() }
 
       val newCache = updateManager.plugins
         .mapNotNull { pluginInfo ->


### PR DESCRIPTION
Once we have a release for github.com/pf4j/pf4j-update/pull/48 we can remove this, but for now this is required or else this refresh process does not work.