### PR TITLE
fix(managed-delivery): Fix adoption report endpoint

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/KeelService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/KeelService.java
@@ -188,7 +188,7 @@ public interface KeelService {
 
   @GET("/reports/adoption")
   @Headers("Accept: text/html")
-  String getAdoptionReport(@QueryMap Map<String, String> params);
+  Response getAdoptionReport(@QueryMap Map<String, String> params);
 
   @GET("/environments/{application}")
   List<Map<String, Object>> getEnvironments(@Path("application") String application);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ManagedController.java
@@ -42,7 +42,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import retrofit.RetrofitError;
 import retrofit.client.Header;
@@ -405,9 +404,12 @@ public class ManagedController {
 
   @ApiOperation(value = "Get a report of Managed Delivery adoption")
   @GetMapping(path = "/reports/adoption", produces = "text/html")
-  @ResponseBody
-  String getAdoptionReport(@RequestParam Map<String, String> params) {
-    return keelService.getAdoptionReport(params);
+  ResponseEntity<byte[]> getAdoptionReport(@RequestParam Map<String, String> params)
+      throws IOException {
+    Response keelResponse = keelService.getAdoptionReport(params);
+    return ResponseEntity.status(keelResponse.getStatus())
+        .header("Content-Type", "text/html")
+        .body(keelResponse.getBody().in().readAllBytes());
   }
 
   @ApiOperation(value = "Get current environment details")


### PR DESCRIPTION
Our REST controllers and Retrofit clients, as configured, default to trying to parse/return JSON, and so without using response wrappers this new keel endpoint fails. This PR fixes that for the adoption report endpoint by using the same approach as for the onboarding report.