### PR TITLE
feat(cache): Configurable directory for deck plugin cache

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCache.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCache.kt
@@ -28,6 +28,7 @@ import java.nio.file.StandardCopyOption
 import org.pf4j.PluginRuntimeException
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
+import java.nio.file.Paths
 
 /**
  * Responsible for keeping an up-to-date cache of all plugins that Deck needs to know about.
@@ -38,7 +39,8 @@ class DeckPluginCache(
   private val springPluginStatusProvider: SpringPluginStatusProvider,
   private val pluginInfoReleaseProvider: PluginInfoReleaseProvider,
   private val registry: Registry,
-  private val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider
+  private val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider,
+  private val pluginsCacheDirectory: String?
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -51,6 +53,11 @@ class DeckPluginCache(
   private val missesId = registry.createId("plugins.deckCache.misses")
   private val downloadDurationId = registry.createId("plugins.deckCache.downloadDuration")
   private val refreshDurationId = registry.createId("plugins.deckCache.refreshDuration")
+  private val CACHE_ROOT_PATH = if (!pluginsCacheDirectory.isNullOrBlank()) {
+    Paths.get(pluginsCacheDirectory)
+  } else {
+    Files.createTempDirectory("downloaded-plugin-cache")
+  }
 
   /**
    * Refreshes the local file cache of _current_ plugins. Should Deck need plugin assets from an older plugin release
@@ -144,7 +151,6 @@ class DeckPluginCache(
   )
 
   companion object {
-    internal val CACHE_ROOT_PATH = Files.createTempDirectory("downloaded-plugin-cache")
     internal const val DECK_REQUIREMENT = "deck"
   }
 }

--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCache.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCache.kt
@@ -29,6 +29,7 @@ import org.pf4j.PluginRuntimeException
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import java.nio.file.Paths
+import java.util.Optional
 
 /**
  * Responsible for keeping an up-to-date cache of all plugins that Deck needs to know about.
@@ -40,7 +41,7 @@ class DeckPluginCache(
   private val pluginInfoReleaseProvider: PluginInfoReleaseProvider,
   private val registry: Registry,
   private val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider,
-  private val pluginsCacheDirectory: String?
+  private val pluginsCacheDirectory: Optional<String>
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -53,8 +54,8 @@ class DeckPluginCache(
   private val missesId = registry.createId("plugins.deckCache.misses")
   private val downloadDurationId = registry.createId("plugins.deckCache.downloadDuration")
   private val refreshDurationId = registry.createId("plugins.deckCache.refreshDuration")
-  private val CACHE_ROOT_PATH = if (!pluginsCacheDirectory.isNullOrBlank()) {
-    Paths.get(pluginsCacheDirectory)
+  private val CACHE_ROOT_PATH = if (pluginsCacheDirectory.isPresent) {
+    Paths.get(pluginsCacheDirectory.get())
   } else {
     Files.createTempDirectory("downloaded-plugin-cache")
   }

--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -35,7 +35,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 class DeckPluginConfiguration {
 
-  @Value("\${spinnaker.extensibility.deck-proxy.path:#{null}}")
+  @Value("\${spinnaker.extensibility.deck-proxy.plugins-path:#{null}}")
   private val pluginsCacheDirectory: String? = null
 
   @Bean

--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
+import java.util.Optional
 
 @Configuration
 @ConditionalOnProperty("spinnaker.extensibility.deck-proxy.enabled", matchIfMissing = true)
@@ -62,7 +63,7 @@ class DeckPluginConfiguration {
       AggregatePluginInfoReleaseProvider(sources, springStrictPluginLoaderStatusProvider),
       registry,
       springStrictPluginLoaderStatusProvider,
-      pluginsCacheDirectory
+      Optional.ofNullable(pluginsCacheDirectory)
     )
   }
 

--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginConfiguration.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.kork.plugins.update.SpinnakerUpdateManager
 import com.netflix.spinnaker.kork.plugins.update.release.provider.AggregatePluginInfoReleaseProvider
 import com.netflix.spinnaker.kork.plugins.update.release.source.LatestPluginInfoReleaseSource
 import com.netflix.spinnaker.kork.plugins.update.release.source.SpringPluginInfoReleaseSource
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -33,6 +34,9 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @ConditionalOnProperty("spinnaker.extensibility.deck-proxy.enabled", matchIfMissing = true)
 @EnableScheduling
 class DeckPluginConfiguration {
+
+  @Value("\${spinnaker.extensibility.deck-proxy.path:#{null}}")
+  private val pluginsCacheDirectory: String? = null
 
   @Bean
   fun deckPluginCache(
@@ -57,7 +61,8 @@ class DeckPluginConfiguration {
       springPluginStatusProvider,
       AggregatePluginInfoReleaseProvider(sources, springStrictPluginLoaderStatusProvider),
       registry,
-      springStrictPluginLoaderStatusProvider
+      springStrictPluginLoaderStatusProvider,
+      pluginsCacheDirectory
     )
   }
 

--- a/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
+++ b/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
@@ -101,7 +101,7 @@ class DeckPluginCacheTest : JUnit5Minutests {
     val pluginInfoReleaseProvider: PluginInfoReleaseProvider = mockk(relaxed = true)
     val registry: Registry = NoopRegistry()
     val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider = mockk(relaxed = true)
-    var subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider, null)
+    val subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider, null)
 
     init {
       val plugins = listOf(

--- a/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
+++ b/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
@@ -101,7 +101,7 @@ class DeckPluginCacheTest : JUnit5Minutests {
     val pluginInfoReleaseProvider: PluginInfoReleaseProvider = mockk(relaxed = true)
     val registry: Registry = NoopRegistry()
     val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider = mockk(relaxed = true)
-    val subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider)
+    var subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider, null)
 
     init {
       val plugins = listOf(

--- a/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
+++ b/gate-plugins/src/test/kotlin/com/netflix/spinnaker/gate/plugins/deck/DeckPluginCacheTest.kt
@@ -37,6 +37,7 @@ import strikt.api.expectThat
 import strikt.assertions.hasSize
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import java.util.Optional
 
 class DeckPluginCacheTest : JUnit5Minutests {
 
@@ -101,7 +102,7 @@ class DeckPluginCacheTest : JUnit5Minutests {
     val pluginInfoReleaseProvider: PluginInfoReleaseProvider = mockk(relaxed = true)
     val registry: Registry = NoopRegistry()
     val springStrictPluginLoaderStatusProvider: SpringStrictPluginLoaderStatusProvider = mockk(relaxed = true)
-    val subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider, null)
+    val subject = DeckPluginCache(updateManager, pluginBundleExtractor, pluginStatusProvider, pluginInfoReleaseProvider, registry, springStrictPluginLoaderStatusProvider, Optional.empty())
 
     init {
       val plugins = listOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
 fiatVersion=1.22.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
-korkVersion=7.61.3
+korkVersion=7.62.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
 fiatVersion=1.22.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
-korkVersion=7.62.0
+korkVersion=7.62.1
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
 fiatVersion=1.22.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
-korkVersion=7.62.1
+korkVersion=7.63.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0


### PR DESCRIPTION
When the service starts up, the `DeckPluginCache` download the deck plugins and add them to the cache, then it serves these plugins to `Deck` service

We want to bake deck plugins in this cache, in order to provide the plugin assets and avoid download them.

This PR include an extra configuration property `spinnaker.extensibility.deck-proxy.plugins-path` on the cache and when it is present the `DeckPluginCache` will store downloaded plugins on the given directory.

Make the cache directory configurable, we will be able to copy the plugin assets that we want to bake for `Deck`.

if the new configuration property is not provided, all the downloaded plugins will be stored in a temporary directory.

