### PR TITLE
chore(dependencies): Bump kork to 7.31.1 and fixup PluginBundleExtractor instantiation

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.gate.plugins.deck
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.plugins.SpringStrictPluginLoaderStatusProvider
 import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -32,9 +33,10 @@ open class DeckPluginConfiguration {
   @Bean
   open fun deckPluginCache(
     updateManager: SpinnakerUpdateManager,
-    registry: Registry
+    registry: Registry,
+    springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider
   ): DeckPluginCache =
-      DeckPluginCache(updateManager, PluginBundleExtractor(), registry)
+      DeckPluginCache(updateManager, PluginBundleExtractor(springStrictPluginLoaderStatusProvider), registry)
 
   @Bean
   open fun deckPluginService(

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 fiatVersion=1.18.0
 enablePublishing=false
 spinnakerGradleVersion=7.8.0
-korkVersion=7.29.0
+korkVersion=7.31.1
 includeProviders=basic,iap,ldap,oauth2,saml,x509
 org.gradle.parallel=true


### PR DESCRIPTION
Previous bumps were failing due to the constructor changing for `PluginBundleExtractor`.