### PR TITLE
fix(config): remove 2nd constructor from ByUserOriginSelector

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -222,7 +222,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
       List<ServiceSelector> selectors = []
       endpoints.each { sourceApp, url ->
         def service = buildService(okHttpClient, ClouddriverService, newFixedEndpoint(url))
-        selectors << new ByUserOriginSelector(service, 2, sourceApp)
+        selectors << new ByUserOriginSelector(service, 2, ['origin': (Object) sourceApp])
       }
 
       return new ClouddriverServiceSelector(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ByUserOriginSelector.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ByUserOriginSelector.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.gate.services.internal;
 
-import com.google.common.collect.ImmutableMap;
 import com.netflix.spinnaker.kork.web.selector.SelectableService;
 import com.netflix.spinnaker.kork.web.selector.ServiceSelector;
 import java.util.Map;
@@ -38,10 +37,6 @@ public class ByUserOriginSelector implements ServiceSelector {
     if (origin == null) {
       log.warn("ByUserOriginSelector created for service {} has null origin", service);
     }
-  }
-
-  public ByUserOriginSelector(Object service, Integer priority, String origin) {
-    this(service, priority, ImmutableMap.of("origin", origin));
   }
 
   @Override


### PR DESCRIPTION
GateConfig occasionally failed to intialize it with argument type mismatch (but hard to reproduce), I suspect it has to do with having multiple constructors and the use of reflection in

  selectorClass.getConstructors()[0].newInstance(...)
