### PR TITLE
fix(managed-delivery): Allow parsing errors to be relayed

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -60,6 +60,7 @@ public interface KeelService {
   List<Map<String, Object>> getManifestArtifacts(@Path("name") String name);
 
   @POST("/delivery-configs")
+  @Headers("Accept: application/json")
   DeliveryConfig upsertManifest(@Body DeliveryConfig manifest);
 
   @DELETE("/delivery-configs/{name}")


### PR DESCRIPTION
It looks like `gate` doesn't have a YAML object mapper autowired into the Spring REST machinery, so error details returned from `keel` in YAML format were being dropped from the response. This forces the response from `keel` to be JSON so those details get included in `gate`'s response.