### PR TITLE
add bean dependency in functional spec

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -39,6 +39,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import retrofit.RestAdapter
 import retrofit.RetrofitError
+import retrofit.RestAdapter;
 import retrofit.client.OkClient
 import retrofit.mime.TypedInput
 import spock.lang.Shared
@@ -233,6 +234,11 @@ class FunctionalSpec extends Specification {
     AccountLookupService accountLookupService() {
       accountLookupService
     }
+
+    @Bean
+    RestAdapter.LogLevel retrofitLogLevel() {
+      return RestAdapter.LogLevel.BASIC
+   }
 
     @Bean
     PipelineController pipelineController() {


### PR DESCRIPTION
This bean definition is required for the kork(`kork-retrofit`) changes 