### PR TITLE
fix(proxy): Take advantage of `InsecureOkHttpClientBuilderProvider`

### DIFF
--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/Proxy.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/Proxy.kt
@@ -35,7 +35,7 @@ internal class Proxy(val config: ProxyConfig) {
    */
   fun init(okHttpClientProvider: OkHttpClientProvider) : Proxy {
     val okHttpClient = okHttpClientProvider.getClient(DefaultServiceEndpoint(
-      "proxy__${config.id}", config.uri, config.additionalAttributes
+      "proxy__${config.id}", config.uri, config.additionalAttributes, false
     ))
 
     this.okHttpClient = okHttpClient


### PR DESCRIPTION
The `DefaultOkHttpClientBuilderProvider` (previous behavior) will actually
utilize the `okHttpClient.*` config properties and unnecessarily set
keystore/truststores.

This is fine when communicating with other Spinnaker services but problematic
externally. The `InsecureOkHttpClientBuilderProvider` loosens the certificate
chain validations.
