### PR TITLE
feat(managed-delivery): Make HTML the default report format

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -385,7 +385,7 @@ public class ManagedController {
   @ApiOperation(value = "Get a report of application onboarding")
   @GetMapping(path = "/reports/onboarding")
   ResponseEntity<byte[]> getOnboardingReport(
-      @RequestHeader(value = "Accept", defaultValue = "text/csv") String accept,
+      @RequestHeader(value = "Accept", defaultValue = "text/html") String accept,
       @RequestParam Map<String, String> params)
       throws IOException {
     Response keelResponse = keelService.getOnboardingReport(accept, params);


### PR DESCRIPTION
Changing the default format to HTML now that keel supports it.