### PR TITLE
fix(authz): remove unneeded storeWholePermission

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpEntity
 import org.springframework.security.access.prepost.PostFilter
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -62,7 +61,6 @@ class ApplicationController {
 
   @ApiOperation(value = "Retrieve a list of applications", response = List.class)
   @RequestMapping(method = RequestMethod.GET)
-  @PreAuthorize("@fiatPermissionEvaluator.storeWholePermission()")
   @PostFilter("hasPermission(filterObject.get('name'), 'APPLICATION', 'READ')")
   List<HashMap<String, Object>> getAllApplications(
     @ApiParam(name = "account", required = false, value = "filters results to only include applications deployed in the specified account")


### PR DESCRIPTION
We always fetch user permission in bulk for auth checks making this
PreAuthorize header unnecessary