### PR TITLE
feat(managed-delivery): Expose /managed/delivery-configs/validate API

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -27,6 +27,7 @@ import retrofit.client.Response;
 import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
+import retrofit.http.Headers;
 import retrofit.http.POST;
 import retrofit.http.Path;
 import retrofit.http.Query;
@@ -66,6 +67,10 @@ public interface KeelService {
 
   @POST("/delivery-configs/diff")
   List<Map> diffManifest(@Body DeliveryConfig manifest);
+
+  @POST("/delivery-configs/validate")
+  @Headers("Accept: application/json")
+  Map validateManifest(@Body DeliveryConfig manifest);
 
   @GET("/delivery-configs/{name}/environment/{environment}/constraints")
   List<ConstraintState> getConstraintState(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -10,7 +10,6 @@ import com.netflix.spinnaker.gate.model.manageddelivery.Resource;
 import com.netflix.spinnaker.gate.services.internal.KeelService;
 import groovy.util.logging.Slf4j;
 import io.swagger.annotations.ApiOperation;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -146,8 +145,8 @@ public class ManagedController {
         try {
           return ResponseEntity.badRequest()
               .body(objectMapper.readValue(e.getResponse().getBody().in(), Map.class));
-        } catch (IOException ioe) {
-          log.error("Error parsing error response from keel: {}", ioe.getMessage(), ioe);
+        } catch (Exception ex) {
+          log.error("Error parsing error response from keel: {}", ex.getMessage(), ex);
           return ResponseEntity.badRequest().body(Collections.emptyMap());
         }
       } else {


### PR DESCRIPTION
Adding this API to gate so it can be used by external tooling like `newt` at Netflix or the `spin` CLI in OSS.

Note that this is different from `/managed/delivery-configs/diff` (which we'd been using for validation prior to this PR) in that it does not cause the fetching of data from clouddriver to compare desired with actual state. This strictly just validates the YAML/JSON of the delivery config.