### PR TITLE
fix(gremlin): Gremlin should be enabled in gate

### DIFF
--- a/gate-integrations-gremlin/src/main/java/com/netflix/spinnaker/config/GremlinConfig.java
+++ b/gate-integrations-gremlin/src/main/java/com/netflix/spinnaker/config/GremlinConfig.java
@@ -31,7 +31,6 @@ import groovy.transform.CompileStatic;
 import groovy.util.logging.Slf4j;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import retrofit.Endpoint;
@@ -42,7 +41,6 @@ import retrofit.converter.JacksonConverter;
 @Slf4j
 @CompileStatic
 @Configuration
-@ConditionalOnProperty("integrations.gremlin.enabled")
 class GremlinConfig {
   @Bean
   GremlinService gremlinService(

--- a/gate-integrations-gremlin/src/main/java/com/netflix/spinnaker/gate/controllers/gremlin/GremlinController.java
+++ b/gate-integrations-gremlin/src/main/java/com/netflix/spinnaker/gate/controllers/gremlin/GremlinController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/integrations/gremlin")
-@ConditionalOnProperty("integrations.gremlin.enabled")
 class GremlinController {
   private static final String APIKEY_KEY = "apiKey";
 

--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -99,7 +99,6 @@ swagger:
 
 integrations:
   gremlin:
-    enabled: false
     baseUrl: https://api.gremlin.com/v1
 
 hystrix:


### PR DESCRIPTION
We removed the gremlin feature flag along with a bunch of other flags but missed removing it in gate. As Halyard no longer sets it, we should enable it here too.