### PR TITLE
fix(web/test): remove race in FunctionalSpec

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -109,7 +109,7 @@ class FunctionalSpec extends Specification {
   }
 
   def cleanup() {
-    ctx.close()
+    ctx?.close()
   }
 
   void "should call ApplicationService for applications"() {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -86,11 +86,7 @@ class FunctionalSpec extends Specification {
     serviceConfiguration = new ServiceConfiguration()
     fiatStatus = Mock(FiatStatus)
 
-
-    def sock = new ServerSocket(0)
-    def localPort = sock.localPort
-    sock.close()
-    System.setProperty("server.port", localPort.toString())
+    System.setProperty("server.port", "0") // to get a random port
     System.setProperty("saml.enabled", "false")
     System.setProperty('spring.session.store-type', 'NONE')
     System.setProperty("spring.main.allow-bean-definition-overriding", "true")
@@ -100,6 +96,7 @@ class FunctionalSpec extends Specification {
     spring.setSources([FunctionalConfiguration] as Set)
     ctx = spring.run()
 
+    def localPort = ctx.environment.getProperty("local.server.port")
     api = new RestAdapter.Builder()
         .setEndpoint("http://localhost:${localPort}")
         .setClient(new OkClient())


### PR DESCRIPTION
There's a window in time between closing the socket and starting the server that another
process could use the same port.  Remove this race to prevent failures like:
```
FunctionalSpec > should call ApplicationService for applications FAILED
    org.gradle.internal.exceptions.DefaultMultiCauseException: Multiple Failures (2 failures)
        org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop'; nested exception is org.springframework.boot.web.server.PortInUseException: Port 59629 is already in use
        java.lang.NullPointerException: Cannot invoke method close() on null object
        at org.junit.vintage.engine.execution.TestRun.getStoredResultOrSuccessful(TestRun.java:196)
        at org.junit.vintage.engine.execution.RunListenerAdapter.fireExecutionFinished(RunListenerAdapter.java:226)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:192)
        at org.junit.vintage.engine.execution.RunListenerAdapter.testFinished(RunListenerAdapter.java:79)
        at org.junit.runner.notification.SynchronizedRunListener.testFinished(SynchronizedRunListener.java:87)
        at org.junit.runner.notification.RunNotifier$9.notifyListener(RunNotifier.java:225)
        at org.junit.runner.notification.RunNotifier$SafeNotifier.run(RunNotifier.java:72)
        at org.junit.runner.notification.RunNotifier.fireTestFinished(RunNotifier.java:222)
        at org.spockframework.runtime.JUnitSupervisor.afterFeature(JUnitSupervisor.java:197)
        at org.spockframework.runtime.BaseSpecRunner.runFeature(BaseSpecRunner.java:236)
        at org.spockframework.runtime.BaseSpecRunner.runFeatures(BaseSpecRunner.java:185)
        at org.spockframework.runtime.BaseSpecRunner.doRunSpec(BaseSpecRunner.java:95)
        at org.spockframework.runtime.BaseSpecRunner$1.invoke(BaseSpecRunner.java:81)
        at org.spockframework.runtime.BaseSpecRunner.invokeRaw(BaseSpecRunner.java:484)
        at org.spockframework.runtime.BaseSpecRunner.invoke(BaseSpecRunner.java:467)
        at org.spockframework.runtime.BaseSpecRunner.runSpec(BaseSpecRunner.java:73)
        at org.spockframework.runtime.BaseSpecRunner.run(BaseSpecRunner.java:64)
        at org.spockframework.runtime.Sputnik.run(Sputnik.java:63)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
        at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:82)
        at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:73)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
        at com.sun.proxy.$Proxy2.stop(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:133)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
        at java.base/java.lang.Thread.run(Thread.java:834)

        Caused by:
        org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop'; nested exception is org.springframework.boot.web.server.PortInUseException: Port 59629 is already in use
            at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:181)
            at org.springframework.context.support.DefaultLifecycleProcessor.access$200(DefaultLifecycleProcessor.java:54)
            at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:356)
            at java.base/java.lang.Iterable.forEach(Iterable.java:75)
            at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:155)
            at org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:123)
            at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:935)
            at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:586)
            at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:145)
            at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:780)
            at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:453)
            at org.springframework.boot.SpringApplication.run(SpringApplication.java:343)
            at com.netflix.spinnaker.gate.FunctionalSpec.setup(FunctionalSpec.groovy:101)

            Caused by:
            org.springframework.boot.web.server.PortInUseException: Port 59629 is already in use
                at org.springframework.boot.web.server.PortInUseException.lambda$throwIfPortBindingException$0(PortInUseException.java:70)
                at org.springframework.boot.web.server.PortInUseException.lambda$ifPortBindingException$1(PortInUseException.java:85)
                at org.springframework.boot.web.server.PortInUseException.ifCausedBy(PortInUseException.java:103)
                at org.springframework.boot.web.server.PortInUseException.ifPortBindingException(PortInUseException.java:82)
                at org.springframework.boot.web.server.PortInUseException.throwIfPortBindingException(PortInUseException.java:69)
                at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:228)
                at org.springframework.boot.web.servlet.context.WebServerStartStopLifecycle.start(WebServerStartStopLifecycle.java:43)
                at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:178)
                ... 12 more

                Caused by:
                java.lang.IllegalArgumentException: standardService.connector.startFailed
                    at org.apache.catalina.core.StandardService.addConnector(StandardService.java:238)
                    at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.addPreviouslyRemovedConnectors(TomcatWebServer.java:282)
                    at org.springframework.boot.web.embedded.tomcat.TomcatWebServer.start(TomcatWebServer.java:213)
                    ... 14 more

                    Caused by:
                    org.apache.catalina.LifecycleException: Protocol handler start failed
                        at org.apache.catalina.connector.Connector.startInternal(Connector.java:1076)
                        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
                        at org.apache.catalina.core.StandardService.addConnector(StandardService.java:234)
                        ... 16 more

                        Caused by:
                        java.net.BindException: Address already in use
                            at java.base/sun.nio.ch.Net.bind(Net.java:455)
                            at java.base/sun.nio.ch.Net.bind(Net.java:447)
                            at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
                            at org.apache.tomcat.util.net.NioEndpoint.initServerSocket(NioEndpoint.java:275)
                            at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:230)
                            at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1227)
                            at org.apache.tomcat.util.net.AbstractEndpoint.start(AbstractEndpoint.java:1313)
                            at org.apache.coyote.AbstractProtocol.start(AbstractProtocol.java:615)
                            at org.apache.catalina.connector.Connector.startInternal(Connector.java:1073)
                            ... 18 more
```