### PR TITLE
feat(proxy): add PUT and DELETE to allowed proxy methods

### DIFF
--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
@@ -32,8 +32,10 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod.DELETE
 import org.springframework.web.bind.annotation.RequestMethod.GET
 import org.springframework.web.bind.annotation.RequestMethod.POST
+import org.springframework.web.bind.annotation.RequestMethod.PUT
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.HandlerMapping
@@ -48,7 +50,7 @@ class ProxyController(
 
   val proxyInvocationsId = registry.createId("proxy.invocations")
 
-  @RequestMapping(value = ["/{proxy}/**"], method = [GET, POST])
+  @RequestMapping(value = ["/{proxy}/**"], method = [DELETE, GET, POST, PUT])
   fun any(
     @PathVariable(value = "proxy") proxy: String,
     @RequestParam requestParams: Map<String, String>,


### PR DESCRIPTION
We've run into a use case where more request methods would help, AFAICT this should be all that's needed given we handle request bodies/etc. already.