### PR TITLE
fix(web): `AuthenticatedRequestFilter` should not clear the `AuthenticatedRequest`

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.gate.converters.JsonHttpMessageConverter
 import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
 import com.netflix.spinnaker.gate.filters.RequestLoggingFilter
 import com.netflix.spinnaker.gate.filters.RequestSheddingFilter
+import com.netflix.spinnaker.gate.filters.ResetAuthenticatedRequestFilter
 import com.netflix.spinnaker.gate.plugins.deck.DeckPluginConfiguration
 import com.netflix.spinnaker.gate.plugins.web.PluginWebConfiguration
 import com.netflix.spinnaker.gate.services.EurekaLookupService
@@ -366,6 +367,13 @@ class GateConfig extends RedisHttpSessionConfiguration {
     )
   }
 
+  @Bean
+  FilterRegistrationBean resetAuthenticatedRequestFilter() {
+    def frb = new FilterRegistrationBean(new ResetAuthenticatedRequestFilter())
+    frb.order = Ordered.HIGHEST_PRECEDENCE
+    return frb
+  }
+
   /**
    * This AuthenticatedRequestFilter pulls the email and accounts out of the Spring
    * security context in order to enabling forwarding them to downstream components.
@@ -376,7 +384,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
   FilterRegistrationBean authenticatedRequestFilter() {
     // no need to force the `AuthenticatedRequestFilter` to create a request id as that is
     // handled by the `RequestTimingFilter`.
-    def frb = new FilterRegistrationBean(new AuthenticatedRequestFilter(false, true, false))
+    def frb = new FilterRegistrationBean(new AuthenticatedRequestFilter(false, true, false, false))
     frb.order = Ordered.LOWEST_PRECEDENCE - 1
     return frb
   }
@@ -401,7 +409,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
     def frb = new FilterRegistrationBean(new RequestLoggingFilter())
     // this filter should be placed very early in the request chain to ensure we track an accurate start time and
     // have a request id available to propagate across thread and service boundaries.
-    frb.order = Ordered.HIGHEST_PRECEDENCE
+    frb.order = Ordered.HIGHEST_PRECEDENCE + 1
     return frb
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/RequestLoggingFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/RequestLoggingFilter.java
@@ -77,7 +77,6 @@ public class RequestLoggingFilter extends HttpFilter {
         MDC.remove("requestUserAgent");
         MDC.remove("requestPort");
         MDC.remove(REQUEST_START_TIME);
-        AuthenticatedRequest.clear();
       }
     }
   }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ResetAuthenticatedRequestFilter.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/filters/ResetAuthenticatedRequestFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.filters;
+
+import com.netflix.spinnaker.security.AuthenticatedRequest;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * An HttpFilter that ensures the AuthenticatedRequest is cleared at the end of every request.
+ *
+ * <p>This filter should run at the highest priority.
+ */
+public class ResetAuthenticatedRequestFilter extends HttpFilter {
+  @Override
+  protected void doFilter(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      AuthenticatedRequest.clear();
+    }
+  }
+}


### PR DESCRIPTION
In `gate`, the `RequestLoggingFilter` has support for clearing the
`AuthenticatedRequest`.

This preserves the `X-SPINNAKER-*` MDC values and allows them to be correctly logged.
