### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 in gate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ allprojects {
       testImplementation "org.springframework.boot:spring-boot-starter-test"
       testImplementation "org.hamcrest:hamcrest-core"
       testRuntimeOnly "cglib:cglib-nodep"
+      testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
       testRuntimeOnly "org.objenesis:objenesis"
     }
 
@@ -62,6 +63,7 @@ allprojects {
     testLogging {
       exceptionFormat = 'full'
     }
+    useJUnitPlatform()
   }
 }
 

--- a/gate-plugins-test/gate-plugins-test.gradle
+++ b/gate-plugins-test/gate-plugins-test.gradle
@@ -13,9 +13,3 @@ dependencies {
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
-
-test {
-  useJUnitPlatform {
-    includeEngines("junit-jupiter", "junit-vintage")
-  }
-}

--- a/gate-plugins/gate-plugins.gradle
+++ b/gate-plugins/gate-plugins.gradle
@@ -32,7 +32,3 @@ dependencies {
   implementation "org.springframework:spring-web"
   implementation "org.pf4j:pf4j-update"
 }
-
-test {
-  useJUnitPlatform()
-}

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -96,5 +96,4 @@ test {
       }
     }
   }
-  useJUnitPlatform()
 }

--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -30,12 +30,6 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
-test {
-  useJUnitPlatform {
-    includeEngines "junit-jupiter"
-  }
-}
-
 compileTestKotlin {
   kotlinOptions {
     languageVersion = "1.4"


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from spring-boot-starter-test. [https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test] It is required for executing junit4 based test cases in gate. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 74 to 265 test case executions.