### PR TITLE
fix(x509/authn): improve login debounce performance

### DIFF
--- a/gate-x509/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsService.groovy
+++ b/gate-x509/src/main/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsService.groovy
@@ -153,8 +153,8 @@ class X509AuthenticationUserDetailsService implements AuthenticationUserDetailsS
       if (loginDebounceEnabled) {
         final Duration debounceWindow = Duration.ofSeconds(dynamicConfigService.getConfig(Long, 'x509.loginDebounce.debounceWindowSeconds', TimeUnit.MINUTES.toSeconds(5)))
         final Optional<Instant> lastDebounced = Optional.ofNullable(loginDebounce.getIfPresent(email))
-        UserPermission.View fiatPermission = AuthenticatedRequest.allowAnonymous { fiatPermissionEvaluator.getPermission(email) }
-        shouldLogin = fiatPermission == null ||
+        boolean needsCachedPermission = !fiatPermissionEvaluator.hasCachedPermission(email)
+        shouldLogin = needsCachedPermission ||
           lastDebounced.map({ now.isAfter(it.plus(debounceWindow)) }).orElse(true)
       } else {
         shouldLogin = true

--- a/gate-x509/src/test/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsServiceSpec.groovy
+++ b/gate-x509/src/test/groovy/com/netflix/spinnaker/gate/security/x509/X509AuthenticationUserDetailsServiceSpec.groovy
@@ -54,6 +54,7 @@ class X509AuthenticationUserDetailsServiceSpec extends Specification {
     userDetails.handleLogin(email, cert)
 
     then: "should not call login"
+    1 * fiatPermissionEvaluator.hasCachedPermission(email) >> true
     0 * perms.login(email)
 
     when: "subsequent login after debounce window"
@@ -61,10 +62,11 @@ class X509AuthenticationUserDetailsServiceSpec extends Specification {
     userDetails.handleLogin(email, cert)
 
     then: "should call login"
+    1 * fiatPermissionEvaluator.hasCachedPermission(email) >> true
     1 * perms.login(email)
 
     when: "login with no cached permission"
-    fiatPermissionEvaluator.getPermission(email) >> null
+    fiatPermissionEvaluator.hasCachedPermission(email) >> false
     userDetails.handleLogin(email, cert)
 
     then: "should call login"


### PR DESCRIPTION
the login debounce check was calling fiat /authorize if the user was not cached, and doing so without supplying an X-SPINNAKER-USER

this would 404 if the user needs to log in, and trigger the exponential backoff in fiat permission evaluator