### PR TITLE
chore(dependencies): remove dependency on groovy-all

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor "org.projectlombok:lombok"
 
-      implementation "org.codehaus.groovy:groovy-all"
+      implementation "org.codehaus.groovy:groovy"
       implementation "net.logstash.logback:logstash-logback-encoder"
       implementation "org.jetbrains.kotlin:kotlin-reflect"
 

--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-security"
+  implementation "org.codehaus.groovy:groovy-json"
   implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
   implementation "org.springframework.session:spring-session-core"
 }

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation "redis.clients:jedis"
 
   implementation "commons-io:commons-io"
+  implementation "org.codehaus.groovy:groovy-templates"
   implementation "org.springframework.session:spring-session-data-redis"
   implementation "de.huxhorn.sulky:de.huxhorn.sulky.ulid"
   implementation "org.apache.commons:commons-lang3"


### PR DESCRIPTION
with a specific goal to get `org.testng:testng:7.4.0` out of shipping code, since it's vulnerable to CVE-2022-4065.
