### PR TITLE
chore(plugins): Replace PF4J ExtensionPoint with SpinnakerExtensionPoint

### DIFF
--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ApiExtension.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ApiExtension.java
@@ -18,16 +18,16 @@
 package com.netflix.spinnaker.gate.api.extension;
 
 import com.netflix.spinnaker.kork.annotations.Alpha;
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint;
 import java.util.Collections;
 import javax.annotation.Nonnull;
-import org.pf4j.ExtensionPoint;
 
 /**
  * An {@code ExtensionPoint} that allows for a new api to be exposed under a common
  * `/extensions/{id}` path.
  */
 @Alpha
-public interface ApiExtension extends ExtensionPoint {
+public interface ApiExtension extends SpinnakerExtensionPoint {
   @Nonnull
   String id();
 


### PR DESCRIPTION
Under the hood, this means we're proxying extensions again.

@ajordens After this merges (and deploys), try adding `@Metered` to your plugin's ApiExtension `handle` method.