### PR TITLE
docs(managed-delivery): Integrate keel API docs into Swagger

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -143,4 +143,7 @@ public interface KeelService {
       @Path("targetEnvironment") String targetEnvironment,
       @Path("reference") String reference,
       @Path("version") String version);
+
+  @GET("/v3/api-docs")
+  Map<String, Object> getApiDocs();
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -276,4 +276,9 @@ public class ManagedController {
       @PathVariable("version") String version) {
     keelService.deleteVeto(application, targetEnvironment, reference, version);
   }
+
+  @GetMapping(path = "/api-docs")
+  Map<String, Object> getApiDocs() {
+    return keelService.getApiDocs();
+  }
 }

--- a/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SwaggerEndpointsConfig.java
+++ b/gate-web/src/main/java/com/netflix/spinnaker/gate/config/SwaggerEndpointsConfig.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.gate.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import springfox.documentation.swagger.web.InMemorySwaggerResourcesProvider;
+import springfox.documentation.swagger.web.SwaggerResource;
+import springfox.documentation.swagger.web.SwaggerResourcesProvider;
+
+@Configuration
+@ConditionalOnProperty("swagger.enabled")
+public class SwaggerEndpointsConfig {
+
+  @Primary
+  @Bean
+  public SwaggerResourcesProvider swaggerResourcesProvider(
+      InMemorySwaggerResourcesProvider defaultResourcesProvider) {
+    return () -> {
+      SwaggerResource keelApiDocs = new SwaggerResource();
+      keelApiDocs.setName("keel");
+      keelApiDocs.setSwaggerVersion("3.0");
+      keelApiDocs.setLocation("/managed/api-docs");
+
+      List<SwaggerResource> resources = new ArrayList<>(defaultResourcesProvider.get());
+      resources.add(keelApiDocs);
+      return resources;
+    };
+  }
+}


### PR DESCRIPTION
Integrates the keel endpoint for Swagger API docs so that it can be selected from the "Select a spec" drop-down on the Swagger UI hosted by gate, and keel's API docs displayed on that UI.

![image](https://user-images.githubusercontent.com/1323478/82478504-db5f3880-9a85-11ea-90cf-ff4b94568d5e.png)
![image](https://user-images.githubusercontent.com/1323478/82478585-fa5dca80-9a85-11ea-8cf4-d4fba930a227.png)
