### PR TITLE
fix(gate): Typos in Account Management API

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -46,7 +46,7 @@ public interface ClouddriverService {
   AccountDefinition updateAccountDefinition(@Body AccountDefinition accountDefinition);
 
   @DELETE("/credentials/{account}")
-  void deleteAccountDefinition(@Path("account") String account);
+  Response deleteAccountDefinition(@Path("account") String account);
 
   @GET("/task/{taskDetailsId}")
   Map getTaskDetails(@Path("taskDetailsId") String taskDetailsId);

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/CredentialsController.groovy
@@ -120,7 +120,7 @@ class CredentialsController {
 
   @PutMapping
   @ApiOperation('Updates an existing account definition.')
-  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  @PreAuthorize("hasPermission(#accountDefinition.name, 'ACCOUNT', 'WRITE')")
   @Alpha
   ClouddriverService.AccountDefinition updateAccount(
     @ApiParam('Account definition body including a discriminator field named "@type" with the account type.')
@@ -132,7 +132,7 @@ class CredentialsController {
   @DeleteMapping('/{accountName}')
   @ApiOperation(value = 'Deletes an account definition by name.',
     notes = 'Deleted accounts can be restored via the update API. Previously deleted accounts cannot be "created" again to avoid conflicts with existing pipelines.')
-  @PreAuthorize("hasPermission(#definition.name, 'ACCOUNT', 'WRITE')")
+  @PreAuthorize("hasPermission(#accountName, 'ACCOUNT', 'WRITE')")
   @Alpha
   void deleteAccount(
     @ApiParam('Name of account definition to delete.')


### PR DESCRIPTION
- Fixes a security annotation on the credentials controller.
- Fixes a retrofit error in Clouddriver proxy.