### PR TITLE
fix(web/test): move GateConfigAuthenticatedRequestFilterTest out of the com.netflix.spinnaker.gate.config package

### DIFF
--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/testconfig/GateConfigAuthenticatedRequestFilterTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/testconfig/GateConfigAuthenticatedRequestFilterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.gate.config;
+package com.netflix.spinnaker.gate.testconfig;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;


### PR DESCRIPTION
so it doesn't pollute the spring context in other tests
