### PR TITLE
fix(plugins-test): try harder for the version of versionNotSupportedP…

### DIFF
--- a/gate-plugins-test/src/test/kotlin/com/netflix/spinnaker/gate/plugins/test/GatePluginsFixture.kt
+++ b/gate-plugins-test/src/test/kotlin/com/netflix/spinnaker/gate/plugins/test/GatePluginsFixture.kt
@@ -63,7 +63,8 @@ class GatePluginsFixture : PluginsTckFixture, GateTestService() {
     plugins.mkdir()
     enabledPlugin = buildPlugin("com.netflix.gate.enabled.plugin", ">=1.0.0")
     disabledPlugin = buildPlugin("com.netflix.gate.disabled.plugin", ">=1.0.0")
-    versionNotSupportedPlugin = buildPlugin("com.netflix.gate.version.not.supported.plugin", ">=2.0.0")
+    // Make it very unlikely that the version of gate satisfies this requirement
+    versionNotSupportedPlugin = buildPlugin("com.netflix.gate.version.not.supported.plugin", "=0.0.9")
   }
 }
 


### PR DESCRIPTION
…lugin to actually not be supported

Before this, a gate version >= 2.0.0 would cause versionNotSupportedPlugin to get used,
causing tests to fail, and making it impossible to e.g. release gate.
