### PR TITLE
chore(oauth2): remove converter-simplexml lib.

### DIFF
--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -4,7 +4,6 @@ dependencies {
   implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
   implementation "com.netflix.spinnaker.kork:kork-security"
-  implementation "com.squareup.retrofit:converter-simplexml"
   implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
   implementation "org.springframework.session:spring-session-core"
 }


### PR DESCRIPTION
SimpleXML converter was deprecated by Retrofit due to CVE-2017-1000190

So I removed converter-simplexml as this lib is no longer being used and no action is required to replace it.

Dependency was introduced in this PR https://github.com/spinnaker/gate/commit/0732238f9f5ea0b49d31bd1cba9c4fc8a48f5e63 used to call old GitHub endpoints that required XML conversion.
