### PR TITLE
fix(managed-delivery): Avoid including null metadata

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/Resource.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/Resource.java
@@ -17,6 +17,8 @@
  */
 package com.netflix.spinnaker.gate.model.manageddelivery;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Map;
 import lombok.Data;
 
@@ -28,6 +30,7 @@ import lombok.Data;
  * serviceAccount [spec] the actual resource
  */
 @Data
+@JsonInclude(Include.NON_NULL)
 public class Resource {
   String apiVersion;
   String kind;


### PR DESCRIPTION
When calling keel to POST a delivery config, and the submitted manifest is in YAML and omits the `metadata` field in resources, gate is converting the YAML to JSON and setting `metadata` to `null`, which breaks parsing in keel. This avoids including the field when it's `null`.