### PR TITLE
chore(build): upgrade kork & fiat version, use new groupId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 allprojects {
   apply plugin: 'io.spinnaker.project'
 
-  group = "com.netflix.spinnaker.gate"
+  group = "io.spinnaker.gate"
 
   if ([korkVersion, fiatVersion].find { it.endsWith('-SNAPSHOT') }) {
     repositories {
@@ -26,10 +26,10 @@ allprojects {
     }
 
     dependencies {
-      implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
-      annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-      testAnnotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+      testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       compileOnly "org.projectlombok:lombok"
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor "org.projectlombok:lombok"

--- a/gate-api/gate-api.gradle
+++ b/gate-api/gate-api.gradle
@@ -16,11 +16,11 @@
 apply plugin: 'java-library'
 
 dependencies {
-  implementation platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
-  annotationProcessor platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion")
+  implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
+  annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
 
-  api "com.netflix.spinnaker.kork:kork-plugins-api"
-  api "com.netflix.spinnaker.kork:kork-annotations"
+  api "io.spinnaker.kork:kork-plugins-api"
+  api "io.spinnaker.kork:kork-annotations"
 
   compileOnly("org.projectlombok:lombok")
   annotationProcessor("org.projectlombok:lombok")

--- a/gate-basic/gate-basic.gradle
+++ b/gate-basic/gate-basic.gradle
@@ -1,5 +1,5 @@
 dependencies {
   implementation project(":gate-core")
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "org.springframework.session:spring-session-core"
 }

--- a/gate-bom/gate-bom.gradle
+++ b/gate-bom/gate-bom.gradle
@@ -22,11 +22,11 @@ javaPlatform {
 }
 
 dependencies {
-  api(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
+  api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
-    api("com.netflix.spinnaker.fiat:fiat-api:$fiatVersion")
-    api("com.netflix.spinnaker.fiat:fiat-core:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-api:$fiatVersion")
+    api("io.spinnaker.fiat:fiat-core:$fiatVersion")
 
     rootProject
       .subprojects

--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -21,19 +21,19 @@ dependencies {
 
   api "com.squareup.retrofit:retrofit"
 
-  implementation "com.netflix.spinnaker.kork:kork-plugins"
+  implementation "io.spinnaker.kork:kork-plugins"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.okhttp:okhttp-apache"
 
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
 
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.github.ben-manes.caffeine:guava"
   implementation "org.apache.commons:commons-lang3"

--- a/gate-iap/gate-iap.gradle
+++ b/gate-iap/gate-iap.gradle
@@ -2,7 +2,7 @@ dependencies {
   implementation project(":gate-core")
   implementation 'com.nimbusds:nimbus-jose-jwt:5.2'
   implementation "com.github.ben-manes.caffeine:guava"
-  implementation "com.netflix.spinnaker.kork:kork-security"
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
 }

--- a/gate-integrations-gremlin/gate-integrations-gremlin.gradle
+++ b/gate-integrations-gremlin/gate-integrations-gremlin.gradle
@@ -1,7 +1,7 @@
 dependencies {
   implementation project(":gate-core")
-  implementation "com.netflix.spinnaker.kork:kork-swagger"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-swagger"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.squareup.okhttp3:okhttp"
   implementation "com.squareup.retrofit:retrofit"

--- a/gate-ldap/gate-ldap.gradle
+++ b/gate-ldap/gate-ldap.gradle
@@ -1,7 +1,7 @@
 dependencies {
   implementation project(":gate-core")
   implementation "org.springframework.security:spring-security-ldap"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "org.apache.commons:commons-lang3"
   implementation "org.springframework.session:spring-session-core"
 

--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -1,9 +1,9 @@
 dependencies {
   implementation project(":gate-core")
   implementation "com.netflix.spectator:spectator-api"
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-exceptions"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
   implementation "org.springframework.session:spring-session-core"
 }

--- a/gate-plugins-test/gate-plugins-test.gradle
+++ b/gate-plugins-test/gate-plugins-test.gradle
@@ -7,8 +7,8 @@ dependencies {
   testImplementation(project(":gate-web"))
   testImplementation(project(":gate-core"))
 
-  testImplementation("com.netflix.spinnaker.kork:kork-plugins")
-  testImplementation("com.netflix.spinnaker.kork:kork-plugins-tck")
+  testImplementation("io.spinnaker.kork:kork-plugins")
+  testImplementation("io.spinnaker.kork:kork-plugins-tck")
 
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/gate-plugins/gate-plugins.gradle
+++ b/gate-plugins/gate-plugins.gradle
@@ -22,10 +22,10 @@ dependencies {
   implementation project(":gate-core")
 
   implementation "com.google.guava:guava"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.kork:kork-plugins"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-plugins"
+  implementation "io.spinnaker.kork:kork-web"
 
   implementation "io.swagger:swagger-annotations"
 

--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -5,8 +5,8 @@ dependencies {
   implementation project(":gate-api")
   implementation project(":gate-core")
 
-  implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-exceptions"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.netflix.spectator:spectator-api"

--- a/gate-saml/gate-saml.gradle
+++ b/gate-saml/gate-saml.gradle
@@ -1,9 +1,9 @@
 dependencies{
   implementation project(':gate-core')
   // RetrySupport is in kork-exceptions and not kork-core!
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.kork:kork-exceptions"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.kork:kork-exceptions"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "com.netflix.spectator:spectator-api"
   implementation 'org.springframework:spring-context'
   implementation 'org.springframework.session:spring-session-core'

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -34,11 +34,11 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.okhttp:okhttp-apache"
 
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
 
-  implementation "com.netflix.spinnaker.kork:kork-plugins"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-plugins"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.netflix.frigga:frigga"
   implementation "redis.clients:jedis"
 
@@ -57,7 +57,7 @@ dependencies {
 
   implementation "io.springfox:springfox-swagger2"
 
-  runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"
+  runtimeOnly "io.spinnaker.kork:kork-runtime"
   runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"
 
   testImplementation "com.graphql-java-kickstart:graphql-spring-boot-starter-test:7.0.1"
@@ -71,8 +71,8 @@ dependencies {
   testImplementation "org.springframework.security:spring-security-ldap"
   testImplementation "org.springframework.security:spring-security-oauth2-jose"
   testImplementation "com.unboundid:unboundid-ldapsdk"
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
-  testRuntimeOnly "com.netflix.spinnaker.kork:kork-retrofit"
+  testImplementation "io.spinnaker.kork:kork-jedis-test"
+  testRuntimeOnly "io.spinnaker.kork:kork-retrofit"
 
   // Add each included authz provider as a runtime dependency
   gradle.includedProviderProjects.each {

--- a/gate-x509/gate-x509.gradle
+++ b/gate-x509/gate-x509.gradle
@@ -1,10 +1,10 @@
 dependencies {
   implementation project(':gate-core')
   implementation "org.bouncycastle:bcprov-jdk15on"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-security"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-security"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.github.ben-manes.caffeine:caffeine"
-  implementation "com.netflix.spinnaker.fiat:fiat-api:$fiatVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
-fiatVersion=1.26.0
+fiatVersion=1.27.0
 includeProviders=basic,iap,ldap,oauth2,saml,x509
-korkVersion=7.99.1
+korkVersion=7.110.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1


### PR DESCRIPTION
There is an issue in the Deck cache of Gate that was solved in this PR: https://github.com/spinnaker/kork/pull/866

but this fix was released in kork 7.110.0

I bumped the version of kork to include the fix in Gate but this involved changing the groupId of kork because now it's been published under "io.spinnaker" and this release branch is pretty old.

I had to bump the version of Fiat as well because it has issues when trying to download the kork version in fiat due to the groupId change.
