### PR TITLE
chore(dependencies): resolve CVEs issues

### DIFF
--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -1,3 +1,6 @@
+repositories {
+  maven { url "https://repo.spring.io/milestone" }
+}
 dependencies {
   implementation project(":gate-core")
   implementation "com.netflix.spectator:spectator-api"
@@ -5,6 +8,6 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
   implementation "com.squareup.retrofit:converter-simplexml"
-  implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
+  implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure:2.3.0.M2"
   implementation "org.springframework.session:spring-session-core"
 }


### PR DESCRIPTION
Remove CVE-2017-7525 caused by jackson-mapper-asl included on spring-security-oauth2 v.2.3.8.RELEASE
Upgrade spring-security-oauth2-autoconfigure v.2.3.0.M2.
Issue addressed to spring security: https://github.com/spring-projects/spring-security-oauth2-boot/issues/226