### PR TITLE
fix(md): serialize instants

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/ConstraintState.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/ConstraintState.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.gate.model.manageddelivery;
 
-import java.time.Instant;
 import java.util.Map;
 import lombok.Data;
 
@@ -27,9 +26,9 @@ public class ConstraintState {
   String artifactVersion;
   String type;
   String status;
-  Instant createdAt;
+  String createdAt;
   String judgedBy;
-  Instant judgedAt;
+  String judgedAt;
   String comment;
   Map<String, Object> attributes;
 }

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.okhttp:okhttp-urlconnection"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.gate.config
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.jakewharton.retrofit.Ok3Client
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext
 import com.netflix.spectator.api.Registry
@@ -153,6 +154,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
     ObjectMapper objectMapper = new ObjectMapper()
       .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .registerModule(new JavaTimeModule())
 
     return new JsonHttpMessageConverter(objectMapper)
   }
@@ -226,7 +228,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
       }
 
       return new ClouddriverServiceSelector(
-          new SelectableService(selectors + defaultSelector), dynamicConfigService, contextProvider)
+        new SelectableService(selectors + defaultSelector), dynamicConfigService, contextProvider)
     }
 
     SelectableService selectableService = createClientSelector("clouddriver", ClouddriverService, okHttpClient)
@@ -315,6 +317,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
     ObjectMapper objectMapper = new ObjectMapper()
       .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .registerModule(new JavaTimeModule())
 
     new RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)


### PR DESCRIPTION
I "fixed" serialization by turning the `Instant`s into `String`s.

Why? I tried many different settings on the object mapper to get the instants to be written as the "nice" format (`2020-02-09T04:28:10Z`) but I could not figure it out.

So, I decided to change the type to String. I left the java time module on the object mapper though because it was shocking that wasn't already configured.