### PR TITLE
feat(slackV2): add new endpoint for keel specific slack callbacks

### DIFF
--- a/gate-api-tck/src/main/resources/gate-test-app.yml
+++ b/gate-api-tck/src/main/resources/gate-test-app.yml
@@ -27,3 +27,6 @@ services:
     enabled: false
   swabbie:
     enabled: false
+  keel:
+    enabled: false
+    baseUrl: http://localhost:8087

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -85,6 +85,7 @@ class AuthConfig {
         .antMatchers('/plugins/deck/**').permitAll()
         .antMatchers(HttpMethod.POST, '/webhooks/**').permitAll()
         .antMatchers(HttpMethod.POST, '/notifications/callbacks/**').permitAll()
+        .antMatchers(HttpMethod.POST, '/managed/notifications/callbacks/**').permitAll()
         .antMatchers('/health').permitAll()
         .antMatchers('/**').authenticated()
     if (fiatSessionFilterEnabled) {

--- a/gate-plugins-test/src/test/resources/gate-plugins-test.yml
+++ b/gate-plugins-test/src/test/resources/gate-plugins-test.yml
@@ -28,6 +28,8 @@ services:
 
   swabbie.enabled: false
 
+  keel.baseUrl: "http://localhost:8087"
+
 slack:
   baseUrl: "https://slack.com"
 

--- a/gate-plugins/src/test/resources/gate-test.yml
+++ b/gate-plugins/src/test/resources/gate-test.yml
@@ -25,6 +25,8 @@ services:
 
   swabbie.enabled: false
 
+  keel.baseUrl: "http://localhost:8087"
+
 ---
 
 spring:

--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -42,6 +42,9 @@ services:
   echo:
     baseUrl: http://localhost:8089
     enabled: true
+  keel:
+    baseUrl: http://localhost:8087
+    enabled: true
   fiat:
     enabled: false
   flapjack:

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -289,6 +289,12 @@ class GateConfig extends RedisHttpSessionConfiguration {
   }
 
   @Bean
+  @ConditionalOnProperty("services.keel.enabled")
+  KeelService keelService() {
+    createClient "keel", KeelService
+  }
+
+  @Bean
   @ConditionalOnProperty('services.kayenta.enabled')
   KayentaService kayentaService(OkHttpClientConfigurationProperties props,
                                 OkHttp3MetricsInterceptor interceptor,

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.gate.model.manageddelivery.DeliveryConfig;
 import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactPin;
 import com.netflix.spinnaker.gate.model.manageddelivery.EnvironmentArtifactVeto;
 import com.netflix.spinnaker.gate.model.manageddelivery.Resource;
+import com.netflix.spinnaker.gate.services.NotificationService;
 import com.netflix.spinnaker.gate.services.internal.KeelService;
 import groovy.util.logging.Slf4j;
 import io.github.resilience4j.retry.RetryConfig;
@@ -28,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,14 +54,19 @@ public class ManagedController {
   private final KeelService keelService;
   private final ObjectMapper objectMapper;
   private final RetryRegistry retryRegistry;
+  private final NotificationService notificationService;
 
   @Autowired
   public ManagedController(
-      KeelService keelService, ObjectMapper objectMapper, RetryRegistry retryRegistry) {
+      KeelService keelService,
+      ObjectMapper objectMapper,
+      RetryRegistry retryRegistry,
+      NotificationService notificationService) {
     this.keelService = keelService;
     this.objectMapper = objectMapper;
     this.yamlResponseHeaders = new HttpHeaders();
     this.retryRegistry = retryRegistry;
+    this.notificationService = notificationService;
     yamlResponseHeaders.setContentType(
         new MediaType("application", "x-yaml", StandardCharsets.UTF_8));
 
@@ -323,5 +330,14 @@ public class ManagedController {
       @PathVariable("reference") String reference,
       @PathVariable("version") String version) {
     keelService.deleteVeto(application, targetEnvironment, reference, version);
+  }
+
+  @PostMapping(
+      path = "/notifications/callbacks/{source}/v2",
+      consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  ResponseEntity<String> processNotificationCallback(
+      @PathVariable String source, RequestEntity<String> request) {
+    return notificationService.processNotificationCallback(source, request, "keel");
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -333,7 +333,7 @@ public class ManagedController {
   }
 
   @PostMapping(
-      path = "/notifications/callbacks/{source}/v2",
+      path = "/notifications/callbacks/{source}",
       consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   ResponseEntity<String> processNotificationCallback(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NotificationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/NotificationController.groovy
@@ -72,6 +72,6 @@ class NotificationController {
     produces = MediaType.APPLICATION_JSON_VALUE
   )
   ResponseEntity<String> processNotificationCallback(@PathVariable String source, RequestEntity<String> request) {
-    return notificationService.processNotificationCallback(source, request)
+    return notificationService.processNotificationCallback(source, request, "echo")
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
@@ -95,7 +95,7 @@ class NotificationService {
    * @param service
    * @return
    */
-  ResponseEntity<String> processNotificationCallback(String source, RequestEntity<String> request, String service) {
+  ResponseEntity<String> processNotificationCallback(String source, RequestEntity<String> request, String service = "echo") {
     Endpoint endpointToUse = echoEndpoint
     OkHttpClient clientToUse = echoOkHttpClient
     String path = request.url.path

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/NotificationService.groovy
@@ -50,8 +50,10 @@ class NotificationService {
   private Front50Service front50Service
   private EchoService echoService
 
-  private OkHttpClient okHttpClient
+  private OkHttpClient echoOkHttpClient
+  private OkHttpClient keelOkHttpClient
   private Endpoint echoEndpoint
+  private Endpoint keelEndpoint
 
   NotificationService(@Autowired(required = false) Front50Service front50Service,
                       @Autowired OkHttpClientProvider okHttpClientProvider,
@@ -63,7 +65,9 @@ class NotificationService {
     // of the body for the x-www-form-urlencoded content type, which is what Slack uses. This allows us to pass
     // the original body unmodified along to echo.
     this.echoEndpoint = serviceConfiguration.getServiceEndpoint("echo")
-    this.okHttpClient =  okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url))
+    this.keelEndpoint = serviceConfiguration.getServiceEndpoint("keel")
+    this.echoOkHttpClient =  okHttpClientProvider.getClient(new DefaultServiceEndpoint("echo", echoEndpoint.url))
+    this.keelOkHttpClient =  okHttpClientProvider.getClient(new DefaultServiceEndpoint("keel", keelEndpoint.url))
   }
 
   Map getNotificationConfigs(String type, String app) {
@@ -82,7 +86,20 @@ class NotificationService {
     echoService.getNotificationTypeMetadata()
   }
 
-  ResponseEntity<String> processNotificationCallback(String source, RequestEntity<String> request) {
+  /**
+   * processNotificationCallback can be called from 2 places:
+   * 1. from NotificationController, which is the generic implementation and will use echo for further processing
+   * 2. from ManagedController, which is keel's (MD) specific implementation and will use keel for further processing
+   * @param source
+   * @param request
+   * @param service
+   * @return
+   */
+  ResponseEntity<String> processNotificationCallback(String source, RequestEntity<String> request, String service) {
+    Endpoint endpointToUse = echoEndpoint
+    OkHttpClient clientToUse = echoOkHttpClient
+    String path = request.url.path
+
     log.debug("Processing notification callback: ${request.getMethod()} ${request.getUrl()}, ${request.getHeaders()}")
     String contentType = request.getHeaders().getFirst("Content-Type")?.toLowerCase()
 
@@ -92,10 +109,16 @@ class NotificationService {
 
     final MediaType mediaType = MediaType.parse(contentType)
 
+    // If the call is coming from ManagedController, use keel client and keel endpoint instead of echo
+    if (service == "keel") {
+      endpointToUse = keelEndpoint
+      clientToUse = keelOkHttpClient
+      path = "/notifications/callback/v2"
+    }
 
-    log.debug("Building echo request with URL ${echoEndpoint.url + request.url.path}, Content-Type: $contentType")
+    log.debug("Building request with URL ${endpointToUse.url + path}, Content-Type: $contentType")
     Request.Builder builder = new Request.Builder()
-      .url(echoEndpoint.url + request.url.path)
+      .url(endpointToUse.url + path)
       .post(RequestBody.create(mediaType, request.body))
 
     request.getHeaders().each { String name, List values ->
@@ -105,9 +128,9 @@ class NotificationService {
       }
     }
 
-    Request echoRequest = builder.build();
+    Request callbackRequest = builder.build();
     try {
-      Response response = okHttpClient.newCall(echoRequest).execute()
+      Response response = clientToUse.newCall(callbackRequest).execute()
       // convert retrofit response to Spring format
       String body = response.body().contentLength() > 0 ? response.body().string() : null
       HttpHeaders headers = new HttpHeaders()

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/NotificationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/services/NotificationServiceSpec.groovy
@@ -51,6 +51,7 @@ class NotificationServiceSpec extends Specification {
 
   void setup() {
     serviceConfiguration.getServiceEndpoint("echo") >> newFixedEndpoint("https://echo")
+    serviceConfiguration.getServiceEndpoint("keel") >> newFixedEndpoint("https://keel")
     clientProvider.getClient(_) >> { DefaultServiceEndpoint serviceEndpoint ->
       serviceEndpoint.name == 'echo'
       serviceEndpoint.baseUrl == 'https://echo'

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -29,7 +29,7 @@ services:
 
   swabbie.enabled: false
 
-  keel.enabled: false
+  keel.baseUrl: "http://localhost:8087"
 
 slack:
   baseUrl: "https://slack.com"

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -29,6 +29,8 @@ services:
 
   swabbie.enabled: false
 
+  keel.enabled: false
+
 slack:
   baseUrl: "https://slack.com"
 


### PR DESCRIPTION
Adding a new endpoint to support callbacks for managed-delivery specific notifications. 
The new endpoint will use the existing service implementation to parse the request and delegate it to `keel` directly, as opposed to using the mid-layer currently in `echo`.