### PR TITLE
feat(gate): Add support for Redis SSL

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
@@ -60,6 +60,10 @@ public class PostConnectionConfiguringJedisConnectionFactory extends JedisConnec
         setPassword(userInfo.get(1));
       }
     }
+
+    if (redisUri.getScheme().equals("rediss")) {
+        setUseSsl(true);
+    }
   }
 
   @Override

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
@@ -62,7 +62,7 @@ public class PostConnectionConfiguringJedisConnectionFactory extends JedisConnec
     }
 
     if (redisUri.getScheme().equals("rediss")) {
-        setUseSsl(true);
+      setUseSsl(true);
     }
   }
 


### PR DESCRIPTION
Follow Kork's existing pattern and check for presence of `rediss` in
the URI Scheme.

Gate doesn't initialise JedisPool() pool with parameters like Kork
so follow Gate conventions and use function to enable SSL.

Tested with default redis configuration and in-cluster (kubernetes) Redis (no auth or tls).
Also tested against Elasticache Redis with below gate.yml snippet with token mounted to container as env var:

```
services:
  redis:
    baseUrl: rediss://:${REDIS_TOKEN}@master.<snip>.cache.amazonaws.com:637
9

# Elasticache Redis doesn't support CONFIG command - disable use of it
redis:
  configuration:
     secure: true
```

Related to: spinnaker/spinnaker#5470