### PR TITLE
feat(auth): Make webhooks endpoint configurable for authentication

### DIFF
--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -73,7 +73,7 @@ class AuthConfig {
   @Value('${fiat.session-filter.enabled:true}')
   boolean fiatSessionFilterEnabled
 
-  @Value('${security.webhooks.default-auth.enabled:false}')
+  @Value('${security.webhooks.default-auth-enabled:false}')
   boolean webhookDefaultAuthEnabled
 
   void configure(HttpSecurity http) throws Exception {

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -73,8 +73,8 @@ class AuthConfig {
   @Value('${fiat.session-filter.enabled:true}')
   boolean fiatSessionFilterEnabled
 
-  @Value('${security.webhook-require-auth.enabled:false}')
-  boolean webhookRequireAuthEnabled
+  @Value('${security.webhooks.default-auth.enabled:false}')
+  boolean webhookDefaultAuthEnabled
 
   void configure(HttpSecurity http) throws Exception {
     // @formatter:off
@@ -100,7 +100,7 @@ class AuthConfig {
       http.addFilterBefore(fiatSessionFilter, AnonymousAuthenticationFilter.class)
     }
 
-    if (webhookRequireAuthEnabled) {
+    if (webhookDefaultAuthEnabled) {
       http.authorizeRequests().antMatchers(HttpMethod.POST, '/webhooks/**').authenticated()
     }
 

--- a/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
+++ b/gate-core/src/main/groovy/com/netflix/spinnaker/gate/config/AuthConfig.groovy
@@ -73,6 +73,9 @@ class AuthConfig {
   @Value('${fiat.session-filter.enabled:true}')
   boolean fiatSessionFilterEnabled
 
+  @Value('${security.webhook-require-auth.enabled:false}')
+  boolean webhookRequireAuthEnabled
+
   void configure(HttpSecurity http) throws Exception {
     // @formatter:off
     http
@@ -95,6 +98,10 @@ class AuthConfig {
         permissionEvaluator)
 
       http.addFilterBefore(fiatSessionFilter, AnonymousAuthenticationFilter.class)
+    }
+
+    if (webhookRequireAuthEnabled) {
+      http.authorizeRequests().antMatchers(HttpMethod.POST, '/webhooks/**').authenticated()
     }
 
     http.logout()

--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
@@ -80,7 +80,7 @@ class AuthConfigTest extends Specification {
       requestMatcherProvider: mockRequestMatcherProvider,
       securityDebug: false,
       fiatSessionFilterEnabled: false,
-      webhookRequireAuthEnabled: true,
+      webhookDefaultAuthEnabled: true,
     )
     def httpSecurity = new HttpSecurity(
       Mock(ObjectPostProcessor),

--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.gate.config
+import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatStatus
+import org.springframework.boot.autoconfigure.security.SecurityProperties
+import org.springframework.security.config.annotation.ObjectPostProcessor
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.util.matcher.AnyRequestMatcher
+import spock.lang.Specification
+import java.util.stream.Collectors
+
+class AuthConfigTest extends Specification {
+  @SuppressWarnings("GroovyAccessibility")
+  def "test webhooks are unauthenticated by default"() {
+    given:
+    def requestMatcher = AnyRequestMatcher.INSTANCE
+    def mockRequestMatcherProvider = Mock(RequestMatcherProvider) {
+      requestMatcher() >> requestMatcher
+    }
+    def authConfig = new AuthConfig(
+      permissionRevokingLogoutSuccessHandler: Mock(AuthConfig.PermissionRevokingLogoutSuccessHandler),
+      securityProperties: Mock(SecurityProperties),
+      configProps: Mock(FiatClientConfigurationProperties),
+      fiatStatus: Mock(FiatStatus),
+      permissionEvaluator: Mock(FiatPermissionEvaluator),
+      requestMatcherProvider: mockRequestMatcherProvider,
+      securityDebug: false,
+      fiatSessionFilterEnabled: false,
+    )
+    def httpSecurity = new HttpSecurity(
+      Mock(ObjectPostProcessor),
+      Mock(AuthenticationManagerBuilder),
+      new HashMap<Class<?, Object>>()
+    )
+
+    when:
+    authConfig.configure(httpSecurity)
+
+    then:
+    def filtered = httpSecurity.authorizeRequests().getUrlMappings()
+      .stream()
+      .filter({ it -> it.requestMatcher.getPattern() == "/webhooks/**" })
+      .filter( { it ->
+        it.configAttrs.stream().any( {att -> att.getAttribute() == "authenticated" })
+      })
+      .collect(Collectors.toList())
+    filtered.size() == 0
+  }
+}


### PR DESCRIPTION
Currently the `/webhooks/**` endpoint is unauthenticated. @aelath and I discovered that we need the ability to force authentication for POST requests to this specific endpoint, so we added a setting in the `AuthConfig` class to do so. This is to ensure that POSTs to `/webhooks/**` will be authenticated with the default authentication Gate is configured for (basic auth, x509, etc). 

In the future, webhooks could possibly have their own security settings if a different authentication method is preferred than the default auth, but that is not part of this PR.

See the below `gate.yml` config for how to enable authentication for webhooks with this change:

```
security:
  webhooks:
    defaultAuthEnabled: true
```

The webhooks endpoint will otherwise be unauthenticated without this setting. 