### PR TITLE
fix(plugins): add an option for strict plugin loading

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.gate.plugins.deck
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.kork.plugins.SpringStrictPluginLoaderStatusProvider
 import com.netflix.spinnaker.kork.plugins.bundle.PluginBundleExtractor
 import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -32,9 +33,11 @@ open class DeckPluginConfiguration {
   @Bean
   open fun deckPluginCache(
     updateManager: SpinnakerUpdateManager,
-    registry: Registry
-  ): DeckPluginCache =
-      DeckPluginCache(updateManager, PluginBundleExtractor(), registry)
+    registry: Registry,
+    strictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider
+  ): DeckPluginCache {
+    return DeckPluginCache(updateManager, PluginBundleExtractor(strictPluginLoaderStatusProvider), registry)
+  }
 
   @Bean
   open fun deckPluginService(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Wed Mar 04 22:41:14 UTC 2020
 fiatVersion=1.14.0
 enablePublishing=false
-korkVersion=7.25.1
+korkVersion=7.25.13
 spinnakerGradleVersion=7.0.1
 org.gradle.parallel=true
 includeProviders=basic,iap,ldap,oauth2,saml,x509


### PR DESCRIPTION
This PR is part of a series of PRs for allowing relaxed plugin loading by adding a config option to turn strict plugin loading on or off. See https://docs.google.com/document/d/1yFDrpkCCV7Vp0wN0gDc9GTbTOBoIzNo-tGj1-vVjq04/edit?usp=sharing for more info