### PR TITLE
config(core): Push Halyard config to base

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -56,7 +56,7 @@ services:
     baseUrl: http://localhost:8090
 
 redis:
-  connection: redis://localhost:6379
+  connection: ${services.redis.baseUrl:redis://localhost:6379}
 
 slack:
   baseUrl: https://slack.com/api

--- a/halconfig/README.md
+++ b/halconfig/README.md
@@ -1,0 +1,6 @@
+This directory contains skeleton gate configs to which Halyard concatenates
+its generated deployment-specific config.
+
+These configs are **deprecated** and in general should not be further updated. To
+set a default config value, either set the value in `gate-web/config/gate.yml`
+or set a default in the code reading the config property.

--- a/halconfig/gate.yml
+++ b/halconfig/gate.yml
@@ -1,4 +1,1 @@
 # halconfig
-
-redis:
-  connection: ${services.redis.baseUrl:redis://localhost:6379}


### PR DESCRIPTION
The redis url is being set in the Halyard-specific file that is concatenated to the config; let's just move that defaulting to the base gate.yml.

This should not cause any visible change to non-Halyard users, as we are defaulting back to the same localhost:6379 if the redis override is not defined. It will also not affect Halyard users as it's just changing where we set this value for them.