### PR TITLE
fix(etag): remove etag filter

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.gate.filters.ContentCachingFilter
 import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestIdInterceptor
 
@@ -37,7 +38,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.filter.ShallowEtagHeaderFilter
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -92,13 +92,9 @@ public class GateWebConfig implements WebMvcConfigurer {
   }
 
   @Bean
-  Filter eTagFilter() {
-    // Note that this filter also sets the content-length for us, which we want so as not to produce a chunked response.
-    ShallowEtagHeaderFilter filter = new ShallowEtagHeaderFilter()
-
-    // Writing a weak ETag so that we still get a gzip'ed response
-    filter.setWriteWeakETag(true)
-    return filter
+  Filter contentCachingFilter() {
+    // This filter simply buffers the response so that Content-Length header can be set
+    return new ContentCachingFilter()
   }
 
   @Bean

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ContentCachingFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ContentCachingFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * This filter simply buffers/caches the response so that the Content-Length header can be set
+ * Setting the Content-Length header prevent the response from being transferred in a chunked way
+ * which not all clients can handle
+ */
+public class ContentCachingFilter implements Filter {
+  @Override
+  public void init(FilterConfig filterConfig) {}
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    ContentCachingResponseWrapper responseWrapper =
+        new ContentCachingResponseWrapper((HttpServletResponse) response);
+
+    chain.doFilter(request, responseWrapper);
+    responseWrapper.copyBodyToResponse();
+  }
+
+  @Override
+  public void destroy() {}
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ContentCachingFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ContentCachingFilter.java
@@ -27,9 +27,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 /**
- * This filter simply buffers/caches the response so that the Content-Length header can be set
- * Setting the Content-Length header prevent the response from being transferred in a chunked way
- * which not all clients can handle
+ * This filter simply buffers/caches the response so that the Content-Length header can be set.
+ * Setting the Content-Length header prevents a response from being transferred with chunked
+ * encoding which may be problematic for some http clients.
  */
 public class ContentCachingFilter implements Filter {
   @Override


### PR DESCRIPTION
Add a content caching filter instead of the `ETag` filter so that we:
a) don't have to waste CPU cycles computing MD5 hashes
b) but still set `Content-Length` on the response to avoid chunked transfers

