### PR TITLE
feat(authn/saml): Configurable signature digest algorithm

### DIFF
--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -29,6 +29,8 @@ import org.opensaml.saml2.core.Assertion
 import org.opensaml.saml2.core.Attribute
 import org.opensaml.xml.schema.XSAny
 import org.opensaml.xml.schema.XSString
+import org.opensaml.xml.security.BasicSecurityConfiguration
+import org.opensaml.xml.signature.SignatureConstants
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.web.ServerProperties
@@ -92,6 +94,8 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
     UserAttributeMapping userAttributeMapping = new UserAttributeMapping()
     long maxAuthenticationAge = 7200
 
+    String signatureDigest = "SHA1" // SHA1 is the default registered in DefaultSecurityConfigurationBootstrap.populateSignatureParams
+
     /**
      * Ensure that the keystore exists and can be accessed with the given keyStorePassword and keyStoreAliasName
      */
@@ -115,6 +119,11 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
             throw new IllegalStateException("Keystore '${keyStore}' does not contain alias '${keyStoreAliasName}'")
           }
         }
+      }
+
+      // Validate signature digest algorithm
+      if (SignatureAlgorithms.fromName(signatureDigest) == null) {
+        throw new IllegalStateException("Invalid saml.signatureDigest value '${signatureDigest}'. Valid values are ${SignatureAlgorithms.values()}")
       }
     }
   }
@@ -165,9 +174,23 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
           .keyPassword(samlSecurityConfigProperties.keyStorePassword)
 
       saml.init(http)
+      initSignatureDigest() // Need to be after SAMLConfigurer initializes the global SecurityConfiguration
 
     // @formatter:on
 
+  }
+
+  private void initSignatureDigest() {
+    def secConfig = org.opensaml.Configuration.getGlobalSecurityConfiguration()
+    if (secConfig != null && secConfig instanceof BasicSecurityConfiguration) {
+      BasicSecurityConfiguration basicSecConfig = (BasicSecurityConfiguration) secConfig
+      def algo = SignatureAlgorithms.fromName(samlSecurityConfigProperties.signatureDigest)
+      log.info("Using ${algo} digest for signing SAML messages")
+      basicSecConfig.registerSignatureAlgorithmURI("RSA", algo.rsaSignatureMethod)
+      basicSecConfig.setSignatureReferenceDigestMethod(algo.digestMethod)
+    } else {
+      log.warn("Unable to find global BasicSecurityConfiguration (found '${secConfig}'). Ignoring rsaSignatureDigest configuration value.")
+    }
   }
 
   void configure(WebSecurity web) throws Exception {
@@ -296,4 +319,26 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
       }
     }
   }
+
+  // Available digests taken from org.opensaml.xml.signature.SignatureConstants (RSA signatures)
+  private enum SignatureAlgorithms {
+    SHA1(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1, SignatureConstants.ALGO_ID_DIGEST_SHA1),
+    SHA256(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, SignatureConstants.ALGO_ID_DIGEST_SHA256),
+    SHA384(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA384, SignatureConstants.ALGO_ID_DIGEST_SHA384),
+    SHA512(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512, SignatureConstants.ALGO_ID_DIGEST_SHA512),
+    RIPEMD160(SignatureConstants.ALGO_ID_SIGNATURE_RSA_RIPEMD160, SignatureConstants.ALGO_ID_DIGEST_RIPEMD160),
+    MD5(SignatureConstants.ALGO_ID_SIGNATURE_NOT_RECOMMENDED_RSA_MD5, SignatureConstants.ALGO_ID_DIGEST_NOT_RECOMMENDED_MD5)
+
+    String rsaSignatureMethod
+    String digestMethod
+    SignatureAlgorithms(String rsaSignatureMethod, String digestMethod) {
+      this.rsaSignatureMethod = rsaSignatureMethod
+      this.digestMethod = digestMethod
+    }
+
+    static SignatureAlgorithms fromName(String digestName) {
+      SignatureAlgorithms.find { it -> (it.name() == digestName.toUpperCase()) } as SignatureAlgorithms
+    }
+  }
+
 }

--- a/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
+++ b/gate-saml/src/main/groovy/com/netflix/spinnaker/gate/security/saml/SamlSsoConfig.groovy
@@ -189,7 +189,7 @@ class SamlSsoConfig extends WebSecurityConfigurerAdapter {
       basicSecConfig.registerSignatureAlgorithmURI("RSA", algo.rsaSignatureMethod)
       basicSecConfig.setSignatureReferenceDigestMethod(algo.digestMethod)
     } else {
-      log.warn("Unable to find global BasicSecurityConfiguration (found '${secConfig}'). Ignoring rsaSignatureDigest configuration value.")
+      log.warn("Unable to find global BasicSecurityConfiguration (found '${secConfig}'). Ignoring signatureDigest configuration value.")
     }
   }
 


### PR DESCRIPTION
When Spinnaker is configured with SAML authentication, the `SAMLRequest` is always signed with the `SHA1` digest algorithm (`SignatureMethod` and `DigestMethod` of the request):

```
<?xml version="1.0" encoding="UTF-8"?>
<saml2p:AuthnRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceURL="http://localhost:8084/saml/SSO" Destination="https://armory.okta.com/app/armory_germansamltest_1/exk7nc0r0hHggwnG32p7/sso/saml" ForceAuthn="false" ID="a3a56cde732h83fd5a8gh0cd7j15h14" IsPassive="false" IssueInstant="2020-07-01T19:16:17.698Z" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Version="2.0">
    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">io.armory.spinnaker.german</saml2:Issuer>
        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
            <ds:SignedInfo>
                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
                <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
                <ds:Reference URI="#a3a56cde732h83fd5a8gh0cd7j15h14">
                    <ds:Transforms>
                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
                    </ds:Transforms>
                    <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
                    <ds:DigestValue>YbPj3/ETyDJVZ1rCkGhM2dTsjc8=</ds:DigestValue>
                </ds:Reference>
            </ds:SignedInfo> 
            <ds:SignatureValue></ds:SignatureValue>
        </ds:Signature>
        ...
</saml2p:AuthnRequest>
```

For security reasons, `SHA1` may not work with IdP's that mandate a stronger digest algorithm. We also cannot just bump to SHA256 or higher because there's the risk of breaking older IdP's that don't support stronger algorithms.

This PR introduces a new SAML optional configuration setting `signatureDigest`, used for signing both `Signature` and `Digest` parts of the SAML request. Valid values are `SHA1, SHA256, SHA384, SHA512, RIPEMD160, MD5` which come from the constants defined in opensaml `SignatureConstants`, which is the underlying implementation being used. If the setting is not defined, it defaults to `SHA1` for keeping compatibility with existing installations.

