### PR TITLE
fix(plugins): Invoke callable on propagated authentication

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/publish/PluginBinaryController.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/publish/PluginBinaryController.kt
@@ -75,9 +75,10 @@ class PluginBinaryController(
 
       val response = okHttpClient.newCall(request).execute()
       if (!response.isSuccessful) {
-        throw SystemException("Failed to upload plugin binary: $response")
+        val reason = response.body()?.string() ?: "Unknown reason: ${response.code()}"
+        throw SystemException("Failed to upload plugin binary: $reason")
       }
-    }
+    }.call()
   }
 
   private fun verifyChecksum(body: ByteArray, sha512sum: String) {


### PR DESCRIPTION
AuthenticatedRequest.propagate returns a `Callable`, whoops.