### PR TITLE
fix(web): Fix logout message

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
@@ -91,7 +91,7 @@ class AuthController {
   @ApiOperation(value = "Get logged out message", response = String.class)
   @RequestMapping(value = "/loggedOut", method = RequestMethod.GET)
   String loggedOut() {
-    return LOGOUT_MESSAGES[r.nextInt(LOGOUT_MESSAGES.size()+1)]
+    return LOGOUT_MESSAGES[r.nextInt(LOGOUT_MESSAGES.size())]
   }
 
   /**


### PR DESCRIPTION
Currently, the implemented code returns `null` sometimes randomly because of accessing out of bound element. This commit fixes it.