### PR TITLE
feat(web): Return proper json from the `RequestSheddingFilter`

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/RequestSheddingFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/RequestSheddingFilter.java
@@ -135,7 +135,7 @@ public class RequestSheddingFilter extends HttpFilter {
         response.setStatus(SERVICE_UNAVAILABLE.value());
         response
             .getWriter()
-            .write("{\"message\": \"Low priority requests are not currently being accepted\"");
+            .write("{\"message\": \"Low priority requests are not currently being accepted\"}");
         return;
       }
       log.debug("Dice roll prevented low priority request shedding: {}", request.getRequestURI());


### PR DESCRIPTION
Previous change was missing a closing `}` on the hand rolled json.