### PR TITLE
fix(notifications): Ensure empty body on callback when appropriate

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
@@ -89,7 +89,7 @@ class NotificationService {
     Response response = okHttpClient.newCall(echoRequest).execute()
 
     // convert retrofit response to Spring format
-    String body = response.body().contentLength() > 0 ? response.body().toString() : null
+    String body = response.body().contentLength() > 0 ? response.body().string() : null
     HttpHeaders headers = new HttpHeaders()
     headers.putAll(response.headers().toMultimap())
     return new ResponseEntity(body, headers, HttpStatus.valueOf(response.code()))

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
@@ -89,7 +89,7 @@ class NotificationService {
     Response response = okHttpClient.newCall(echoRequest).execute()
 
     // convert retrofit response to Spring format
-    String body = response.body().string()
+    String body = response.body().contentLength() > 0 ? response.body().toString() : null
     HttpHeaders headers = new HttpHeaders()
     headers.putAll(response.headers().toMultimap())
     return new ResponseEntity(body, headers, HttpStatus.valueOf(response.code()))

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/NotificationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/NotificationServiceSpec.groovy
@@ -70,6 +70,8 @@ class NotificationServiceSpec extends Specification {
       .addHeader("multi-value-header", "value2")
       .build()
 
+    Response expectedEchoResponse = mockEchoResponse(expectedEchoRequest)
+
     when: "a request is received for processing"
     ResponseEntity<String> response = notificationService.processNotificationCallback("someSource", incomingRequest)
 
@@ -85,7 +87,7 @@ class NotificationServiceSpec extends Specification {
       echoRequest.headers() == expectedEchoRequest.headers()
       echoCall
     }
-    1 * echoCall.execute() >> mockEchoResponse(expectedEchoRequest)
+    1 * echoCall.execute() >> expectedEchoResponse
 
     and: "returns the response from echo converted as appropriate"
     response == new ResponseEntity<String>('{ "status": "ok" }', null, HttpStatus.OK)


### PR DESCRIPTION
For some reason Spring takes an empty string and converts it into a quoted empty string `""` in a `ResponseEntity`, which messes up rendering of the response in Slack. This ensures that's not the case.