### PR TITLE
feat(web): request shedding is now filter-based and checked before the spring security filter chain is evaluated

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.gate.config.PostConnectionConfiguringJedisConnectio
 import com.netflix.spinnaker.gate.converters.JsonHttpMessageConverter
 import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
 import com.netflix.spinnaker.gate.filters.RequestLoggingFilter
+import com.netflix.spinnaker.gate.filters.RequestSheddingFilter
 import com.netflix.spinnaker.gate.filters.RequestTimingFilter
 import com.netflix.spinnaker.gate.plugins.deck.DeckPluginConfiguration
 import com.netflix.spinnaker.gate.plugins.web.PluginWebConfiguration
@@ -414,6 +415,16 @@ class GateConfig extends RedisHttpSessionConfiguration {
     // this filter should be placed very early in the request chain to ensure we track an accurate start time and
     // have a request id available to propagate across thread and service boundaries.
     frb.order = Ordered.HIGHEST_PRECEDENCE
+    return frb
+  }
+
+  @Bean
+  FilterRegistrationBean requestSheddingFilter(DynamicConfigService dynamicConfigService) {
+    def frb = new FilterRegistrationBean(new RequestSheddingFilter(dynamicConfigService, registry))
+
+    // this filter should be placed early in the request chain to allow for requests to be shed prior to the
+    // spring security filter chain being evaluated.
+    frb.order = Ordered.HIGHEST_PRECEDENCE + 1
     return frb
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.gate.filters.ContentCachingFilter
 import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.RequestIdInterceptor
 
-import com.netflix.spinnaker.gate.interceptors.RequestSheddingInterceptor
 import com.netflix.spinnaker.gate.ratelimit.RateLimitPrincipalProvider
 import com.netflix.spinnaker.gate.ratelimit.RateLimiter
 import com.netflix.spinnaker.gate.ratelimit.RateLimitingInterceptor
@@ -83,7 +82,6 @@ public class GateWebConfig implements WebMvcConfigurer {
     }
 
     registry.addInterceptor(new RequestContextInterceptor())
-    registry.addInterceptor(new RequestSheddingInterceptor(dynamicConfigService, this.registry))
   }
 
   @Bean


### PR DESCRIPTION
The explicit `.setStatus` could be swapped out for an exception provided the following config was used:
```
spring:
  security:
    filter:
      dispatcherTypes: async, request
```

Removing `error` from `dispatcherTypes` prevents the spring security filter chain from
evaluating during the `/error` redirect.
