### PR TITLE
feat(serviceAccounts): filter service accounts by application

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -21,12 +21,14 @@ import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.filters.FiatSessionFilter
 import com.netflix.spinnaker.gate.services.PermissionService
+import com.netflix.spinnaker.gate.services.ServiceAccountFilterConfigProps
 import com.netflix.spinnaker.security.User
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.security.SecurityProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -44,6 +46,7 @@ import javax.servlet.http.HttpServletResponse
 
 @Slf4j
 @Configuration
+@EnableConfigurationProperties([ServiceConfiguration, ServiceAccountFilterConfigProps])
 class AuthConfig {
 
   @Autowired

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/ServiceAccountFilterConfigProps.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/ServiceAccountFilterConfigProps.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import java.util.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConfigurationProperties("fiat.service-accounts.filter")
+public class ServiceAccountFilterConfigProps {
+  private static final Set<Authorization> DEFAULT_MATCH_AUTHORIZATIONS =
+      Collections.unmodifiableSet(EnumSet.of(Authorization.WRITE, Authorization.EXECUTE));
+
+  private final boolean enabled;
+  private final Set<Authorization> matchAuthorizations;
+
+  @ConstructorBinding
+  public ServiceAccountFilterConfigProps(Boolean enabled, List<Authorization> matchAuthorizations) {
+    this.enabled = enabled == null ? true : enabled;
+    if (matchAuthorizations == null) {
+      this.matchAuthorizations = DEFAULT_MATCH_AUTHORIZATIONS;
+    } else if (matchAuthorizations.isEmpty()) {
+      this.matchAuthorizations = Collections.emptySet();
+    } else {
+      this.matchAuthorizations = Collections.unmodifiableSet(EnumSet.copyOf(matchAuthorizations));
+    }
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public Collection<Authorization> getMatchAuthorizations() {
+    return matchAuthorizations;
+  }
+}

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ExtendedFiatService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/ExtendedFiatService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services.internal;
+
+import com.netflix.spinnaker.fiat.model.UserPermission;
+import java.util.List;
+import retrofit.http.GET;
+import retrofit.http.Path;
+
+public interface ExtendedFiatService {
+
+  @GET("/authorize/{userId}/serviceAccounts?expand=true")
+  List<UserPermission.View> getUserServiceAccounts(@Path("userId") String userId);
+}

--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/services/PermissionServiceSpec.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/services/PermissionServiceSpec.groovy
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.services
+
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.fiat.model.UserPermission
+import com.netflix.spinnaker.fiat.model.resources.Application
+import com.netflix.spinnaker.fiat.model.resources.Permissions
+import com.netflix.spinnaker.fiat.model.resources.Role
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
+import com.netflix.spinnaker.gate.services.internal.ExtendedFiatService
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException
+import com.netflix.spinnaker.security.User
+import retrofit.RetrofitError
+import retrofit.client.Response
+import retrofit.converter.ConversionException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PermissionServiceSpec extends Specification {
+
+  def "lookupServiceAccount returns empty on 404"() {
+    given:
+    def extendedFiatService = Stub(ExtendedFiatService) {
+      getUserServiceAccounts(user) >> { throw theFailure }
+    }
+    def subject = new PermissionService(extendedFiatService: extendedFiatService)
+
+    when:
+    def result = subject.lookupServiceAccounts(user)
+
+    then:
+    noExceptionThrown()
+    result == []
+
+    where:
+    user = 'foo@bar.com'
+
+    theFailure << [httpRetrofitError(404), conversionError(404)]
+
+  }
+
+  @Unroll
+  def "lookupServiceAccount failures are marked retryable"() {
+    given:
+    def extendedFiatService = Stub(ExtendedFiatService) {
+      getUserServiceAccounts(user) >> { throw theFailure }
+    }
+    def subject = new PermissionService(extendedFiatService: extendedFiatService)
+
+    when:
+    subject.lookupServiceAccounts(user)
+
+    then:
+    def exception = thrown(SpinnakerException)
+    exception.retryable == expectedRetryable
+
+    where:
+    user = 'foo@bar.com'
+
+    theFailure             || expectedRetryable
+    httpRetrofitError(400) || false
+    conversionError(400)   || false
+    conversionError(200)   || false
+    networkError()         || true
+    httpRetrofitError(500) || true
+    conversionError(500)   || true
+    unexpectedError()      || true
+  }
+
+  private RetrofitError conversionError(int code) {
+    RetrofitError.conversionError(
+      'http://foo',
+      new Response('http://foo', code, 'you are bad', [], null),
+      null,
+      null,
+      new ConversionException('boom'))
+  }
+
+  private RetrofitError networkError() {
+    RetrofitError.networkError('http://foo', new IOException())
+  }
+
+  private RetrofitError unexpectedError() {
+    RetrofitError.unexpectedError('http://foo', new Throwable())
+  }
+
+  private RetrofitError httpRetrofitError(int code) {
+    RetrofitError.httpError(
+      'http://foo',
+      new Response('http://foo', code, 'you are bad', [], null),
+      null,
+      null)
+  }
+
+
+  @Unroll
+  def "getServiceAccountsForApplication when #desc looks up all serviceAccounts (#expectLookup) and falls back to getServiceAccounts (#expectFallback)"() {
+    given:
+    def cfgProps = new ServiceAccountFilterConfigProps(enabled, matchAuths ? auths : [])
+    def user = username == null ? null : Stub(User) {
+      getUsername() >> username
+    }
+    def fiatStatus = Stub(FiatStatus) {
+      isEnabled() >> fiatEnabled
+    }
+    def permissionEvaluator = Mock(FiatPermissionEvaluator)
+    def extendedFiatService = Mock(ExtendedFiatService)
+    def result = hasResult ? lookupResult : []
+
+    def subject = new PermissionService(
+      fiatStatus: fiatStatus,
+      permissionEvaluator: permissionEvaluator,
+      extendedFiatService: extendedFiatService,
+      serviceAccountFilterConfigProps: cfgProps)
+
+    when:
+    subject.getServiceAccountsForApplication(user, application)
+
+    then:
+    (expectLookup ? 1 : 0) * extendedFiatService.getUserServiceAccounts(username) >> result
+    (expectFallback ? 1 : 0) * permissionEvaluator.getPermission(username) >> userPermissionView
+    0 * _
+
+    where:
+    enabled | matchAuths | username      | application | fiatEnabled | hasResult || expectLookup || expectFallback || desc
+    true    | true       | 'foo@bar.com' | 'myapp'     | true        | true      || true         || false          || "successfully performs filtered lookup"
+    false   | true       | 'foo@bar.com' | 'myapp'     | true        | true      || false        || true           || "filtering disabled"
+    true    | false      | 'foo@bar.com' | 'myapp'     | true        | true      || false        || true           || "no authorizations to filter on"
+    true    | true       | null          | 'myapp'     | true        | true      || false        || false          || "no username supplied"
+    true    | true       | 'foo@bar.com' | null        | true        | true      || false        || true           || "no application supplied"
+    true    | true       | 'foo@bar.com' | 'myapp'     | false       | true      || false        || false          || "fiat disabled"
+    true    | true       | 'foo@bar.com' | 'myapp'     | true        | false     || true         || true           || "no service accounts match"
+
+    auths = [Authorization.WRITE]
+    lookupResult = [sa("foo-service-account", application, auths)]
+    userPermission = new UserPermission(id: 'foo@bar.com')
+    userPermissionView = userPermission.getView()
+  }
+
+  private UserPermission.View sa(String name, String application, Collection<Authorization> auths) {
+    UserPermission userPermission = new UserPermission();
+    userPermission.setId(name)
+    userPermission.setRoles([new Role(name: name, source: Role.Source.EXTERNAL)] as Set<Role>)
+
+    Application app = new Application()
+    app.setName(application)
+    Permissions.Builder pb = new Permissions.Builder()
+    for (auth in auths) {
+      pb.add(auth, name)
+    }
+    app.setPermissions(pb.build())
+
+    userPermission.setApplications([app] as Set<Application>)
+    return userPermission.getView()
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -184,6 +184,12 @@ class GateConfig extends RedisHttpSessionConfiguration {
   }
 
   @Bean
+  ExtendedFiatService extendedFiatService(OkHttpClient okHttpClient) {
+    // always create the fiat service even if 'services.fiat.enabled' is 'false' (it can be enabled dynamically)
+    createClient "fiat", ExtendedFiatService, okHttpClient, null, true
+  }
+
+  @Bean
   @ConditionalOnProperty("services.fiat.config.dynamic-endpoints.login")
   FiatService fiatLoginService(OkHttpClient okHttpClient) {
     // always create the fiat service even if 'services.fiat.enabled' is 'false' (it can be enabled dynamically)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/AuthController.groovy
@@ -84,8 +84,20 @@ class AuthController {
 
   @ApiOperation(value = "Get service accounts", response = List.class)
   @RequestMapping(value = "/user/serviceAccounts", method = RequestMethod.GET)
-  List<String> getServiceAccounts(@ApiIgnore @SpinnakerUser User user) {
-    permissionService.getServiceAccounts(user)
+  List<String> getServiceAccounts(@ApiIgnore @SpinnakerUser User user,
+                                  @RequestParam(name = "application", required = false) String application) {
+
+    String appName = Optional.ofNullable(application)
+      .map({ s -> s.trim() })
+      .filter({ s -> !s.isEmpty()})
+      .orElse(null);
+
+
+    if (appName == null) {
+      return permissionService.getServiceAccounts(user)
+    }
+
+    return permissionService.getServiceAccountsForApplication(user, appName)
   }
 
   @ApiOperation(value = "Get logged out message", response = String.class)

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/basic/BasicAuthSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/basic/BasicAuthSpec.groovy
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Slf4j
 @GateSystemTest
-@SpringBootTest
+@SpringBootTest(properties = ["fiat.enabled=false"])
 @ContextConfiguration(
   classes = [Main, GateConfig, BasicAuthConfig, BasicTestConfig, RedisTestConfig],
   initializers = YamlFileApplicationContextInitializer

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/security/ldap/LdapAuthSpec.groovy
@@ -48,7 +48,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 @Slf4j
 @GateSystemTest
 @SpringBootTest(
-    properties = ['ldap.enabled=true', 'spring.application.name=gate'])
+    properties = ['ldap.enabled=true', 'spring.application.name=gate', 'fiat.enabled=false'])
 @ContextConfiguration(
   classes = [LdapSsoConfig, Main, LdapTestConfig, RedisTestConfig],
   initializers = YamlFileApplicationContextInitializer


### PR DESCRIPTION
enables a more meaningful list of service accounts when selecting a run as user

This feature can be disabled by setting `fiat.service-accounts.filter.enabled=false`.

The required authorizations for the service account on the application can be customized,
by default they are either of WRITE or EXECUTE, but can be set as
`fiat.service-accounts.filter.match-authorizations=READ,WRITE,EXECUTE`

In the event that no service accounts match the specific application, the user's full
list of service accounts is returned as a fallback.