### PR TITLE
feat(core): expose autoscalers for application

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ClouddriverService.groovy
@@ -91,6 +91,9 @@ interface ClouddriverService {
   @GET("/applications/{name}")
   Map getApplication(@Path("name") String name)
 
+  @GET("/applications/{application}/autoscalers")
+  List<Map> getAutoscalersForApplication(@Path("application") String application)
+
   @Headers("Accept: application/json")
   @GET("/applications/{name}/clusters")
   Map getClusters(@Path("name") String name)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AutoscalerController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AutoscalerController.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.AutoscalerService;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/applications/{application}/autoscalers")
+public class AutoscalerController {
+  private final AutoscalerService autoscalerService;
+
+  @Autowired
+  AutoscalerController(AutoscalerService autoscalerService) {
+    this.autoscalerService = autoscalerService;
+  }
+
+  @ApiOperation(value = "Retrieve a list of autoscalers for an application", response = List.class)
+  @RequestMapping(method = RequestMethod.GET)
+  public List<Map> getAutoscalersForApplication(@PathVariable String application) {
+    return this.autoscalerService.getAutoscalersForApplication(application);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AutoscalerController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AutoscalerController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/applications/{application}/autoscalers")
-public class AutoscalerController {
+final class AutoscalerController {
   private final AutoscalerService autoscalerService;
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AutoscalerService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AutoscalerService.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class AutoscalerService {
+public final class AutoscalerService {
   private final ClouddriverService clouddriverService;
 
   @Autowired

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AutoscalerService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/AutoscalerService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AutoscalerService {
+  private final ClouddriverService clouddriverService;
+
+  @Autowired
+  AutoscalerService(ClouddriverService clouddriverService) {
+    this.clouddriverService = clouddriverService;
+  }
+
+  public List<Map> getAutoscalersForApplication(String application) {
+    return this.clouddriverService.getAutoscalersForApplication(application);
+  }
+}


### PR DESCRIPTION
Autoscalers for [K8S UI RFC](https://github.com/spinnaker/governance/blob/master/rfc/kubernetes-ui-enhancements/kubernetes-ui-enhancements.md)
See [Deck PR](https://github.com/spinnaker/deck/pull/7938) for details on what use case this enables.
[Clouddriver PR](https://github.com/spinnaker/clouddriver/pull/4347)