### PR TITLE
feat(proxy): Handle delayed initialization of proxy configurations

### DIFF
--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -9,4 +9,5 @@ dependencies {
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.netflix.spectator:spectator-api"
+  implementation "com.google.guava:guava"
 }


### PR DESCRIPTION
Using a simple `CacheBuilder` to ensure that all `ProxyConfig` objects
are only initialized _once_.
