### PR TITLE
feat(api): An `ExtensionPoint` that allows plugin endpoints to be exposed under a common path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    kotlinVersion = "1.3.21"
+    kotlinVersion = "1.3.71"
   }
   repositories {
     jcenter()

--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ApiExtension.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ApiExtension.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.gate.api.extension;
+
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import org.pf4j.ExtensionPoint;
+
+/**
+ * An {@code ExtensionPoint} that allows for a new api to be exposed under a common
+ * `/extensions/{id}` path.
+ */
+@Alpha
+public interface ApiExtension extends ExtensionPoint {
+  @Nonnull
+  String id();
+
+  default boolean handles(@Nonnull HttpRequest httpRequest) {
+    return false;
+  }
+
+  @Nonnull
+  default HttpResponse handle(@Nonnull HttpRequest httpRequest) {
+    return HttpResponse.of(200, Collections.emptyMap(), "Hello world!");
+  }
+}

--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/HttpRequest.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/HttpRequest.java
@@ -13,13 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'java-library'
 
-dependencies {
-  implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
-  api "com.netflix.spinnaker.kork:kork-plugins-api"
-  api "com.netflix.spinnaker.kork:kork-annotations"
+package com.netflix.spinnaker.gate.api.extension;
 
-  compileOnly("org.projectlombok:lombok")
-  annotationProcessor("org.projectlombok:lombok")
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.Map;
+import lombok.Data;
+
+/** An {@link HttpRequest} represents a request that will be handled by an {@link ApiExtension}. */
+@Alpha
+@Data(staticConstructor = "of")
+public class HttpRequest {
+  private final String method;
+  private final String requestURI;
+  private final Map<String, String> headers;
+  private final Map<String, String> parameters;
+
+  private String body;
 }

--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/HttpResponse.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/HttpResponse.java
@@ -13,13 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-apply plugin: 'java-library'
 
-dependencies {
-  implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
-  api "com.netflix.spinnaker.kork:kork-plugins-api"
-  api "com.netflix.spinnaker.kork:kork-annotations"
+package com.netflix.spinnaker.gate.api.extension;
 
-  compileOnly("org.projectlombok:lombok")
-  annotationProcessor("org.projectlombok:lombok")
+import com.netflix.spinnaker.kork.annotations.Alpha;
+import java.util.Map;
+import lombok.Data;
+
+/**
+ * An {@link HttpResponse} represents the response from a request that has been handled by an {@link
+ * ApiExtension}.
+ */
+@Alpha
+@Data(staticConstructor = "of")
+public class HttpResponse {
+  private final int status;
+  private final Map<String, String> headers;
+  private final Object body;
 }

--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -1,11 +1,12 @@
-apply from: "$rootDir/gradle/kotlin.gradle"
+apply from: "${project.rootDir}/gradle/kotlin.gradle"
+apply from: "${project.rootDir}/gradle/kotlin-test.gradle"
 
 dependencies {
+  implementation project(":gate-api")
   implementation project(":gate-core")
 
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.netflix.spectator:spectator-api"
-
 }

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionController.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionController.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.api.extension.ApiExtension
+import com.netflix.spinnaker.gate.api.extension.HttpRequest
+import com.netflix.spinnaker.kork.annotations.Alpha
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import com.squareup.okhttp.internal.http.HttpMethod
+import java.io.IOException
+import java.util.stream.Collectors
+import javax.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.util.CollectionUtils
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * A top-level [RestController] that exposes all api extensions under a common
+ * `/extensions/{{ApiExtension.id}}` path.
+ */
+@Alpha
+@RestController
+@RequestMapping("/extensions")
+class ApiExtensionController @Autowired constructor(private val apiExtensions: List<ApiExtension>) {
+
+  init {
+    val duplicateApiExtensionIds = apiExtensions
+      .groupBy { it.id().toLowerCase() }
+      .filter { it.value.size > 1 }
+      .flatMap { it.value }
+      .map { "[class=${it.javaClass}], id=${it.id()}]" }
+
+    if (duplicateApiExtensionIds.isNotEmpty()) {
+      throw SystemException("Duplicate api extensions were detected (${duplicateApiExtensionIds.joinToString(", ")}")
+    }
+  }
+
+  @RequestMapping(value = ["/{extension}/**"])
+  fun any(
+    @PathVariable(value = "extension") extension: String,
+    @RequestParam requestParams: Map<String?, String?>?,
+    httpServletRequest: HttpServletRequest
+  ): ResponseEntity<Any> {
+
+    val httpRequest = HttpRequest.of(
+      httpServletRequest.method,
+      httpServletRequest.requestURI.replace("/extensions/$extension", ""),
+      httpServletRequest.headerNames.toList().map { it to httpServletRequest.getHeader(it) }.toMap(),
+      requestParams
+    )
+
+    if (HttpMethod.permitsRequestBody(httpRequest.method)) {
+      try {
+        httpRequest.body = httpServletRequest
+          .reader
+          .lines()
+          .collect(Collectors.joining(System.lineSeparator()))
+      } catch (e: IOException) {
+        throw SpinnakerException("Unable to read request body", e)
+      }
+    }
+
+    val apiExtension = apiExtensions.stream()
+      .filter { e: ApiExtension -> e.id().equals(extension, ignoreCase = true) && e.handles(httpRequest) }
+      .findFirst()
+
+    if (!apiExtension.isPresent) {
+      throw NotFoundException()
+    }
+
+    val httpResponse = apiExtension.get().handle(httpRequest)
+    val status = HttpStatus.resolve(httpResponse.status)
+      ?: throw SpinnakerException("Unsupported http status code: " + httpResponse.status)
+
+    return ResponseEntity(
+      httpResponse.body,
+      CollectionUtils.toMultiValueMap(httpResponse.headers.map { it.key to listOf(it.value) }.toMap()),
+      status
+    )
+  }
+}

--- a/gate-proxy/src/test/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionControllerTest.kt
+++ b/gate-proxy/src/test/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionControllerTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.controllers
+
+import com.netflix.spinnaker.gate.api.extension.ApiExtension
+import com.netflix.spinnaker.gate.api.extension.HttpRequest
+import com.netflix.spinnaker.gate.api.extension.HttpResponse
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isEqualTo
+
+class ApiExtensionControllerTest : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("basic validation") {
+      test("raises SystemException when duplicate api extension identifiers are detected") {
+        expectThrows<SystemException> {
+          ApiExtensionController(listOf(firstApiExtension, firstApiExtension))
+        }
+      }
+
+      test("raises SystemException when duplicate api extension identifiers are detected") {
+        ApiExtensionController(listOf(firstApiExtension))
+        ApiExtensionController(listOf(firstApiExtension, secondApiExtension))
+      }
+    }
+
+    context("basic request handling") {
+      test("raises NotFoundException when api extension does not exist") {
+        expectThrows<NotFoundException> {
+          subject.any(
+            "does-not-exist", emptyMap(), mockk(relaxed = true)
+          )
+        }
+      }
+
+      test("returns expected response") {
+        expectThat(subject.any(
+          firstApiExtension.id(), emptyMap(), mockk(relaxed = true)
+        ).body).isEqualTo("This is a result from ${firstApiExtension.id()}")
+
+        expectThat(subject.any(
+          secondApiExtension.id(), emptyMap(), mockk(relaxed = true)
+        ).body).isEqualTo("This is a result from ${secondApiExtension.id()}")
+      }
+    }
+  }
+
+  private inner class Fixture {
+    val firstApiExtension = SimpleApiExtension("1")
+    val secondApiExtension = SimpleApiExtension("2")
+    val subject = ApiExtensionController(listOf(firstApiExtension, secondApiExtension))
+  }
+
+  class SimpleApiExtension(private val id: String) : ApiExtension {
+    override fun id(): String {
+      return id
+    }
+
+    override fun handles(httpRequest: HttpRequest): Boolean {
+      return true
+    }
+
+    override fun handle(httpRequest: HttpRequest): HttpResponse {
+      return HttpResponse.of(200, emptyMap(), "This is a result from ${id()}")
+    }
+  }
+}

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+  implementation project(":gate-api")
   implementation project(":gate-core")
   implementation project(":gate-proxy")
   implementation project(":gate-plugins")


### PR DESCRIPTION
This implementation is similar to that of the `ProxyController` and allows for
new endpoints to be exposed under the `/extensions/{id}/**` path.
