### PR TITLE
feat(proxy): Migrate to `okhttp3`

### DIFF
--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ProxyConfig.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ProxyConfig.java
@@ -17,9 +17,10 @@
 package com.netflix.spinnaker.gate.api.extension;
 
 import com.netflix.spinnaker.kork.annotations.Alpha;
-import java.security.KeyStore;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.Data;
 
 @Data
@@ -30,51 +31,6 @@ public class ProxyConfig {
 
   /** Target uri for this proxy. */
   private String uri;
-
-  /** Whether ssl hostname verification should be skipped. */
-  private Boolean skipHostnameVerification = false;
-
-  /** Fully qualified path to keystore file. */
-  private String keyStore;
-
-  /** Type of keystore, defaults to {@code KeyStore.getDefaultType()}. */
-  private String keyStoreType = KeyStore.getDefaultType();
-
-  /**
-   * Plain text keystore password.
-   *
-   * <p>If keyStore is non-null, one of keyStorePassword or keyStorePasswordFile must be supplied.
-   */
-  private String keyStorePassword;
-
-  /**
-   * Fully qualified path to keystore password file.
-   *
-   * <p>If keyStore is non-null, one of keyStorePassword or keyStorePasswordFile must be supplied.
-   */
-  private String keyStorePasswordFile;
-
-  /** Fully qualified path to truststore file. */
-  private String trustStore;
-
-  /** Type of truststore, defaults to {@code KeyStore.getDefaultType()}. */
-  private String trustStoreType = KeyStore.getDefaultType();
-
-  /**
-   * Plain text truststore password.
-   *
-   * <p>If trustStore is non-null, one of trustStorePassword or trustStorePasswordFile must be
-   * supplied.
-   */
-  private String trustStorePassword;
-
-  /**
-   * Fully qualified path to truststore password file.
-   *
-   * <p>If trustStore is non-null, one of trustStorePassword or trustStorePasswordFile must be
-   * supplied.
-   */
-  private String trustStorePasswordFile;
 
   /** Supported http methods for this proxy. */
   private List<String> methods = new ArrayList<>();
@@ -87,4 +43,7 @@ public class ProxyConfig {
 
   /** Write timeout, defaults to 30s. */
   private Long writeTimeoutMs = 30_000L;
+
+  /** Additional attributes for this proxy. */
+  private Map<String, Object> additionalAttributes = new HashMap<>();
 }

--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation project(":gate-core")
 
   implementation "com.netflix.spinnaker.kork:kork-exceptions"
+  implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.netflix.spectator:spectator-api"


### PR DESCRIPTION
This PR moves away from using our own hand rolled `OkHttpClient` in favor
of what `OkHttpClientProvider` provides.

A few attributes have been removed from `ProxyConfig` that I believe were
only used by Netflix.

If we need to support custom keystore/truststore behaviors, we should do
so by implementing a custom `OkHttpClientBuilderProvider`.
