### PR TITLE
fix(managed): properly annotate YAML support on upsertManifest

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -121,7 +121,10 @@ public class ManagedController {
   @ApiOperation(
       value = "Create or update a delivery config manifest",
       response = DeliveryConfig.class)
-  @PostMapping(path = "/delivery-configs")
+  @PostMapping(
+      path = "/delivery-configs",
+      consumes = {APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE},
+      produces = {APPLICATION_JSON_VALUE})
   DeliveryConfig upsertManifest(@RequestBody DeliveryConfig manifest) {
     return keelService.upsertManifest(manifest);
   }


### PR DESCRIPTION
Because this endpoint wasn't annotated properly, our auto-generated swagger UI was refusing to allow YAML request bodies in the example/playground. Should be behaviorally equivalent.