### PR TITLE
fix(applications): use a clouddriver service selector

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -67,7 +67,7 @@ class ApplicationController {
   List<HashMap<String, Object>> getAllApplications(
     @ApiParam(name = "account", required = false, value = "filters results to only include applications deployed in the specified account")
     @RequestParam(value = "account", required = false) String account,
-    @ApiParam(name = "owner", required = false, value = "filteres results to only include applications owned by the specified email")
+    @ApiParam(name = "owner", required = false, value = "filters results to only include applications owned by the specified email")
     @RequestParam(value = "owner", required = false) String owner) {
     return applicationService.getAllApplications()
       .findAll {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PagerDutyController.groovy
@@ -75,7 +75,6 @@ class PagerDutyController {
   @Scheduled(fixedDelay = 300000L)
   void refreshPagerDuty() {
     try {
-      log.info("Refreshing PagerDuty service list")
       List<Map> services = fetchAllServices()
       log.info("Fetched {} PagerDuty services", services?.size())
       pagerDutyServicesCache.set(services)
@@ -84,7 +83,6 @@ class PagerDutyController {
     }
 
     try {
-      log.info("Refreshing PagerDuty oncall list")
       List<Map> onCalls = fetchAllOnCalls()
       log.info("Fetched {} PagerDuty onCall", onCalls?.size())
       pagerDutyOnCallCache.set(onCalls)


### PR DESCRIPTION
So that /applications/* gets the same clouddriver sharding treatment as every other.

Also some opportunistic log cleanup.
