### PR TITLE
chore(web): clean up for spring property setup

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
 
+  implementation "io.spinnaker.kork:kork-config"
   implementation "io.spinnaker.kork:kork-plugins"
   implementation "io.spinnaker.kork:kork-web"
   implementation "com.netflix.frigga:frigga"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableAsync
+import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder
 
 @EnableAsync
 @EnableConfigurationProperties
@@ -41,15 +42,7 @@ import org.springframework.scheduling.annotation.EnableAsync
 )
 class Main {
 
-  static final Map<String, String> DEFAULT_PROPS = [
-    'netflix.environment': 'test',
-    'netflix.account': '${netflix.environment}',
-    'netflix.stack': 'test',
-    'spring.config.additional-location': '${user.home}/.spinnaker/',
-    'spring.application.name': 'gate',
-    'spring.config.name': 'spinnaker,${spring.application.name}',
-    'spring.profiles.active': '${netflix.environment},local'
-  ]
+  static final Map<String, String> DEFAULT_PROPS = new DefaultPropertiesBuilder().property("spring.application.name", "gate").build()
 
   static void main(String... args) {
     new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main).run(args)


### PR DESCRIPTION
Using `com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder` class to setup spring and other related properties required for the spring boot application to start.
