### PR TITLE
fix(slack): Add retries with backoff to prevent conversations.list rate limiting

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.gate.services.SlackService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import io.swagger.annotations.ApiOperation;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +88,12 @@ public class SlackController {
     String cursor = response.response_metadata.next_cursor;
     while (cursor != null & cursor.length() > 0) {
       String nextCursor = cursor;
-      response = retrySupport.retry(() -> slackService.getChannels(slackConfigProperties.getToken(), nextCursor), 4, Duration.ofSeconds(30), true);
+      response =
+          retrySupport.retry(
+             () -> slackService.getChannels(slackConfigProperties.getToken(), nextCursor),
+             4,
+             Duration.ofSeconds(30),
+             true);
       cursor = response.response_metadata.next_cursor;
       channels.addAll(response.channels);
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SlackController.java
@@ -90,10 +90,10 @@ public class SlackController {
       String nextCursor = cursor;
       response =
           retrySupport.retry(
-             () -> slackService.getChannels(slackConfigProperties.getToken(), nextCursor),
-             4,
-             Duration.ofSeconds(30),
-             true);
+              () -> slackService.getChannels(slackConfigProperties.getToken(), nextCursor),
+              4,
+              Duration.ofSeconds(30),
+              true);
       cursor = response.response_metadata.next_cursor;
       channels.addAll(response.channels);
     }


### PR DESCRIPTION
Fetching slack channels is hitting Slack's Tier 2 rate limiting, since the api paginates channels.

The API is fairly limited, and our current approach of only allowing non-archived, public channels is the most filtering we can achieve. Since we cannot further limit the channels we receive from slack, `RetrySupport` is utilized to prevent rate limiting.

I ran an experiment for several hours where I backed the `limit` down to `100` channels per request. There were no rate limits hit during that time, but this should be observed in an environment with more nodes making these requests. 