### PR TITLE
chore(plugins): Enable v2 framework in gate-plugins-test

### DIFF
--- a/gate-plugins-test/src/main/kotlin/com/netflix/spinnaker/gate/plugins/GateApiExtension.kt
+++ b/gate-plugins-test/src/main/kotlin/com/netflix/spinnaker/gate/plugins/GateApiExtension.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.gate.plugins
 import com.netflix.spinnaker.gate.api.extension.ApiExtension
 import com.netflix.spinnaker.gate.api.extension.HttpRequest
 import com.netflix.spinnaker.gate.api.extension.HttpResponse
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import javax.annotation.Nonnull
 import org.pf4j.Extension
@@ -65,7 +65,7 @@ class GateApiExtension(
   }
 }
 
-@ExtensionConfiguration("api-extension")
+@PluginConfiguration("api-extension")
 class ApiExtensionConfigProperties {
   var id: String = "test"
 }

--- a/gate-plugins-test/src/test/resources/gate-plugins-test.yml
+++ b/gate-plugins-test/src/test/resources/gate-plugins-test.yml
@@ -33,6 +33,8 @@ slack:
 
 spinnaker:
   extensibility:
+    framework:
+      version: v2
     plugins-root-path: build/plugins
     plugins:
       com.netflix.gate.enabled.plugin:

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -92,7 +92,8 @@ test {
       String implementationVersion = getAttributes()["Implementation-Version"]
       if (implementationVersion == null
         || implementationVersion.isEmpty()
-        || implementationVersion == "undefined") {
+        || implementationVersion == "undefined"
+        || implementationVersion.endsWith("SNAPSHOT")) {
         attributes(
           'Implementation-Version': '1.0.0'
         )


### PR DESCRIPTION
The tests will fail until the framework bug is resolved, but this is a good thing to do.