### PR TITLE
chore(dockerfile): upgrade to latest alpine image

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.16
 RUN apk add --update \
     openjdk11 \
     && rm -rf /var/cache/apk

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
 RUN apk --no-cache add --update bash openjdk11-jre
 RUN addgroup -S -g 10111 spinnaker


### PR DESCRIPTION
This resolves a performance issue in JDK11 when Spinnaker is running in
a cluster with containerd.