### PR TITLE
Adapt for okhttp3 4.x

### DIFF
--- a/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/web/publish/PluginPublishController.kt
+++ b/gate-plugins/src/main/kotlin/com/netflix/spinnaker/gate/plugins/web/publish/PluginPublishController.kt
@@ -28,10 +28,12 @@ import io.swagger.annotations.ApiOperation
 import java.lang.String.format
 import lombok.SneakyThrows
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -92,7 +94,7 @@ class PluginPublishController(
             .addFormDataPart(
               "plugin",
               format("%s-%s.zip", pluginId, pluginVersion),
-              RequestBody.create(MediaType.parse("application/octet-stream"), body)
+              body.toRequestBody(("application/octet-stream").toMediaType())
             )
             .build()
         )
@@ -100,7 +102,7 @@ class PluginPublishController(
 
       val response = okHttpClient.newCall(request).execute()
       if (!response.isSuccessful) {
-        val reason = response.body()?.string() ?: "Unknown reason: ${response.code()}"
+        val reason = response.body?.string() ?: "Unknown reason: ${response.code}"
         throw SystemException("Failed to upload plugin binary: $reason")
       }
     }.call()

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ProxyController.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.security.AuthenticatedRequest
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.internal.http.HttpMethod
+import okhttp3.MediaType.Companion.toMediaType
 import java.net.SocketException
 import java.util.stream.Collectors
 import javax.servlet.http.HttpServletRequest
@@ -120,7 +121,7 @@ class ProxyController(
       .toString()
       .substringAfter("/proxies/$proxyId")
 
-    val proxiedUrlBuilder = Request.Builder().url(proxyConfig.uri + proxyPath).build().url().newBuilder()
+    val proxiedUrlBuilder = Request.Builder().url(proxyConfig.uri + proxyPath).build().url.newBuilder()
     for ((key, value) in requestParams) {
       proxiedUrlBuilder.addQueryParameter(key, value)
     }
@@ -135,7 +136,7 @@ class ProxyController(
 
       val body = if (HttpMethod.permitsRequestBody(method) && request.contentType != null) {
         RequestBody.create(
-          okhttp3.MediaType.parse(request.contentType),
+          request.contentType.toMediaType(),
           request.reader.lines().collect(Collectors.joining(System.lineSeparator()))
         )
       } else {
@@ -145,9 +146,9 @@ class ProxyController(
       val response = proxy.okHttpClient.newCall(
         Request.Builder().url(proxiedUrl).method(method, body).build()
       ).execute()
-      statusCode = response.code()
+      statusCode = response.code
       contentType = response.header("Content-Type") ?: contentType
-      responseBody = response.body()?.string() ?: ""
+      responseBody = response.body?.string() ?: ""
     } catch (e: SocketException) {
       log.error("Exception processing proxy request", e)
       statusCode = HttpStatus.GATEWAY_TIMEOUT.value()


### PR DESCRIPTION
This PR is a follow up on https://github.com/spinnaker/kork/pull/1044, where OkHttp was updated to the latest 4.x version. It was primarily motivated by https://github.com/square/okhttp/issues/6738 and is based on the official upgrade instructions: https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/

