### PR TITLE
fix(context): don't clear the context in RequestContextInterceptor

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/interceptors/RequestContextInterceptor.java
@@ -47,7 +47,5 @@ public class RequestContextInterceptor extends HandlerInterceptorAdapter {
   @Override
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
-      throws Exception {
-    AuthenticatedRequest.clear();
-  }
+      throws Exception {}
 }


### PR DESCRIPTION
AuthenticatedRequestFilter is responsible for it. Doing it in an interceptor means that other interceptors such as RequestLoggingInterceptor may get an empty context.
