### PR TITLE
fix(config): Exception in fresh development environment (LocalGit)

### DIFF
--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -47,6 +47,7 @@ services:
     enabled: false
   fiat:
     enabled: false
+    baseUrl: http://localhost:7003
   flapjack:
     enabled: false
   igor:


### PR DESCRIPTION
After following the guide below in a fresh development environment (LocalGit):
https://spinnaker.io/docs/community/contributing/code/developer-guides/dev-env/getting-set-up/

I got:
`BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.fiat.shared.FiatService]: Factory method 'fiatService' threw exception`

When I run `./gradlew run`