### PR TITLE
fix(gate/web): Add explicit name property to AccountDefinition

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -524,6 +524,7 @@ public interface ClouddriverService {
   class AccountDefinition {
     private final Map<String, Object> details = new HashMap<>();
     private String type;
+    private String name;
 
     @JsonAnyGetter
     public Map<String, Object> details() {
@@ -543,6 +544,14 @@ public interface ClouddriverService {
     @JsonProperty("@type")
     public void setType(String type) {
       this.type = type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
     }
   }
 }


### PR DESCRIPTION
This fixes an authorization check error where Jackson knows how to
handle the `name` property of an account definition, but SpEL does
not see the property. Now the PostFilter annotation should work
equivalently to the same filter check in Clouddriver.

Related to updates for https://github.com/spinnaker/spinnaker/issues/6525