### PR TITLE
fix(build): Do not set Implementation-Version in test JAR if already set to a valid version

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -88,9 +88,14 @@ test {
   //assertions can be made against the version (see gate-plugins-test, for example).
   jar {
     manifest {
-      attributes(
-        'Implementation-Version': '1.0.0'
-      )
+      String implementationVersion = getAttributes()["Implementation-Version"]
+      if (implementationVersion == null
+        || implementationVersion.isEmpty()
+        || implementationVersion == "undefined") {
+        attributes(
+          'Implementation-Version': '1.0.0'
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
This protects us from the scenario wherein the Implementation-Version set for a test actually ends up being the version used in a final JAR artifact (since Gradle does not re-compile the JAR after it has been compiled for a test task).