### PR TITLE
feat(proxy): Slight tightening of the `ProxyConfig` contact.

### DIFF
--- a/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ProxyConfig.java
+++ b/gate-api/src/main/java/com/netflix/spinnaker/gate/api/extension/ProxyConfig.java
@@ -45,5 +45,5 @@ public class ProxyConfig {
   private Long writeTimeoutMs = 30_000L;
 
   /** Additional attributes for this proxy. */
-  private Map<String, Object> additionalAttributes = new HashMap<>();
+  private Map<String, String> additionalAttributes = new HashMap<>();
 }

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/Proxy.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/Proxy.kt
@@ -35,7 +35,7 @@ internal class Proxy(val config: ProxyConfig) {
    */
   fun init(okHttpClientProvider: OkHttpClientProvider) : Proxy {
     val okHttpClient = okHttpClientProvider.getClient(DefaultServiceEndpoint(
-      "proxy__${config.id}", config.uri, config.additionalAttributes, false
+      "proxy__${config.id}", config.uri, config.additionalAttributes as Map<String, Any>, false
     ))
 
     this.okHttpClient = okHttpClient


### PR DESCRIPTION
s/Object/String, we can revisit should we need to store more than
simple Strings.
