### PR TITLE
Fix Issue #6675 : CheckPrecondition doesn't evaluate expression correctly when upstream stages get restarted

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -203,6 +203,16 @@ class PipelineController {
   @ApiOperation(value = "Restart a stage execution", response = HashMap.class)
   @PutMapping("/{id}/stages/{stageId}/restart")
   Map restartStage(@PathVariable("id") String id, @PathVariable("stageId") String stageId, @RequestBody Map context) {
+    Map pipelineMap = getPipeline(id)
+    String pipelineName = pipelineMap.get("name");
+    String application = pipelineMap.get("application");
+    List<Map> pipelineConfigs = front50Service.getPipelineConfigsForApplication(application, true)
+    if (pipelineConfigs!=null && !pipelineConfigs.isEmpty()){
+      Optional<Map> filterResult = pipelineConfigs.stream().filter({ pipeline -> ((String) pipeline.get("name")) != null && ((String) pipeline.get("name")).trim().equalsIgnoreCase(pipelineName) }).findFirst()
+      if (filterResult.isPresent()){
+        context = filterResult.get()
+      }
+	}
     pipelineService.restartPipelineStage(id, stageId, context)
   }
 


### PR DESCRIPTION
This PR includes the changes to fix the [issue #6675](https://github.com/spinnaker/spinnaker/issues/6675) 

* Provide a descriptive summary for your changes.
**Issue:** Expression is not considered during restart of pipeline instead it picks the expression result from the previous run
**Fix:** 
The existing `context` passed to `pipelineService.restartPipelineStage(id, stageId, context)` method is not having the pipeline config details to read the expression during restart, to fix this getting the pipelineconfig for an application with specific `@PathVariable("id")` and updating the `context`
