### PR TITLE
chore(java11): Turn on the cross-compiler plugin in Dockerfile.compile

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -8,4 +8,4 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 ENV JDK_18 /usr/lib/jvm/java-1.8-openjdk
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx4g
-CMD ./gradlew gate-web:installDist -x test
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true gate-web:installDist -x test


### PR DESCRIPTION
This got missed because my script tries to add it before `--no-daemon`.
So go ahead and add that too, for consistency and because otherwise
GRADLE_OPTS does nothing useful.