### PR TITLE
fix(misc): fix(misc): Removing hard references to TomcatConfigurationProperties since we moved that to a runtime only(kork-tomcat) dependency

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/MultiAuthSupport.java
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/MultiAuthSupport.java
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.gate.config;
 
-import com.netflix.spinnaker.config.TomcatConfigurationProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.context.WebServerApplicationContext;
 import org.springframework.boot.web.embedded.tomcat.TomcatWebServer;
@@ -17,18 +16,18 @@ public class MultiAuthSupport {
   @Value("${default.legacy-server-port-auth:true}")
   private boolean legacyServerPortAuth;
 
+  @Value("${default.legacy-server-port:-1}")
+  private int legacyServerPort;
+
   @Bean
-  RequestMatcherProvider multiAuthRequestMatcherProvider(
-      ApplicationContext applicationContext,
-      TomcatConfigurationProperties tomcatConfigurationProperties) {
+  RequestMatcherProvider multiAuthRequestMatcherProvider(ApplicationContext applicationContext) {
     return new RequestMatcherProvider() {
       @Override
       public RequestMatcher requestMatcher() {
         if (applicationContext instanceof WebServerApplicationContext) {
           final WebServerApplicationContext ctx = (WebServerApplicationContext) applicationContext;
           return req -> {
-            if (legacyServerPortAuth
-                && tomcatConfigurationProperties.getLegacyServerPort() == req.getLocalPort()) {
+            if (legacyServerPortAuth && legacyServerPort == req.getLocalPort()) {
               return true;
             }
             // we have to do this per request because at bean-creation time the WebServer has not

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
 fiatVersion=1.22.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
-korkVersion=7.59.0
+korkVersion=7.60.3
 kotlinVersion=1.3.71
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0


### PR DESCRIPTION
- TomcatConfigurationProperties now lives in kork-tomcat which is a runtime only dep.
- Injected the only prop we need in `MultiAuthSupport` explicitly.