### PR TITLE
feat(pipeline): Return pretty-printed Source JSON

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -41,6 +41,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import retrofit.RetrofitError
 
+import javax.servlet.http.HttpServletResponse
+
 import static net.logstash.logback.argument.StructuredArguments.value
 
 @Slf4j
@@ -103,10 +105,14 @@ class PipelineController {
   }
 
   @ApiOperation(value = "Retrieve a pipeline execution")
-  @GetMapping("{id}")
-  Map getPipeline(@PathVariable("id") String id) {
+  @RequestMapping(value = "/{id}", method = RequestMethod.GET)
+  void getPipeline(HttpServletResponse response, @PathVariable("id") String id) {
     try {
-      pipelineService.getPipeline(id)
+      def pipeline = pipelineService.getPipeline(id)
+      def asJsonString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(pipeline)
+
+      response.addHeader("Content-Type", "application/json; charset=utf-8")
+      response.getOutputStream().write(asJsonString.getBytes("UTF-8"))
     } catch (RetrofitError e) {
       if (e.response?.status == 404) {
         throw new NotFoundException("Pipeline not found (id: ${id})")


### PR DESCRIPTION
Change 'Source' output to be pretty-printed JSON instead of compact representation. Required changing the `@RequestMapping` attribute to handle the output ourselves rather than returning a structured object.

With this change, users get a pretty-printed view of the `Source` output for a pipeline execution instead of an unreadable JSON blob.

---------

I tried a few different approaches, including using `String` as the return type: 
```java
@GetMapping("{id}")
String getPipeline(@PathVariable("id") String id) {
```
But Spring Boot used `text/html` as the content-type and still displayed everything on a single line.

I also tried to set the content-type in `produces`:
```java
@GetMapping(value = "{id}", produces = ["application/json"])
String getPipeline(@PathVariable("id") String id) {
```
but this produced a _single string_ containing the full output with all the new lines and quotes escaped, i.e.
```
"{\n  \"application\" : \"my-test-app\",\n  \"authentication\" : {\n    \"allowedAccounts\" : [ \"account1\", \"…
```

Using `HttpServletResponse` directly let me both set the correct content-type and provide the exact output I wanted to return.