### PR TITLE
fix(etag): produce weak ETag

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -93,7 +93,12 @@ public class GateWebConfig implements WebMvcConfigurer {
 
   @Bean
   Filter eTagFilter() {
-    new ShallowEtagHeaderFilter()
+    // Note that this filter also sets the content-length for us, which we want so as not to produce a chunked response.
+    ShallowEtagHeaderFilter filter = new ShallowEtagHeaderFilter()
+
+    // Writing a weak ETag so that we still get a gzip'ed response
+    filter.setWriteWeakETag(true)
+    return filter
   }
 
   @Bean


### PR DESCRIPTION
follow up from: https://github.com/spinnaker/gate/pull/1123

We noticed that `ETag` filter somehow makes it so that requests from `gate` are no longer gzipped.
Removing the filter caused the issue that responses no longer contained `Content-Length` header which means that the responses were chunked.
This is a pretty big difference and a breaking change for clients that might not be able to handle chunked responses.

This change sets the `ETag` to be weak which doesn't circumvent gzip but also sets the `content-length` and is thus not chunked.

