### PR TITLE
feat(web): Add the rawResources clouddriver endpoint

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -102,7 +102,7 @@ public interface ClouddriverService {
 
   @Headers("Accept: application/json")
   @GET("/applications/{name}/rawResources")
-  List<Map> getApplicationRawResources(@Path("name") String appName);
+  List<Map<String, Object>> getApplicationRawResources(@Path("name") String appName);
 
   @Headers("Accept: application/json")
   @GET("/applications/{name}/serverGroups")

--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -101,6 +101,10 @@ public interface ClouddriverService {
       @Query("validateOldest") Boolean validateOldest);
 
   @Headers("Accept: application/json")
+  @GET("/applications/{name}/rawResources")
+  List<Map> getApplicationRawResources(@Path("name") String appName);
+
+  @Headers("Accept: application/json")
   @GET("/applications/{name}/serverGroups")
   List getServerGroups(
       @Path("name") String name,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RawResourceController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RawResourceController.java
@@ -18,26 +18,26 @@
 package com.netflix.spinnaker.gate.controllers;
 
 import com.netflix.spinnaker.gate.services.RawResourceService;
-import groovy.transform.CompileStatic;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-@CompileStatic
 @RestController
 public class RawResourceController {
+  private final RawResourceService rawResourceService;
 
-  @Autowired RawResourceService rawResourceService;
+  @Autowired
+  public RawResourceController(RawResourceService rawResourceService) {
+    this.rawResourceService = rawResourceService;
+  }
 
   @ApiOperation(
       value = "Retrieve a list of raw resources for a given application",
       response = List.class)
   @RequestMapping(value = "/applications/{application}/rawResources", method = RequestMethod.GET)
-  List<Map> getApplicationRawResources(
-      @PathVariable String application,
-      @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
-    return rawResourceService.getApplicationRawResources(application, sourceApp);
+  List<Map<String, Object>> getApplicationRawResources(@PathVariable String application) {
+    return rawResourceService.getApplicationRawResources(application);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RawResourceController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/RawResourceController.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Coveo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.gate.controllers;
+
+import com.netflix.spinnaker.gate.services.RawResourceService;
+import groovy.transform.CompileStatic;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@CompileStatic
+@RestController
+public class RawResourceController {
+
+  @Autowired RawResourceService rawResourceService;
+
+  @ApiOperation(
+      value = "Retrieve a list of raw resources for a given application",
+      response = List.class)
+  @RequestMapping(value = "/applications/{application}/rawResources", method = RequestMethod.GET)
+  List<Map> getApplicationRawResources(
+      @PathVariable String application,
+      @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
+    return rawResourceService.getApplicationRawResources(application, sourceApp);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RawResourceService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RawResourceService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Coveo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.gate.services;
+
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
+import groovy.transform.CompileStatic;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@CompileStatic
+@Component
+public class RawResourceService {
+
+  @Autowired private ClouddriverServiceSelector clouddriverServiceSelector;
+
+  public List<Map> getApplicationRawResources(String appName, String selectorKey) {
+    return clouddriverServiceSelector.select().getApplicationRawResources(appName);
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RawResourceService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/RawResourceService.java
@@ -18,19 +18,21 @@
 package com.netflix.spinnaker.gate.services;
 
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
-import groovy.transform.CompileStatic;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-@CompileStatic
 @Component
 public class RawResourceService {
+  private final ClouddriverServiceSelector clouddriverServiceSelector;
 
-  @Autowired private ClouddriverServiceSelector clouddriverServiceSelector;
+  @Autowired
+  public RawResourceService(ClouddriverServiceSelector clouddriverServiceSelector) {
+    this.clouddriverServiceSelector = clouddriverServiceSelector;
+  }
 
-  public List<Map> getApplicationRawResources(String appName, String selectorKey) {
+  public List<Map<String, Object>> getApplicationRawResources(String appName) {
     return clouddriverServiceSelector.select().getApplicationRawResources(appName);
   }
 }


### PR DESCRIPTION
It serves all resources regardless of their Spinnaker kind

For context, see this PR: https://github.com/spinnaker/clouddriver/pull/5057