### PR TITLE
feat(md): expose veto endpoints

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/EnvironmentArtifactVeto.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/EnvironmentArtifactVeto.java
@@ -16,14 +16,8 @@
 
 package com.netflix.spinnaker.gate.model.manageddelivery;
 
-import lombok.Data;
-import org.jetbrains.annotations.Nullable;
-
-@Data
-public class EnvironmentArtifactPin {
+public class EnvironmentArtifactVeto {
   String targetEnvironment;
   String reference;
   String version;
-  @Nullable String pinnedBy;
-  @Nullable String comment;
 }

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.gate.model.manageddelivery.ConstraintState;
 import com.netflix.spinnaker.gate.model.manageddelivery.ConstraintStatus;
 import com.netflix.spinnaker.gate.model.manageddelivery.DeliveryConfig;
 import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactPin;
+import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactVeto;
 import com.netflix.spinnaker.gate.model.manageddelivery.Resource;
 import java.util.List;
 import java.util.Map;
@@ -121,4 +122,14 @@ public interface KeelService {
   @DELETE("/application/{application}/pin/{targetEnvironment}")
   Response deletePinForEnvironment(
       @Path("application") String application, @Path("targetEnvironment") String targetEnvironment);
+
+  @POST("/application/{application}/veto")
+  Response veto(@Path("application") String application, @Body EnvironmentArtifactVeto veto);
+
+  @DELETE("/application/{application}/veto/{targetEnvironment}/{reference}/{version}")
+  Response deleteVeto(
+      @Path("application") String application,
+      @Path("targetEnvironment") String targetEnvironment,
+      @Path("reference") String reference,
+      @Path("version") String version);
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.gate.model.manageddelivery.ConstraintState;
 import com.netflix.spinnaker.gate.model.manageddelivery.ConstraintStatus;
 import com.netflix.spinnaker.gate.model.manageddelivery.DeliveryConfig;
 import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactPin;
+import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactVeto;
 import com.netflix.spinnaker.gate.model.manageddelivery.Resource;
 import com.netflix.spinnaker.gate.services.internal.KeelService;
 import groovy.util.logging.Slf4j;
@@ -231,5 +232,22 @@ public class ManagedController {
   void deletePinForEnv(
       @PathVariable("application") String application, @PathVariable String targetEnvironment) {
     keelService.deletePinForEnvironment(application, targetEnvironment);
+  }
+
+  @ApiOperation(value = "Veto an artifact version in an environment")
+  @PostMapping(path = "/application/{application}/veto")
+  void veto(
+      @PathVariable("application") String application, @RequestBody EnvironmentArtifactVeto veto) {
+    keelService.veto(application, veto);
+  }
+
+  @ApiOperation(value = "Veto an artifact version in an environment")
+  @DeleteMapping(path = "/application/{application}/veto/{targetEnvironment}/{reference}/{version}")
+  void deleteVeto(
+      @PathVariable("application") String application,
+      @PathVariable("targetEnvironment") String targetEnvironment,
+      @PathVariable("reference") String reference,
+      @PathVariable("version") String version) {
+    keelService.deleteVeto(application, targetEnvironment, reference, version);
   }
 }


### PR DESCRIPTION
Exposing veto endpoints that were moved by this PR (https://github.com/spinnaker/keel/pull/1022).
Updating pin endpoints to no longer accept the artifact type, because it's no longer needed (change done https://github.com/spinnaker/keel/pull/1014).

I'll wait to merge until both of those PRs are in.