### PR TITLE
feat(clouddriver): make selector accept configurable criteria

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/DynamicRoutingConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/DynamicRoutingConfigProperties.java
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.gate.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+@Data
+@ConfigurationProperties(prefix = "dynamic-routing")
+public class DynamicRoutingConfigProperties {
+  public static final String ENABLED_PROPERTY = "dynamic-routing.enabled";
+  public Boolean enabled;
+
+  @NestedConfigurationProperty public ClouddriverConfigProperties clouddriver;
+
+  @Data
+  public static class ClouddriverConfigProperties {
+    public static final String ENABLED_PROPERTY = "dynamic-routing.clouddriver.enabled";
+    public boolean enabled;
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoadBalancerService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/LoadBalancerService.groovy
@@ -57,7 +57,7 @@ class LoadBalancerService {
         def service = clouddriverServiceSelector.select(selectorKey)
         def accountDetails = objectMapper.convertValue(service.getAccount(account), Map)
         def loadBalancerDetails = service.getLoadBalancerDetails(provider, account, region, name)
-        
+
         loadBalancerDetails = loadBalancerDetails.collect { loadBalancerDetail ->
           def loadBalancerContext = loadBalancerDetail.collectEntries {
             return it.value instanceof String ? [it.key, it.value] : [it.key, ""]

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ByUserOriginSelector.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ByUserOriginSelector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services.internal;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.spinnaker.kork.web.selector.SelectableService;
+import com.netflix.spinnaker.kork.web.selector.ServiceSelector;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ByUserOriginSelector implements ServiceSelector {
+  private final Object service;
+  private final int priority;
+
+  @Nullable private final String origin;
+
+  public ByUserOriginSelector(Object service, Integer priority, Map<String, Object> config) {
+    this.service = service;
+    this.priority = priority;
+    this.origin = (String) config.get("origin");
+
+    if (origin == null) {
+      log.warn("ByUserOriginSelector created for service {} has null origin", service);
+    }
+  }
+
+  public ByUserOriginSelector(Object service, Integer priority, String origin) {
+    this(service, priority, ImmutableMap.of("origin", origin));
+  }
+
+  @Override
+  public Object getService() {
+    return service;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public boolean supports(SelectableService.Criteria criteria) {
+    return origin != null && origin.equals(criteria.getOrigin());
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.dynamicconfig.SpringDynamicConfigService
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
+import com.netflix.spinnaker.kork.web.selector.SelectableService
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthIndicatorAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -91,7 +92,7 @@ class FunctionalSpec extends Specification {
     executorService = Mock(ExecutorService)
     taskService = Mock(TaskService)
     clouddriverService = Mock(ClouddriverService)
-    clouddriverServiceSelector = new ClouddriverServiceSelector(clouddriverService)
+    clouddriverServiceSelector = new ClouddriverServiceSelector(Mock(SelectableService), new SpringDynamicConfigService())
     orcaService = Mock(OrcaService)
     credentialsService = Mock(CredentialsService)
     accountLookupService = Mock(AccountLookupService)


### PR DESCRIPTION
Historically, ClouddriverServiceSelector was hardcoded to look only at the user origin (coming from the X-RateLimit-App header), and was able to look up a different url for clouddriver based on the value of that header.

With this PR, ClouddriverServiceSelector accepts a configurable SelectableService for which we can pass any number of criteria, similar to the existing pattern for e.g. orca and rosco. To avoid a breaking change, GateConfig will try to detect the previous clouddriver selector style (a `dynamicEndpoints` map) and configure an equivalent SelectableService. Additionally, we support a dynamic config to turn off routing at runtime if needed.

Note that RequestContext does not currently contain most criteria that gate can be configured to route on, will change this in an upcoming PR.