### PR TITLE
fix(artifactReference): add artifactReference field into ConstrainStatus model

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/ConstraintStatus.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/model/manageddelivery/ConstraintStatus.java
@@ -22,6 +22,7 @@ import lombok.Data;
 public class ConstraintStatus {
   String type;
   String artifactVersion;
+  String artifactReference;
   String status;
   String comment;
 }


### PR DESCRIPTION
We recently added the `artifactReference` field into `ConstrainStatus` model, in order to have a unique artifact identifier.
This PR is followed by https://github.com/spinnaker/deck/pull/8485 for deck
and https://github.com/spinnaker/keel/pull/1399 in keel.