### PR TITLE
refactor: change deck assets cache control header to max-age of 30 days

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginsController.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginsController.kt
@@ -53,7 +53,7 @@ class DeckPluginsController(
         .header("Content-Type", pluginAsset.contentType)
         .header("Cache-Control",
             CacheControl
-                .maxAge(1, TimeUnit.DAYS)
+                .maxAge(30, TimeUnit.DAYS)
                 .mustRevalidate()
                 .cachePrivate()
                 .headerValue


### PR DESCRIPTION
We're using 30 days for regular deck assets at nflx, so let's start there for plugin assets.  these assets should be effectively  immutable based for a given url.