### PR TITLE
feat(web): Expose experimental account storage API

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -511,6 +511,16 @@ public interface ClouddriverService {
     private final Map<String, Object> details = new HashMap<String, Object>();
   }
 
+  /**
+   * Wrapper type for Clouddriver account definitions. Clouddriver account definitions implement
+   * {@code CredentialsDefinition}, and its type discriminator is present in a property named
+   * {@code @type}. An instance of an account definition may have fairly different properties than
+   * its corresponding {@code AccountCredentials} instance. Account definitions must store all the
+   * relevant properties unchanged while {@link Account} and {@link AccountDetails} may summarize
+   * and remove data returned from their corresponding APIs. Account definitions must be transformed
+   * by a {@code CredentialsParser} before their corresponding credentials may be used by
+   * Clouddriver.
+   */
   class AccountDefinition {
     private final Map<String, Object> details = new HashMap<>();
     private String type;

--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -33,19 +33,19 @@ public interface ClouddriverService {
   @GET("/credentials/{account}")
   AccountDetails getAccount(@Path("account") String account);
 
-  @GET("/accounts?accountType={type}")
+  @GET("/credentials/type/{type}")
   List<AccountDefinition> getAccountDefinitionsByType(
       @Path("type") String type,
       @Query("limit") Integer limit,
       @Query("startingAccountName") String startingAccountName);
 
-  @POST("/accounts")
+  @POST("/credentials")
   AccountDefinition createAccountDefinition(@Body AccountDefinition accountDefinition);
 
-  @PUT("/accounts")
+  @PUT("/credentials")
   AccountDefinition updateAccountDefinition(@Body AccountDefinition accountDefinition);
 
-  @DELETE("/accounts/{account}")
+  @DELETE("/credentials/{account}")
   void deleteAccountDefinition(@Path("account") String account);
 
   @GET("/task/{taskDetailsId}")

--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import retrofit.client.Response;
 import retrofit.http.Body;
+import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.Headers;
 import retrofit.http.POST;
@@ -30,6 +32,21 @@ public interface ClouddriverService {
 
   @GET("/credentials/{account}")
   AccountDetails getAccount(@Path("account") String account);
+
+  @GET("/accounts?accountType={type}")
+  List<AccountDefinition> getAccountDefinitionsByType(
+      @Path("type") String type,
+      @Query("limit") Integer limit,
+      @Query("startingAccountName") String startingAccountName);
+
+  @POST("/accounts")
+  AccountDefinition createAccountDefinition(@Body AccountDefinition accountDefinition);
+
+  @PUT("/accounts")
+  AccountDefinition updateAccountDefinition(@Body AccountDefinition accountDefinition);
+
+  @DELETE("/accounts/{account}")
+  void deleteAccountDefinition(@Path("account") String account);
 
   @GET("/task/{taskDetailsId}")
   Map getTaskDetails(@Path("taskDetailsId") String taskDetailsId);
@@ -492,5 +509,30 @@ public interface ClouddriverService {
     private Boolean primaryAccount;
     private String cloudProvider;
     private final Map<String, Object> details = new HashMap<String, Object>();
+  }
+
+  class AccountDefinition {
+    private final Map<String, Object> details = new HashMap<>();
+    private String type;
+
+    @JsonAnyGetter
+    public Map<String, Object> details() {
+      return details;
+    }
+
+    @JsonAnySetter
+    public void set(String name, Object value) {
+      details.put(name, value);
+    }
+
+    @JsonProperty("@type")
+    public String getType() {
+      return type;
+    }
+
+    @JsonProperty("@type")
+    public void setType(String type) {
+      this.type = type;
+    }
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.gate.services.AccountLookupService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.Account
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
+import com.netflix.spinnaker.kork.annotations.Alpha
 import com.netflix.spinnaker.security.User
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiParam
@@ -94,6 +95,7 @@ class CredentialsController {
   @GetMapping('/type/{accountType}')
   @ApiOperation('Looks up account definitions by type.')
   @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'WRITE')")
+  @Alpha
   List<ClouddriverService.AccountDefinition> getAccountsByType(
     @ApiParam(value = 'Value of the "@type" key for accounts to search for.', example = 'kubernetes')
     @PathVariable String accountType,
@@ -108,6 +110,7 @@ class CredentialsController {
   @PostMapping
   @ApiOperation('Creates a new account definition.')
   @PreAuthorize('isAuthenticated()')
+  @Alpha
   ClouddriverService.AccountDefinition createAccount(
     @ApiParam('Account definition body including a discriminator field named "@type" with the account type.')
     @RequestBody ClouddriverService.AccountDefinition accountDefinition
@@ -118,6 +121,7 @@ class CredentialsController {
   @PutMapping
   @ApiOperation('Updates an existing account definition.')
   @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  @Alpha
   ClouddriverService.AccountDefinition updateAccount(
     @ApiParam('Account definition body including a discriminator field named "@type" with the account type.')
     @RequestBody ClouddriverService.AccountDefinition accountDefinition
@@ -129,6 +133,7 @@ class CredentialsController {
   @ApiOperation(value = 'Deletes an account definition by name.',
     notes = 'Deleted accounts can be restored via the update API. Previously deleted accounts cannot be "created" again to avoid conflicts with existing pipelines.')
   @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  @Alpha
   void deleteAccount(
     @ApiParam('Name of account definition to delete.')
     @PathVariable String accountName

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -21,12 +21,21 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.security.AllowedAccountsSupport
 import com.netflix.spinnaker.gate.security.SpinnakerUser
 import com.netflix.spinnaker.gate.services.AccountLookupService
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.Account
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService.AccountDetails
 import com.netflix.spinnaker.security.User
 import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.access.prepost.PostFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
@@ -42,6 +51,9 @@ class CredentialsController {
 
   @Autowired
   AllowedAccountsSupport allowedAccountsSupport
+
+  @Autowired
+  ClouddriverService clouddriverService
 
   @Autowired
   ObjectMapper objectMapper
@@ -77,5 +89,50 @@ class CredentialsController {
   AccountDetails getAccount(@SpinnakerUser User user, @PathVariable("account") String account,
                             @RequestHeader(value = "X-RateLimit-App", required = false) String sourceApp) {
     return getAccountDetailsWithAuthorizedFlag(user).find { it.name == account }
+  }
+
+  @GetMapping('/type/{accountType}')
+  @ApiOperation('Looks up account definitions by type.')
+  @PostFilter("hasPermission(filterObject.name, 'ACCOUNT', 'WRITE')")
+  List<ClouddriverService.AccountDefinition> getAccountsByType(
+    @ApiParam(value = 'Value of the "@type" key for accounts to search for.', example = 'kubernetes')
+    @PathVariable String accountType,
+    @ApiParam('Maximum number of entries to return in results. Used for pagination.')
+    @RequestParam OptionalInt limit,
+    @ApiParam('Account name to start account definition listing from. Used for pagination.')
+    @RequestParam Optional<String> startingAccountName
+  ) {
+    clouddriverService.getAccountDefinitionsByType(accountType, limit.isPresent() ? limit.getAsInt() : null, startingAccountName.orElse(null))
+  }
+
+  @PostMapping
+  @ApiOperation('Creates a new account definition.')
+  @PreAuthorize('isAuthenticated()')
+  ClouddriverService.AccountDefinition createAccount(
+    @ApiParam('Account definition body including a discriminator field named "@type" with the account type.')
+    @RequestBody ClouddriverService.AccountDefinition accountDefinition
+  ) {
+    clouddriverService.createAccountDefinition(accountDefinition)
+  }
+
+  @PutMapping
+  @ApiOperation('Updates an existing account definition.')
+  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  ClouddriverService.AccountDefinition updateAccount(
+    @ApiParam('Account definition body including a discriminator field named "@type" with the account type.')
+    @RequestBody ClouddriverService.AccountDefinition accountDefinition
+  ) {
+    clouddriverService.updateAccountDefinition(accountDefinition)
+  }
+
+  @DeleteMapping('/{accountName}')
+  @ApiOperation(value = 'Deletes an account definition by name.',
+    notes = 'Deleted accounts can be restored via the update API. Previously deleted accounts cannot be "created" again to avoid conflicts with existing pipelines.')
+  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  void deleteAccount(
+    @ApiParam('Name of account definition to delete.')
+    @PathVariable String accountName
+  ) {
+    clouddriverService.deleteAccountDefinition(accountName)
   }
 }


### PR DESCRIPTION
This adds some of the REST APIs introduced in the experimental account
storage API in Clouddriver to Gate. Initially, these APIs are only
available for admins.

https://github.com/spinnaker/spinnaker/issues/6525

Requires https://github.com/spinnaker/clouddriver/pull/5594
