### PR TITLE
fix(plugins): Start without deck caching enabled

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -34,10 +34,10 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @ConditionalOnProperty("spinnaker.extensibility.deck-proxy.enabled", matchIfMissing = true)
 @ComponentScan("com.netflix.spinnaker.gate.plugins.deck")
 @EnableScheduling
-open class DeckPluginConfiguration {
+class DeckPluginConfiguration {
 
   @Bean
-  open fun deckPluginCache(
+  fun deckPluginCache(
     updateManager: SpinnakerUpdateManager,
     registry: Registry,
     springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider,
@@ -60,12 +60,8 @@ open class DeckPluginConfiguration {
   }
 
   @Bean
-  open fun deckPluginService(
+  fun deckPluginService(
     pluginCache: DeckPluginCache,
     registry: Registry
   ): DeckPluginService = DeckPluginService(pluginCache, registry)
-
-  @Bean
-  open fun deckPluginsController(pluginService: DeckPluginService): DeckPluginsController =
-      DeckPluginsController(pluginService)
 }

--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginsController.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginsController.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import io.swagger.annotations.ApiOperation
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletResponse
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.http.CacheControl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/plugins/deck")
+@ConditionalOnBean(DeckPluginService::class)
 class DeckPluginsController(
   private val deckPluginService: DeckPluginService
 ) {


### PR DESCRIPTION
`@ComponentScan` strikes again, the bean factory method is totally useless.