### PR TITLE
fix(image): Add tzdata to set timezone on gate pod

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apk --no-cache add --update bash openjdk11-jre
+RUN apk --no-cache add --update bash openjdk11-jre tzdata
 RUN addgroup -S -g 10111 spinnaker
 RUN adduser -S -G spinnaker -u 10111 spinnaker
 COPY gate-web/build/install/gate /opt/gate

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
+RUN apt-get update && apt-get -y install openjdk-11-jre-headless tzdata wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY gate-web/build/install/gate /opt/gate
 RUN mkdir -p /opt/gate/plugins && chown -R spinnaker:nogroup /opt/gate/plugins


### PR DESCRIPTION
Issue:
Inorder to set timezone on a container, setting it through "TZ" environment variable is one of the ways. However, as tzdata package is not installed on the pod, setting "TZ" environment variable doesn't make any difference.

Solution:
Having "tzdata" package installed on the pod gives the flexibility to the user to simply set "TZ" env var and configurable timezone of the pod for better troubleshooting of the logs.