### PR TITLE
feat(pipeline executions/gate) : Added code to save multiple pipelines at once to sql db.

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
@@ -121,12 +121,63 @@ public class TaskService {
     return task;
   }
 
+  public Map bulkCreateAndWaitForCompletion(Map body, int maxPolls, int intervalMs) {
+    log.info("Bulk Creating and waiting for completion: " + body);
+
+    if (body.containsKey("application")) {
+      AuthenticatedRequest.setApplication(body.get("application").toString());
+    }
+
+    Map createResult = create(body);
+    if (createResult.get("ref") == null) {
+      log.warn("No ref field found in create result, returning entire result: " + createResult);
+      return createResult;
+    }
+
+    String taskId = ((String) createResult.get("ref")).split("/")[2];
+    log.info("Create succeeded; polling task for completion: " + taskId);
+
+    LinkedHashMap<String, String> map = new LinkedHashMap<String, String>(1);
+    map.put("id", taskId);
+    Map task = map;
+    for (int i = 0; i < maxPolls; i++) {
+      try {
+        Thread.sleep(intervalMs);
+      } catch (InterruptedException ignored) {
+      }
+
+      task = getTask(taskId);
+      if (new ArrayList<>(Arrays.asList("SUCCEEDED", "TERMINAL"))
+          .contains((String) task.get("status"))) {
+        List<Map<String, String>> bulksaveTasks = (List<Map<String, String>>) task.get("steps");
+        long count = 0;
+        if (bulksaveTasks != null && !bulksaveTasks.isEmpty()) {
+          count =
+              bulksaveTasks.stream()
+                  .filter(
+                      hashmap ->
+                          ("SUCCEEDED".equals((String) hashmap.get("status"))
+                              || "TERMINAL".equals((String) hashmap.get("status"))))
+                  .count();
+        }
+        if (count == 2) {
+          return task;
+        }
+      }
+    }
+    return task;
+  }
+
   public Map createAndWaitForCompletion(Map body, int maxPolls) {
     return createAndWaitForCompletion(body, maxPolls, 1000);
   }
 
   public Map createAndWaitForCompletion(Map body) {
     return createAndWaitForCompletion(body, 32, 1000);
+  }
+
+  public Map bulkCreateAndWaitForCompletion(Map body) {
+    return bulkCreateAndWaitForCompletion(body, 120, 1000);
   }
 
   /** @deprecated This pipeline operation does not belong here. */

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -92,6 +92,43 @@ class PipelineController {
     }
   }
 
+  @CompileDynamic
+  @ApiOperation(value = "Save an array of pipeline definition")
+  @PostMapping('/bulksave')
+  Map bulksavePipeline(
+    @RequestBody List<Map> pipelineList,
+    @RequestParam(value = "staleCheck", required = false, defaultValue = "false")
+      Boolean staleCheck) {
+
+    def retData = []
+    def operation = [
+      description: "bulk save pipeline",
+      application: "bulk save application",
+      job        : [
+        [
+          type      : "savePipeline",
+          pipeline  : (String) Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipelineList).getBytes("UTF-8")),
+          user      : AuthenticatedRequest.spinnakerUser.orElse("anonymous"),
+          staleCheck: staleCheck,
+          bulksave  : true
+        ]
+      ]
+    ]
+
+    def result = taskService.bulkCreateAndWaitForCompletion(operation)
+    String resultStatus = result.get("status")
+
+    if (!"SUCCEEDED".equalsIgnoreCase(resultStatus)) {
+      String exception = result.variables.find { it.key == "exception" }?.value?.details?.errors?.getAt(0)
+      throw new PipelineException(
+        exception ?: "Pipeline bulk save operation did not succeed: ${result.get("id", "unknown task id")} (status: ${resultStatus})"
+      )
+    } else {
+      retData = result.variables.find { it.key == "bulksave"}?.value
+    }
+    return retData
+  }
+
   @ApiOperation(value = "Rename a pipeline definition")
   @PostMapping('move')
   void renamePipeline(@RequestBody Map renameCommand) {


### PR DESCRIPTION
feat(pipeline executions/gate) : Added code to save multiple pipelines at once to sql db.

This is part of: spinnaker/spinnaker#6147.

Enhanced PipelineController.groovy to

Added new rest api method bulksavePipeline(List<Map> pipelineList, Boolean staleCheck)
This method accepts a list of pipelines json.
This method returns a Map object having the below data:
{
  “Successful”: <count>,
  “Failed”: <cound>,
  “Failed_list”: [<array of failed pipelines - (application, pipeline name, etc) and the error message]
}

Enhanced TaskService.java to

Added code to poll the task until the SavePipelineTask and MonitorFront50Task status : succeeded, terminal.

