### PR TITLE
feat(web): Add weighted rate limiter

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -56,6 +56,7 @@ dependencies {
   testImplementation project(":gate-ldap") // TODO: Move system tests to own module
   testImplementation project(":gate-basic")
   testImplementation "com.squareup.okhttp:mockwebserver"
+  testImplementation "com.netflix.spinnaker.kork:kork-test"
 
   testImplementation "com.squareup.retrofit:retrofit-mock"
   testImplementation "org.springframework.security:spring-security-test"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfig.java
@@ -15,33 +15,59 @@
  */
 package com.netflix.spinnaker.gate.config;
 
+import com.netflix.spinnaker.gate.ratelimit.BucketedRedisRateLimiter;
 import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider;
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter;
 import com.netflix.spinnaker.gate.ratelimit.RedisRateLimitPrincipalProvider;
-import com.netflix.spinnaker.gate.ratelimit.RedisRateLimiter;
 import com.netflix.spinnaker.gate.ratelimit.StaticRateLimitPrincipalProvider;
+import com.netflix.spinnaker.gate.ratelimit.scoring.RequestResponseSizeScoreJudge;
+import com.netflix.spinnaker.gate.ratelimit.scoring.ScoreJudge;
+import com.netflix.spinnaker.gate.ratelimit.scoring.ScoringRedisRateLimiter;
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import java.time.Clock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import redis.clients.jedis.JedisPool;
 
 @Configuration
-@ConditionalOnExpression("${rate-limit.enabled:false}")
+@ConditionalOnProperty("rate-limit.enabled")
 public class RateLimiterConfig {
 
   @Autowired(required = false)
-  RateLimiterConfiguration rateLimiterConfiguration;
+  RateLimiterConfigProperties rateLimiterConfiguration;
 
   @Bean
-  @ConditionalOnExpression("${rate-limit.redis.enabled:false}")
-  RateLimiter redisRateLimiter(JedisPool jedisPool) {
-    return new RedisRateLimiter(jedisPool);
+  @ConditionalOnMissingBean(Clock.class)
+  Clock clock() {
+    return Clock.systemDefaultZone();
   }
 
   @Bean
-  @ConditionalOnExpression("${rate-limit.redis.enabled:false}")
+  @ConditionalOnExpression("${rate-limit.redis.enabled:false} && ${rate-limit.redis.bucketed:true}")
+  RateLimiter redisRateLimiter(JedisPool jedisPool) {
+    return new BucketedRedisRateLimiter(jedisPool);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${rate-limit.redis.enabled:false} && ${rate-limit.redis.scoring:false}")
+  @ConditionalOnMissingBean(ScoreJudge.class)
+  ScoreJudge requestResponseSizeScoreJudge(DynamicConfigService dynamicConfigService) {
+    return new RequestResponseSizeScoreJudge(dynamicConfigService);
+  }
+
+  @Bean
+  @ConditionalOnExpression("${rate-limit.redis.enabled:false} && ${rate-limit.redis.scoring:false}")
+  RateLimiter redisScoringRateLimiter(JedisPool jedisPool, ScoreJudge scoreJudge, Clock clock) {
+    return new ScoringRedisRateLimiter(jedisPool, scoreJudge, clock);
+  }
+
+  @Bean
+  @ConditionalOnExpression(
+      "${rate-limit.redis.enabled:false} && ${rate-limit.redis.principal-provider:true}")
   RateLimitPrincipalProvider redisRateLimiterPrincipalProvider(JedisPool jedisPool) {
     return new RedisRateLimitPrincipalProvider(jedisPool, rateLimiterConfiguration);
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RateLimiterConfigProperties.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties("rate-limit")
-public class RateLimiterConfiguration {
+public class RateLimiterConfigProperties {
 
   /**
    * When learning mode is enabled, principals that go over their allocated rate limit will not
@@ -36,6 +36,8 @@ public class RateLimiterConfiguration {
   /**
    * The number of seconds for each rate limit bucket. Capacity will be filled at the beginning of
    * each rate interval.
+   *
+   * <p>If using a sliding window rate limiter, this value will be treated as "3600" - an hour.
    */
   private int rateSeconds = 10;
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/AbstractRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/AbstractRateLimitPrincipalProvider.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.spinnaker.gate.ratelimit;
 
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration.PrincipalOverride;
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties.PrincipalOverride;
 import java.util.List;
 
 public abstract class AbstractRateLimitPrincipalProvider implements RateLimitPrincipalProvider {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/Rate.java
@@ -23,12 +23,38 @@ public class Rate {
   static final String REMAINING_HEADER = "X-RateLimit-Remaining";
   static final String RESET_HEADER = "X-RateLimit-Reset";
   static final String LEARNING_HEADER = "X-RateLimit-Learning";
+  static final String REQUEST_COST = "X-RateLimit-RequestCost";
 
   Integer capacity;
   Integer rateSeconds;
   Integer remaining;
   Long reset;
   Boolean throttled;
+  Integer requestCost;
+
+  public void setCapacity(Integer capacity) {
+    this.capacity = capacity;
+  }
+
+  public void setRateSeconds(Integer rateSeconds) {
+    this.rateSeconds = rateSeconds;
+  }
+
+  public void setRemaining(Integer remaining) {
+    this.remaining = remaining;
+  }
+
+  public void setReset(Long reset) {
+    this.reset = reset;
+  }
+
+  public void setThrottled(Boolean throttled) {
+    this.throttled = throttled;
+  }
+
+  public void setRequestCost(Integer requestCost) {
+    this.requestCost = requestCost;
+  }
 
   public boolean isThrottled() {
     return throttled;
@@ -39,5 +65,6 @@ public class Rate {
     response.setIntHeader(REMAINING_HEADER, remaining);
     response.setDateHeader(RESET_HEADER, reset);
     response.setHeader(LEARNING_HEADER, learning.toString());
+    response.setIntHeader(REQUEST_COST, requestCost);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProvider.java
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.gate.ratelimit;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
 
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration;
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,12 +34,12 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
   private static final Logger log = LoggerFactory.getLogger(RedisRateLimitPrincipalProvider.class);
 
   private JedisPool jedisPool;
-  private RateLimiterConfiguration rateLimiterConfiguration;
+  private RateLimiterConfigProperties rateLimiterConfiguration;
 
   private boolean supportsDeckSourceApp;
 
   public RedisRateLimitPrincipalProvider(
-      JedisPool jedisPool, RateLimiterConfiguration rateLimiterConfiguration) {
+      JedisPool jedisPool, RateLimiterConfigProperties rateLimiterConfiguration) {
     this.jedisPool = jedisPool;
     this.rateLimiterConfiguration = rateLimiterConfiguration;
 
@@ -196,7 +196,7 @@ public class RedisRateLimitPrincipalProvider extends AbstractRateLimitPrincipalP
 
     return rateLimiterConfiguration.getCapacityBySourceApp().stream()
         .filter(o -> o.getSourceApp().equalsIgnoreCase(sourceApp))
-        .map(RateLimiterConfiguration.SourceAppOverride::getOverride)
+        .map(RateLimiterConfigProperties.SourceAppOverride::getOverride)
         .findFirst();
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/StaticRateLimitPrincipalProvider.java
@@ -15,13 +15,13 @@
  */
 package com.netflix.spinnaker.gate.ratelimit;
 
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration;
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties;
 
 public class StaticRateLimitPrincipalProvider extends AbstractRateLimitPrincipalProvider {
 
-  private RateLimiterConfiguration rateLimiterConfiguration;
+  private RateLimiterConfigProperties rateLimiterConfiguration;
 
-  public StaticRateLimitPrincipalProvider(RateLimiterConfiguration rateLimiterConfiguration) {
+  public StaticRateLimitPrincipalProvider(RateLimiterConfigProperties rateLimiterConfiguration) {
     this.rateLimiterConfiguration = rateLimiterConfiguration;
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/RequestResponseSizeScoreJudge.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/RequestResponseSizeScoreJudge.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit.scoring;
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public class RequestResponseSizeScoreJudge implements ScoreJudge {
+
+  private static final Logger log = LoggerFactory.getLogger(RequestResponseSizeScoreJudge.class);
+
+  private static final double DEFAULT_BASELINE_BYTES = 1024 * 1024; // 1MB
+
+  private final DynamicConfigService dynamicConfigService;
+
+  public RequestResponseSizeScoreJudge(DynamicConfigService dynamicConfigService) {
+    this.dynamicConfigService = dynamicConfigService;
+  }
+
+  @Override
+  public int score(@NotNull HttpServletRequest request, HttpServletResponse response) {
+    if (!(response instanceof ContentCachingResponseWrapper)) {
+      return score(request.getContentLength(), 0);
+    }
+
+    int requestSize = request.getContentLength();
+    int responseSize = ((ContentCachingResponseWrapper) response).getContentSize();
+
+    int score = score(requestSize, responseSize);
+    log.trace(
+        "Judged request score of {} (request={}, response={})", score, requestSize, responseSize);
+    return score;
+  }
+
+  @Override
+  public int historicalScore(@Nonnull List<Integer> history) {
+    return (int)
+        Math.max(Math.floor(history.stream().reduce(0, Integer::sum) / (double) history.size()), 1);
+  }
+
+  private int score(int requestLength, int responseLength) {
+    return (int)
+        Math.max(
+            Math.floor(
+                (requestLength + responseLength)
+                    / dynamicConfigService.getConfig(
+                        Double.class,
+                        "rate-limit.score-judge.baseline-size-bytes",
+                        DEFAULT_BASELINE_BYTES)),
+            1);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoreJudge.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoreJudge.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit.scoring;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Scores a Request / Response for rate limiting. */
+public interface ScoreJudge {
+
+  /**
+   * Creates a score for the given request & response.
+   *
+   * <p>It is possible that {@code response} will be null if there is no historical score.
+   *
+   * @param request
+   * @param response
+   * @return The total cost of this request. Must be positive.
+   */
+  int score(@Nonnull HttpServletRequest request, @Nullable HttpServletResponse response);
+
+  /** Returns a score given a list of historical scores. */
+  int historicalScore(@Nonnull List<Integer> historicalScores);
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRateLimiter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRateLimiter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.gate.ratelimit;
+package com.netflix.spinnaker.gate.ratelimit.scoring;
 
+import com.netflix.spinnaker.gate.ratelimit.RateLimiter;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-public interface RateLimiter {
+/** Rate limits requests based on the cost of fulfilling the particular request. */
+public interface ScoringRateLimiter extends RateLimiter {
 
-  Rate incrementRate(
-      @Nonnull RateLimitPrincipal principal,
+  int calculateTotalCost(
       @Nonnull HttpServletRequest request,
-      @Nullable String handlerMethod);
+      @Nonnull HttpServletResponse response,
+      @Nonnull String handlerMethod);
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRedisRateLimiter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRedisRateLimiter.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.gate.ratelimit.scoring;
+
+import static java.lang.String.format;
+
+import com.netflix.spinnaker.gate.ratelimit.Rate;
+import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipal;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Transaction;
+
+/**
+ * Rate limits requests based on cost of servicing the request, storing principal request usage in a
+ * sliding window.
+ *
+ * <p>Request cost comes in two forms: "Perceived cost" (PC) and "Actual cost" (AC). While serving
+ * any request, the decision to accept a request or not will use the PC supplemented by historical
+ * ACs of the request handler.
+ *
+ * <p>Historical costs use only AC values and are stored without taking into account the request
+ * handler's parameter values. This is a balance of having data to calculate a PC that is roughly
+ * accurate and actual operational cost of maintaining a large amount of historical information.
+ *
+ * <p>Costs are calculated by a {@link ScoreJudge}. If the ScoreJudge is unable to determine the
+ * score for a particular request, a default PC will be calculated using only request information.
+ * Should a principal have full capacity, but the request will be allowed regardless of request
+ * cost.
+ */
+public class ScoringRedisRateLimiter implements ScoringRateLimiter {
+
+  private static final Logger log = LoggerFactory.getLogger(ScoringRateLimiter.class);
+
+  private static final int NUM_SCORES = 100;
+
+  private final JedisPool jedisPool;
+  private final ScoreJudge scoreJudge;
+  private final Clock clock;
+
+  public ScoringRedisRateLimiter(JedisPool jedisPool, ScoreJudge scoreJudge, Clock clock) {
+    this.jedisPool = jedisPool;
+    this.scoreJudge = scoreJudge;
+    this.clock = clock;
+  }
+
+  @Override
+  public Rate incrementRate(
+      @Nonnull RateLimitPrincipal principal,
+      @Nonnull HttpServletRequest request,
+      @Nullable String handlerMethod) {
+    Rate rate = new Rate();
+
+    final String key = principalKey(principal.getName());
+    try (Jedis jedis = jedisPool.getResource()) {
+      // Calculate the score that will be used for the existing request
+      int score = getRequestScore(request, handlerMethod);
+      rate.setRequestCost(score);
+
+      // Get the remaining capacity for the principal
+      final long now = clock.millis();
+      final long window = clock.instant().minus(Duration.ofHours(1)).toEpochMilli();
+
+      // Age-out old requests, range the set of requests for the principal and reset the expiry
+      Transaction txn = jedis.multi();
+      txn.zremrangeByScore(key, 0, window);
+      txn.zrange(key, 0, -1);
+      txn.expire(key, (int) window / 1_000);
+      List<Object> result = txn.exec();
+
+      // zrange result: History of previously used request in the window
+      @SuppressWarnings("unchecked")
+      final int usedRequests =
+          ((Set<String>) result.get(1)).stream().map(Integer::valueOf).reduce(0, Integer::sum);
+
+      if (usedRequests == 0) {
+        // It's cool dog, just allow it regardless of cost or capacity.
+        rate.setThrottled(false);
+        rate.setRemaining(principal.getCapacity() - score);
+      } else if (usedRequests + score > principal.getCapacity()) {
+        rate.setThrottled(true);
+        rate.setRemaining(principal.getCapacity());
+      } else {
+        rate.setThrottled(false);
+        rate.setRemaining(principal.getCapacity() - (usedRequests + score));
+      }
+
+      // Add the request if this request is actually accepted
+      if (!rate.isThrottled()) {
+        jedis.zadd(key, now, String.valueOf(score));
+      }
+    }
+
+    rate.setRateSeconds(1);
+    rate.setCapacity(principal.getCapacity());
+    rate.setReset(Instant.now().plus(Duration.ofHours(1)).toEpochMilli());
+
+    return rate;
+  }
+
+  @Override
+  public int calculateTotalCost(
+      @Nonnull HttpServletRequest request,
+      @Nonnull HttpServletResponse response,
+      @Nullable String handlerMethod) {
+    final int score = scoreJudge.score(request, response);
+
+    if (handlerMethod == null) {
+      // If the handlerMethod couldn't be resolved, we can't save this invocation, so just return
+      // the score.
+      return score;
+    }
+
+    // Persist the actual total score of the request, keeping the last 100 scores for the handler.
+    final String key = handlerKey(handlerMethod);
+    try (Jedis jedis = jedisPool.getResource()) {
+      Pipeline p = jedis.pipelined();
+      p.rpush(key, String.valueOf(score));
+      p.ltrim(key, 0, NUM_SCORES - 1);
+      p.expire(key, 3_600);
+      p.sync();
+    } catch (Exception e) {
+      log.error("Failed updating request score ({}) for '{}'", score, key, e);
+      return score;
+    }
+
+    return score;
+  }
+
+  private int getRequestScore(HttpServletRequest request, String handlerMethod) {
+    if (handlerMethod == null) {
+      // No handlerMethod, so we can only operate off of whatever score is generated from the
+      // request itself.
+      return scoreJudge.score(request, null);
+    }
+
+    final String key = handlerKey(handlerMethod);
+    try (Jedis jedis = jedisPool.getResource()) {
+      return scoreJudge.historicalScore(
+          jedis.lrange(key, 0, NUM_SCORES - 1).stream()
+              .map(Integer::valueOf)
+              .collect(Collectors.toList()));
+    } catch (Exception e) {
+      final int requestOnlyScore = scoreJudge.score(request, null);
+      log.error(
+          "Failed calculating score for '{}', falling back to request score ({})",
+          key,
+          requestOnlyScore,
+          e);
+      return requestOnlyScore;
+    }
+  }
+
+  private static String handlerKey(String handlerMethod) {
+    return format("rateLimitHistory:%s", handlerMethod);
+  }
+
+  private static String principalKey(String principalName) {
+    return format("rateLimitWindow:%s", principalName);
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProviderSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/RedisRateLimitPrincipalProviderSpec.groovy
@@ -15,11 +15,10 @@
  */
 package com.netflix.spinnaker.gate.ratelimit
 
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration.PrincipalOverride
-import com.netflix.spinnaker.gate.config.RateLimiterConfiguration.SourceAppOverride
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties.PrincipalOverride
+import com.netflix.spinnaker.gate.config.RateLimiterConfigProperties.SourceAppOverride
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
-import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -45,7 +44,7 @@ class RedisRateLimitPrincipalProviderSpec extends Specification {
     given:
     RedisRateLimitPrincipalProvider subject = new RedisRateLimitPrincipalProvider(
       (JedisPool) embeddedRedis.pool,
-      new RateLimiterConfiguration(
+      new RateLimiterConfigProperties(
         capacity: 60,
         capacityByPrincipal: [
           new PrincipalOverride(principal: 'anonymous', override: 5),

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/RequestResponseSizeScoreJudgeSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/RequestResponseSizeScoreJudgeSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.ratelimit.scoring
+
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import org.springframework.web.util.ContentCachingResponseWrapper
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest
+
+class RequestResponseSizeScoreJudgeSpec extends Specification {
+
+  DynamicConfigService dynamicConfigService = Mock()
+
+  @Subject
+  ScoreJudge subject = new RequestResponseSizeScoreJudge(dynamicConfigService)
+
+  @Unroll
+  def "calculates score"() {
+    given:
+    def request = Mock(HttpServletRequest)
+    def response = Mock(ContentCachingResponseWrapper)
+
+    when:
+    def result = subject.score(request, response)
+
+    then:
+    1 * dynamicConfigService.getConfig(_, _, _) >> (double) baselineBytes
+    1 * request.getContentLength() >> requestSize
+    1 * response.getContentSize() >> responseSize
+    result == expected
+
+    where:
+    baselineBytes | requestSize | responseSize || expected
+    1024          | -1          | 7 * 1024     || 6
+    1024 * 1024   | -1          | 2811794      || 2
+  }
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRedisRateLimiterSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ratelimit/scoring/ScoringRedisRateLimiterSpec.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.ratelimit.scoring
+
+import com.netflix.spinnaker.gate.ratelimit.Rate
+import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipal
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.test.time.MutableClock
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.util.Pool
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.function.Consumer
+import java.util.function.Function
+
+class ScoringRedisRateLimiterSpec extends Specification {
+
+  private static final String HANDLER_NAME = "myHandlerName(String, boolean)"
+
+  static int port
+
+  @Shared
+  @AutoCleanup("destroy")
+  EmbeddedRedis embeddedRedis
+
+  def setupSpec() {
+    embeddedRedis = EmbeddedRedis.embed()
+    embeddedRedis.jedis.flushDB()
+    port = embeddedRedis.port
+  }
+
+  def cleanup() {
+    embeddedRedis.jedis.flushDB()
+  }
+
+  def 'should create new sliding window for unknown principal'() {
+    given:
+    ScoreJudge judge = Mock() {
+      historicalScore(_) >> 2
+    }
+    ScoringRateLimiter subject = new ScoringRedisRateLimiter((JedisPool) embeddedRedis.pool, judge, new MutableClock())
+
+    and:
+    RateLimitPrincipal principal = new RateLimitPrincipal("user@example.com", 10, 10, true)
+
+    and:
+    HttpServletRequest request = Mock()
+
+    when:
+    Rate rate = subject.incrementRate(principal, request, HANDLER_NAME)
+
+    then:
+    noExceptionThrown()
+    rate.capacity == 10
+    rate.remaining == 8
+    !rate.isThrottled()
+
+    and: 'cost of request should be added to sliding window'
+    withJedis(embeddedRedis.pool) {
+      it.zrange(ScoringRedisRateLimiter.principalKey(principal.name), 0, -1) == ["2"] as Set
+    }
+  }
+
+  def 'should use historical scores to get current request cost'() {
+    given:
+    ScoreJudge judge = Mock()
+    ScoringRateLimiter subject = new ScoringRedisRateLimiter((JedisPool) embeddedRedis.pool, judge, new MutableClock())
+
+    and:
+    RateLimitPrincipal principal = new RateLimitPrincipal("user@example.com", 10, 10, true)
+
+    and:
+    withJedis(embeddedRedis.pool) {
+      it.rpush(ScoringRedisRateLimiter.handlerKey(HANDLER_NAME), "5")
+    }
+
+    and:
+    HttpServletRequest request = Mock()
+
+    when:
+    Rate rate = subject.incrementRate(principal, request, HANDLER_NAME)
+
+    then:
+    noExceptionThrown()
+    1 * judge.historicalScore([5]) >> 2
+    rate.capacity == 10
+    rate.remaining == 8
+  }
+
+  def 'should age-out old requests'() {
+    given:
+    Clock clock = new MutableClock()
+    clock.instant(Instant.now())
+
+    ScoreJudge judge = Mock() {
+      historicalScore(_) >> 1
+    }
+    ScoringRateLimiter subject = new ScoringRedisRateLimiter((JedisPool) embeddedRedis.pool, judge, clock)
+
+    and:
+    RateLimitPrincipal principal = new RateLimitPrincipal("user@example.com", 10, 10, true)
+
+    and:
+    HttpServletRequest request = Mock()
+
+    and:
+    subject.incrementRate(principal, request, HANDLER_NAME)
+    clock.incrementBy(Duration.ofMinutes(1))
+
+    subject.incrementRate(principal, request, HANDLER_NAME)
+    clock.incrementBy(Duration.ofMinutes(30))
+
+    subject.incrementRate(principal, request, HANDLER_NAME)
+    clock.incrementBy(Duration.ofMinutes(30))
+
+    when:
+    subject.incrementRate(principal, request, HANDLER_NAME)
+
+    then:
+    withJedis(embeddedRedis.pool) {
+      it.zrange(ScoringRedisRateLimiter.principalKey(principal.name), 0, -1) == ["1"] as Set
+    }
+  }
+
+  def 'should add score to historical list'() {
+    given:
+    ScoreJudge judge = Mock() {
+      score(_, _) >> 1
+    }
+    ScoringRateLimiter subject = new ScoringRedisRateLimiter((JedisPool) embeddedRedis.pool, judge, new MutableClock())
+
+    and:
+    HttpServletRequest request = Mock()
+    HttpServletResponse response = Mock()
+
+    when:
+    subject.calculateTotalCost(request, response, HANDLER_NAME)
+
+    then:
+    noExceptionThrown()
+    withJedis(embeddedRedis.pool) {
+      it.lrange(ScoringRedisRateLimiter.handlerKey(HANDLER_NAME), 0, -1) == ["1"]
+    }
+
+    when:
+    subject.calculateTotalCost(request, response, HANDLER_NAME)
+
+    then:
+    noExceptionThrown()
+    withJedis(embeddedRedis.pool) {
+      it.lrange(ScoringRedisRateLimiter.handlerKey(HANDLER_NAME), 0, -1) == ["1", "1"]
+    }
+  }
+
+  private static void withJedis(Pool<Jedis> pool, Consumer<Jedis> command) {
+    Jedis jedis = pool.getResource()
+    try {
+      command.accept(jedis)
+    } finally {
+      jedis.close()
+    }
+  }
+}


### PR DESCRIPTION
We had an incident yesterday where a large customer burst a bunch of traffic into Spinnaker, taking down our API clouddriver shard. The quantity of requests wasn't so much the problem, as they were respecting the rate limits provided to them, but that the requests were costly in serialization (50MB responses each). The serialization song-and-dance caused Clouddriver to OOM and crash out - spreading the load across more Clouddriver instances did help us resolve the issue, but running larger clusters for rare spikes isn't great.

This PR makes a number of improvements on the rate limiter in the form of a new `ScoringRedisRateLimiter`.

1. This `RateLimiter` implementation uses a sliding window, rather than a leaky bucket.
1. Every request is scored and assigned a "cost", based on request & response content length. This cost is exposed to clients via `X-RateLimit-RequestCost`

A baseline aggregate content length is configured (defaulting to 1MB), any requests that are roughly 1MB and below will be assigned a cost of "1", but a response with 50MB of content length would have a request cost of 50. Given a user's rate limit capacity of 500, one API call would then cost them 50 requests out of that capacity.

Since the same API endpoint can vary wildly in terms of response size based on the parameters that it is provided, historical request costs are stored and used to inform a "perceived cost" of a request, since the response size will not be known at request time. Only when the response has been received from a downstream service will the historical table be updated to inform future requests. This means that when the rate limiter is initially deployed, most requests will likely cost around "1".