### PR TITLE
chore(swagger): add proper return type for invokePipelineConfigViaEcho

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -214,7 +214,7 @@ class PipelineController {
     }
   }
 
-  @ApiOperation(value = "Trigger a pipeline execution")
+  @ApiOperation(value = "Trigger a pipeline execution", response = Map.class)
   @PreAuthorize("hasPermission(#application, 'APPLICATION', 'EXECUTE')")
   @PostMapping("/v2/{application}/{pipelineNameOrId:.+}")
   HttpEntity invokePipelineConfigViaEcho(@PathVariable("application") String application,


### PR DESCRIPTION
The current swagger client is broken due to HttpEntity being interpreted as a json struct rather than a flat representation of the body class member. 
This api returns responses in the format:
```
{"eventId":"xxxxx","ref":"/pipelines/xxxxx"}
```
Swagger expects:
```
{"body":{}}
```

Gave Swagger a return type hint of Map, which maps properly with the proper return format.