### PR TITLE
fix(web): disable keel by default since it is an optional service

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -44,7 +44,7 @@ services:
     enabled: true
   keel:
     baseUrl: http://localhost:8087
-    enabled: true
+    enabled: false
   fiat:
     enabled: false
   flapjack:


### PR DESCRIPTION
We don't need `keel.enabled=true` to `gate-web/config/gate.yml` since keel service is optional.
