### PR TITLE
fix(libs): move properties migrator to runtimeOnly of web

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ allprojects {
       implementation "org.codehaus.groovy:groovy-all"
       implementation "net.logstash.logback:logstash-logback-encoder"
       implementation "org.jetbrains.kotlin:kotlin-reflect"
-      runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
-      testRuntime "org.springframework.boot:spring-boot-properties-migrator"
 
       testImplementation "org.spockframework:spock-core"
       testImplementation "org.spockframework:spock-spring"

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -58,6 +58,7 @@ dependencies {
   implementation "io.springfox:springfox-swagger2"
 
   runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"
+  runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
 
   testImplementation "com.graphql-java-kickstart:graphql-spring-boot-starter-test:7.0.1"
 


### PR DESCRIPTION
This doesn't need to be on every classpath, it happens at runtime during app startup