### PR TITLE
allow retrieval of resources in YAML format

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -44,6 +44,10 @@ public interface KeelService {
   @GET("/resources/{name}")
   Resource getResource(@Path("name") String name);
 
+  @GET("/resources/{name}")
+  @Headers("Accept: application/x-yaml")
+  Resource getResourceYaml(@Path("name") String name);
+
   @GET("/resources/{name}/status")
   String getResourceStatus(@Path("name") String name);
 
@@ -58,6 +62,10 @@ public interface KeelService {
 
   @GET("/delivery-configs/{name}")
   DeliveryConfig getManifest(@Path("name") String name);
+
+  @GET("/delivery-configs/{name}")
+  @Headers("Accept: application/x-yaml")
+  DeliveryConfig getManifestYaml(@Path("name") String name);
 
   @GET("/delivery-configs/{name}/artifacts")
   List<Map<String, Object>> getManifestArtifacts(@Path("name") String name);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -85,6 +85,12 @@ public class ManagedController {
     return keelService.getResource(resourceId);
   }
 
+  @ApiOperation(value = "Get a resource", response = Resource.class)
+  @GetMapping(path = "/resources/{resourceId}.yml", produces = APPLICATION_YAML_VALUE)
+  Resource getResourceYaml(@PathVariable("resourceId") String resourceId) {
+    return keelService.getResourceYaml(resourceId);
+  }
+
   @ApiOperation(value = "Get status of a resource", response = Map.class)
   @GetMapping(path = "/resources/{resourceId}/status")
   Map getResourceStatus(@PathVariable("resourceId") String resourceId) {
@@ -145,6 +151,12 @@ public class ManagedController {
   @GetMapping(path = "/delivery-configs/{name}")
   DeliveryConfig getManifest(@PathVariable("name") String name) {
     return keelService.getManifest(name);
+  }
+
+  @ApiOperation(value = "Get a delivery config manifest", response = DeliveryConfig.class)
+  @GetMapping(path = "/delivery-configs/{name}.yml", produces = APPLICATION_YAML_VALUE)
+  DeliveryConfig getManifestYaml(@PathVariable("name") String name) {
+    return keelService.getManifestYaml(name);
   }
 
   @ApiOperation(


### PR DESCRIPTION
New endpoint so that browsers can be forced to show YAML without messing with the `Accept` header