### PR TITLE
fix(getAllPluginInfo): fix return type

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/web/info/PluginInfoController.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/web/info/PluginInfoController.kt
@@ -66,7 +66,7 @@ class PluginInfoController(
 
   @ApiOperation(value = "Get all plugin info objects")
   @RequestMapping(method = [RequestMethod.GET])
-  fun getAllPluginInfo(@RequestParam(value = "service", required = false) service: String?): List<Map<*, *>> {
+  fun getAllPluginInfo(@RequestParam(value = "service", required = false) service: String?): List<*> {
     return front50Service.getPluginInfo(service)
   }
 


### PR DESCRIPTION
When running swagger to update the Spin CLI to latest gate code for https://github.com/spinnaker/spin/pull/294 and https://github.com/spinnaker/spinnaker/issues/5967 the following change needed to accommodate changes from https://github.com/spinnaker/gate/pull/1307