### PR TITLE
fix(vulnerability): Remove fixed version of com.nimbusds:nimbus-jose-jwt dependency to accommodate safer version from kork.

### DIFF
--- a/gate-iap/gate-iap.gradle
+++ b/gate-iap/gate-iap.gradle
@@ -1,6 +1,6 @@
 dependencies {
   implementation project(":gate-core")
-  implementation 'com.nimbusds:nimbus-jose-jwt:5.2'
+  implementation 'com.nimbusds:nimbus-jose-jwt'
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "io.spinnaker.kork:kork-security"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"


### PR DESCRIPTION
This is a clean up activity after introducing [CVE-2019-17195](https://nvd.nist.gov/vuln/detail/CVE-2019-17195) fix in kork.