### PR TITLE
feat(context): replace RequestContext with AuthenticatedRequest

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/security/RequestContext.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/security/RequestContext.java
@@ -16,61 +16,71 @@
 
 package com.netflix.spinnaker.gate.security;
 
-public class RequestContext {
-  private static final ThreadLocal<RequestContext> threadLocal = new ThreadLocal<>();
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import lombok.extern.slf4j.Slf4j;
 
-  private String application;
-  private String authenticatedUser;
-  private String executionType;
-  private String executionId;
-  private String origin;
+/**
+ * No longer backed by a thread local, this is now a readonly proxy to {@link AuthenticatedRequest},
+ * which is the only source of truth for context values. This is to avoid the situation where
+ * RequestContext and {@link AuthenticatedRequest} provide an inconsistent view of the context or
+ * lose it across thread boundaries.
+ */
+@Slf4j
+public class RequestContext {
+  private static final RequestContext placeholder = new RequestContext();
+
+  private RequestContext() {}
 
   public RequestContext(String origin, String authenticatedUser) {
-    this.origin = origin;
-    this.authenticatedUser = authenticatedUser != null ? authenticatedUser : "anonymous";
+    log.warn("call to deprecated RequestContext's constructor");
   }
 
+  @Deprecated
   public static void set(RequestContext requestContext) {
-    threadLocal.set(requestContext);
+    log.warn("call to deprecated method RequestContext::set");
   }
 
+  @Deprecated
   public static void setApplication(String application) {
-    threadLocal.get().application = application;
+    log.warn("call to deprecated method RequestContext::setApplication");
   }
 
+  @Deprecated
   public static void setExecutionType(String executionType) {
-    threadLocal.get().executionType = executionType;
+    log.warn("call to deprecated method RequestContext::setExecutionType");
   }
 
+  @Deprecated
   public static void setExecutionId(String executionId) {
-    threadLocal.get().executionId = executionId;
+    log.warn("call to deprecated method RequestContext::setExecutionId");
+  }
+
+  @Deprecated
+  public static void clear() {
+    log.warn("call to deprecated method RequestContext::clear");
   }
 
   public static RequestContext get() {
-    return threadLocal.get();
-  }
-
-  public static void clear() {
-    threadLocal.remove();
+    return placeholder;
   }
 
   public String getApplication() {
-    return application;
+    return AuthenticatedRequest.getSpinnakerApplication().orElse(null);
   }
 
   public String getAuthenticatedUser() {
-    return authenticatedUser;
+    return AuthenticatedRequest.getSpinnakerUser().orElse(null);
   }
 
   public String getExecutionType() {
-    return executionType;
+    return AuthenticatedRequest.getSpinnakerExecutionType().orElse(null);
   }
 
   public String getExecutionId() {
-    return executionId;
+    return AuthenticatedRequest.getSpinnakerExecutionId().orElse(null);
   }
 
   public String getOrigin() {
-    return origin;
+    return AuthenticatedRequest.getSpinnakerUserOrigin().orElse(null);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -144,5 +144,4 @@ public class GateWebConfig implements WebMvcConfigurer {
   void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.favorPathExtension(false)
   }
-
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -18,7 +18,6 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.PipelineService
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
@@ -36,7 +35,6 @@ import io.swagger.annotations.Example
 import io.swagger.annotations.ExampleProperty
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -185,7 +183,7 @@ class PipelineController {
   @PostMapping('/start')
   ResponseEntity start(@RequestBody Map map) {
     if (map.containsKey("application")) {
-      RequestContext.setApplication(map.get("application").toString())
+      AuthenticatedRequest.setApplication(map.get("application").toString())
     }
     String authenticatedUser = AuthenticatedRequest.getSpinnakerUser().orElse("anonymous")
     maybePropagateTemplatedPipelineErrors(map, {
@@ -204,7 +202,7 @@ class PipelineController {
     trigger.user = trigger.user ?: AuthenticatedRequest.getSpinnakerUser().orElse('anonymous')
     trigger.notifications = trigger.notifications ?: [];
 
-    RequestContext.setApplication(application)
+    AuthenticatedRequest.setApplication(application)
     try {
       pipelineService.trigger(application, pipelineNameOrId, trigger)
     } catch (NotFoundException e) {
@@ -223,7 +221,7 @@ class PipelineController {
                                          @PathVariable("pipelineNameOrId") String pipelineNameOrId,
                                          @RequestBody(required = false) Map trigger) {
     trigger = trigger ?: [:]
-    RequestContext.setApplication(application)
+    AuthenticatedRequest.setApplication(application)
     try {
       def body = pipelineService.triggerViaEcho(application, pipelineNameOrId, trigger)
       return new ResponseEntity(body, HttpStatus.ACCEPTED)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.gate.interceptors;
 
-import com.netflix.spinnaker.gate.security.RequestContext;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,18 +31,14 @@ public class RequestContextInterceptor extends HandlerInterceptorAdapter {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
       throws Exception {
-    RequestContext.set(
-        new RequestContext(
-            AuthenticatedRequest.getSpinnakerUserOrigin().orElse(null),
-            AuthenticatedRequest.getSpinnakerUser().orElse(null)));
-
-    Matcher m = applicationPattern.matcher(request.getRequestURI());
+    String requestURI = request.getRequestURI();
+    Matcher m = applicationPattern.matcher(requestURI);
     if (m.find()) {
-      RequestContext.setApplication(m.group(1));
+      AuthenticatedRequest.setApplication(m.group(1));
     }
 
-    if (orchestrationMatch.matcher(request.getRequestURI()).matches()) {
-      RequestContext.setExecutionType("orchestration");
+    if (orchestrationMatch.matcher(requestURI).matches()) {
+      AuthenticatedRequest.setExecutionType("orchestration");
     }
 
     return true;
@@ -53,6 +48,6 @@ public class RequestContextInterceptor extends HandlerInterceptorAdapter {
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {
-    RequestContext.clear();
+    AuthenticatedRequest.clear();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestIdInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestIdInterceptor.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.gate.interceptors;
 
 import static com.netflix.spinnaker.security.AuthenticatedRequest.Header.REQUEST_ID;
-import static com.netflix.spinnaker.security.AuthenticatedRequest.getSpinnakerRequestId;
 
+import com.netflix.spinnaker.security.AuthenticatedRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -31,7 +31,7 @@ public class RequestIdInterceptor extends HandlerInterceptorAdapter {
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    getSpinnakerRequestId()
+    AuthenticatedRequest.getSpinnakerRequestId()
         .ifPresent(requestId -> response.setHeader(REQUEST_ID.getHeader(), requestId));
     return true;
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -173,15 +173,16 @@ class PipelineService {
   }
 
   /**
-   * Retrieve an orca execution by id to populate RequestContext application
+   * Retrieve an orca execution by id to populate the application in AuthenticatedRequest
    *
    * @param id
    */
   void setApplicationForExecution(String id) {
     try {
       Map execution = retrySupport.retry({ -> getPipeline(id) }, 5, 1000, false)
-      if (execution.containsKey("application")) {
-        RequestContext.setApplication(execution.get("application").toString())
+      Object application = execution.get("application")
+      if (application != null) {
+        AuthenticatedRequest.setApplication(application.toString())
       }
     } catch (Exception e) {
       log.error("Error loading execution {} from orca", id, e)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/TaskService.groovy
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.gate.security.RequestContext
 import com.netflix.spinnaker.gate.services.commands.HystrixFactory
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,20 +40,20 @@ class TaskService {
 
   Map create(Map body) {
     if (body.containsKey("application")) {
-      RequestContext.setApplication(body.get("application").toString())
+      AuthenticatedRequest.setApplication(body.get("application").toString())
     }
     orcaServiceSelector.withContext(RequestContext.get()).doOperation(body)
   }
 
   Map createAppTask(String app, Map body) {
     body.application = app
-    RequestContext.setApplication(app)
+    AuthenticatedRequest.setApplication(app)
     orcaServiceSelector.withContext(RequestContext.get()).doOperation(body)
   }
 
   Map createAppTask(Map body) {
     if (body.containsKey("application")) {
-      RequestContext.setApplication(body.get("application").toString())
+      AuthenticatedRequest.setApplication(body.get("application").toString())
     }
     orcaServiceSelector.withContext(RequestContext.get()).doOperation(body)
   }
@@ -98,7 +99,7 @@ class TaskService {
     log.info("Creating and waiting for completion: ${body}")
 
     if (body.containsKey("application")) {
-      RequestContext.setApplication(body.get("application").toString())
+      AuthenticatedRequest.setApplication(body.get("application").toString())
     }
 
     Map createResult = create(body)
@@ -144,7 +145,7 @@ class TaskService {
     try {
       Map task = getTask(id)
       if (task.containsKey("application")) {
-        RequestContext.setApplication(task.get("application").toString())
+        AuthenticatedRequest.setApplication(task.get("application").toString())
       }
     } catch (Exception e) {
       log.error("Error loading execution {} from orca", id, e)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaServiceSelector.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/OrcaServiceSelector.java
@@ -20,10 +20,9 @@ import com.netflix.spinnaker.gate.security.RequestContext;
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
 
 public class OrcaServiceSelector {
+  private final SelectableService<OrcaService> selectableService;
 
-  private final SelectableService selectableService;
-
-  public OrcaServiceSelector(SelectableService selectableService) {
+  public OrcaServiceSelector(SelectableService<OrcaService> selectableService) {
     this.selectableService = selectableService;
   }
 
@@ -38,7 +37,6 @@ public class OrcaServiceSelector {
               .withOrigin(context.getOrigin())
               .withExecutionType(context.getExecutionType());
     }
-
-    return (OrcaService) selectableService.getService(criteria);
+    return selectableService.getService(criteria);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Mon Jan 27 23:08:54 UTC 2020
 fiatVersion=1.13.0
 enablePublishing=false
-korkVersion=7.14.0
+korkVersion=7.15.0
 spinnakerGradleVersion=7.0.1
 org.gradle.parallel=true
 includeProviders=basic,iap,ldap,oauth2,saml,x509


### PR DESCRIPTION
This makes gate's RequestContext a readonly proxy to kork's AuthenticatedRequest. This is to avoid the situation where RequestContext and AuthenticatedRequest provide an inconsistent view of the context or lose it across thread boundaries.

This is a relatively big change, values in AuthenticatedRequest get propagated across threads and to downstream services in the form of X-SPINNAKER headers. So with this change, gate will now start emitting X-SPINNAKER-APPLICATION headers for instance (until now, only orca did that).
