### PR TITLE
fix(dependency): Issue with jackson-bom and kotlin-bom version conflict resolution while upgrading the spring-boot 2.3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,10 @@ plugins {
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
   id "org.jetbrains.dokka" version "0.10.1" apply false
-  id "io.spring.dependency-management" version "$springDependencyPluginVersion"
 }
 
 allprojects {
   apply plugin: 'io.spinnaker.project'
-  apply plugin: "io.spring.dependency-management"
 
   group = "io.spinnaker.gate"
 
@@ -46,12 +44,6 @@ allprojects {
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
       testRuntimeOnly "org.objenesis:objenesis"
-    }
-
-    dependencyManagement {
-      imports {
-        mavenBom "io.spinnaker.kork:kork-bom:$korkVersion"
-      }
     }
 
     configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
     }
 
     dependencies {
-      implementation platform("io.spinnaker.kork:kork-bom:$korkVersion")
+      implementation enforcedPlatform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
       testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,12 @@ plugins {
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
   id "org.jetbrains.dokka" version "0.10.1" apply false
+  id "io.spring.dependency-management" version "$springDependencyPluginVersion"
 }
 
 allprojects {
   apply plugin: 'io.spinnaker.project'
+  apply plugin: "io.spring.dependency-management"
 
   group = "io.spinnaker.gate"
 
@@ -44,6 +46,12 @@ allprojects {
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
       testRuntimeOnly "org.objenesis:objenesis"
+    }
+
+    dependencyManagement {
+      imports {
+        mavenBom "io.spinnaker.kork:kork-bom:$korkVersion"
+      }
     }
 
     configurations.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ korkVersion=7.131.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.16.0
+springDependencyPluginVersion=1.0.11.RELEASE
 targetJava11=true
 
 # To enable a composite reference to a project, set the

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ korkVersion=7.132.0
 kotlinVersion=1.4.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.16.0
-springDependencyPluginVersion=1.0.11.RELEASE
 targetJava11=true
 
 # To enable a composite reference to a project, set the


### PR DESCRIPTION
Spring boot has moved to gradle based dependency management from v2.3.x. This change has brought issue of conflict resolution failure of the Jackson-bom version and kotlin-bom version with gate service when it consumes the maven-bom generated by kork. The issue details are available in given link.
https://docs.google.com/document/d/1Ck4KeoB1ER0aQUTnf3e-x-M3i2Ur0It7YaaxEMiMXls/edit

To resolve this issue while upgrading gate service with spring v2.3.x, we must require the spring dependency management gradle plugin.