### PR TITLE
fix(oauth2): Handle oddly-formatted roles userInfo

### DIFF
--- a/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
+++ b/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
@@ -239,7 +239,7 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
     def roles = details[userInfoMapping.roles] ?: []
     if (roles instanceof Collection) {
       // Some providers (Azure AD) return roles in this format: ["[\"role-1\", \"role-2\"]"]
-      if (roles[0][0] == '[') {
+      if (roles[0] instanceof String && roles[0][0] == '[') {
         def js = new JsonSlurper()
         return js.parseText(roles).flatten() as List<String>
       }

--- a/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
+++ b/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServices.groovy
@@ -239,7 +239,7 @@ class SpinnakerUserInfoTokenServices implements ResourceServerTokenServices {
     def roles = details[userInfoMapping.roles] ?: []
     if (roles instanceof Collection) {
       // Some providers (Azure AD) return roles in this format: ["[\"role-1\", \"role-2\"]"]
-      if (roles[0][0] == '[' || roles[0][0] == '{' ) {
+      if (roles[0][0] == '[') {
         def js = new JsonSlurper()
         return js.parseText(roles).flatten() as List<String>
       }

--- a/gate-oauth2/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
+++ b/gate-oauth2/src/test/groovy/com/netflix/spinnaker/gate/security/oauth2/SpinnakerUserInfoTokenServicesSpec.groovy
@@ -91,17 +91,20 @@ class SpinnakerUserInfoTokenServicesSpec extends Specification {
     tokenServices.getRoles(details) == expectedRoles
 
     where:
-    rolesValue        || expectedRoles
-    null              || []
-    ""                || []
-    ["foo", "bar"]    || ["foo", "bar"]
-    "foo,bar"         || ["foo", "bar"]
-    "foo bar"         || ["foo", "bar"]
-    "foo"             || ["foo"]
-    "foo   bar"       || ["foo", "bar"]
-    "foo,,,bar"       || ["foo", "bar"]
-    "foo, bar"        || ["foo", "bar"]
-    1                 || []
-    [blergh: "blarg"] || []
+    rolesValue                || expectedRoles
+    null                      || []
+    ""                        || []
+    ["foo", "bar"]            || ["foo", "bar"]
+    "foo,bar"                 || ["foo", "bar"]
+    "foo bar"                 || ["foo", "bar"]
+    "foo"                     || ["foo"]
+    "foo   bar"               || ["foo", "bar"]
+    "foo,,,bar"               || ["foo", "bar"]
+    "foo, bar"                || ["foo", "bar"]
+    ["[]"]                    || []
+    ["[\"foo\"]"]             || ["foo"]
+    ["[\"foo\", \"bar\"]"]    || ["foo", "bar"]
+    1                         || []
+    [blergh: "blarg"]         || []
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 enablePublishing=false
-fiatVersion=1.18.5
+fiatVersion=1.18.6
 includeProviders=basic,iap,ldap,oauth2,saml,x509
 korkVersion=7.42.5
 kotlinVersion=1.3.71


### PR DESCRIPTION
Azure AD (and other OAuth2.0 providers, perhaps) return roles as an array with a single string entry, where the string is a JSON-formatted array:

```json
["[\"0af94c47-f083-42cf-b1c6-9b0d4871b704\",\"d094e693-ae79-4e3c-8590-3d60d304fc50\",\"66ed6631-e6ac-4a27-a015-47a253ad2439\"]"]
```

The current parsing of roles results in this being a single role, which is a long string:

```json
"[\"0af94c47-f083-42cf-b1c6-9b0d4871b704\",\"d094e693-ae79-4e3c-8590-3d60d304fc50\",\"66ed6631-e6ac-4a27-a015-47a253ad2439\"]"
```

This code introduces detection of this one specific edge case (if the first 'role' in the array starts with the character `[` or `{`), and uses the Groovy JsonSlurper package to parse it into a Groovy object.

Roles before the change:
![Screen Shot 2020-05-13 at 8 58 02 PM](https://user-images.githubusercontent.com/4943268/81880849-7aeb6b00-955c-11ea-9a45-82a8f3bcdc67.png)

Roles after the change:
![Screen Shot 2020-05-13 at 8 56 35 PM](https://user-images.githubusercontent.com/4943268/81880856-7f178880-955c-11ea-99c8-7b73e9fc78a0.png)
