### PR TITLE
fix(etag): removing etag filter

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -37,14 +37,12 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.filter.ShallowEtagHeaderFilter
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector
 import retrofit.RetrofitError
 
-import javax.servlet.Filter
 import javax.servlet.http.HttpServletResponse
 
 @Configuration
@@ -89,11 +87,6 @@ public class GateWebConfig implements WebMvcConfigurer {
   @Bean
   HandlerMappingIntrospector mvcHandlerMappingIntrospector(ApplicationContext context) {
     return new HandlerMappingIntrospector(context)
-  }
-
-  @Bean
-  Filter eTagFilter() {
-    new ShallowEtagHeaderFilter()
   }
 
   @Bean


### PR DESCRIPTION
We noticed that `ETag` filter somehow makes it so that requests from `gate` are no longer gzipped.
Since `deck` doesn't even use ETags, rather than figuring our what wrong with `ETag`s I am just removing them to get the gzip benefit (and stop wasting CPU cycles computing `ETag`s)
