### PR TITLE
feat(quietperiod): expose current state of quiet period

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CapabilitiesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CapabilitiesController.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.controllers;
 
+import com.netflix.spinnaker.gate.services.internal.EchoService;
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CapabilitiesController {
 
   private final OrcaServiceSelector orcaService;
+  private final EchoService echoService;
 
   @ApiOperation(value = "Retrieve the list configured deployment monitors", response = List.class)
   @GetMapping(value = "/deploymentMonitors")
@@ -44,5 +46,11 @@ public class CapabilitiesController {
   @GetMapping(value = "/expressions")
   Map getExpressionCapabilities() {
     return orcaService.select().getExpressionCapabilities();
+  }
+
+  @ApiOperation(value = "Retrieve the current state of the quiet period", response = Map.class)
+  @GetMapping(value = "/quietPeriod")
+  Map getQuietPeriodState() {
+    return echoService.getQuietPeriodState();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CapabilitiesController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CapabilitiesController.java
@@ -21,18 +21,23 @@ import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/capabilities")
-@RequiredArgsConstructor
 public class CapabilitiesController {
-
   private final OrcaServiceSelector orcaService;
-  private final EchoService echoService;
+  private final Optional<EchoService> echoService;
+
+  @Autowired
+  CapabilitiesController(OrcaServiceSelector orcaService, Optional<EchoService> echoService) {
+    this.orcaService = orcaService;
+    this.echoService = echoService;
+  }
 
   @ApiOperation(value = "Retrieve the list configured deployment monitors", response = List.class)
   @GetMapping(value = "/deploymentMonitors")
@@ -51,6 +56,6 @@ public class CapabilitiesController {
   @ApiOperation(value = "Retrieve the current state of the quiet period", response = Map.class)
   @GetMapping(value = "/quietPeriod")
   Map getQuietPeriodState() {
-    return echoService.getQuietPeriodState();
+    return echoService.map(EchoService::getQuietPeriodState).orElse(null);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/internal/EchoService.groovy
@@ -42,4 +42,7 @@ interface EchoService {
 
   @POST('/')
   String postEvent(@Body Map event)
+  
+  @GET('/quietPeriod')
+  Map getQuietPeriodState()
 }


### PR DESCRIPTION
Adds an endpoint `GET: /capabilities/quietPeriod` that retrieves the current state of quiet period from `echo`
(see `echo` PR https://github.com/spinnaker/echo/pull/784)

The shape of the data returned is:
```
{
  "startTime": 1581282000000,
  "endTime": 1581339600000,
  "enabled": true,
  "inQuietPeriod": false
}
```

The idea is that `deck` could query this and warn the user when they are starting a pipeline within a quiet period
