### PR TITLE
fix(plugins): Load ApiExtension config property from service yml in gate-plugins-test

### DIFF
--- a/gate-plugins-test/src/main/kotlin/com/netflix/spinnaker/gate/plugins/GateApiExtension.kt
+++ b/gate-plugins-test/src/main/kotlin/com/netflix/spinnaker/gate/plugins/GateApiExtension.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.gate.plugins
 import com.netflix.spinnaker.gate.api.extension.ApiExtension
 import com.netflix.spinnaker.gate.api.extension.HttpRequest
 import com.netflix.spinnaker.gate.api.extension.HttpResponse
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 import com.netflix.spinnaker.kork.plugins.api.PluginSdks
 import javax.annotation.Nonnull
@@ -68,5 +67,5 @@ class GateApiExtension(
 
 @PluginConfiguration("api-extension")
 class ApiExtensionConfigProperties {
-  var id: String = "test"
+  var id: String = ""
 }

--- a/gate-plugins-test/src/test/resources/gate-plugins-test.yml
+++ b/gate-plugins-test/src/test/resources/gate-plugins-test.yml
@@ -39,6 +39,8 @@ spinnaker:
     plugins:
       com.netflix.gate.enabled.plugin:
         enabled: true
+        api-extension.config:
+          id: test
       com.netflix.gate.disabled.plugin:
         enabled: false
       com.netflix.gate.version.not.supported.plugin:


### PR DESCRIPTION
Just a minor tweak, seems like a decent thing to test.