### PR TITLE
feat(artifacts): Add new ArtifactStore endpoints

### DIFF
--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -21,6 +21,7 @@ dependencies {
 
   api "com.squareup.retrofit:retrofit"
 
+  implementation "io.spinnaker.kork:kork-artifacts"
   implementation "io.spinnaker.kork:kork-plugins"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
   implementation "com.squareup.retrofit:converter-jackson"

--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.plugins.SpinnakerPluginDescriptor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -399,6 +400,10 @@ public interface ClouddriverService {
 
   @GET("/installedPlugins")
   List<SpinnakerPluginDescriptor> getInstalledPlugins();
+
+  @GET("/artifacts/content-address/{application}/{hash}")
+  Artifact.StoredView getStoredArtifact(
+      @Path("application") String application, @Path("hash") String hash);
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
 
+  implementation "io.spinnaker.kork:kork-artifacts"
+  implementation "io.spinnaker.kork:kork-core"
   implementation "io.spinnaker.kork:kork-config"
   implementation "io.spinnaker.kork:kork-plugins"
   implementation "io.spinnaker.kork:kork-web"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ArtifactController.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.controllers;
 
 import com.netflix.spinnaker.gate.services.ArtifactService;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import io.swagger.annotations.ApiOperation;
 import java.io.InputStream;
 import java.util.List;
@@ -96,5 +97,13 @@ public class ArtifactController {
       @PathVariable String packageName,
       @PathVariable String version) {
     return artifactService.getArtifactByVersion(provider, packageName, version);
+  }
+
+  @ApiOperation(value = "Retrieve artifact by content hash")
+  @RequestMapping(value = "/content-address/{application}/{hash}", method = RequestMethod.GET)
+  Artifact.StoredView getStoredArtifact(
+      @PathVariable(value = "application") String application,
+      @PathVariable(value = "hash") String hash) {
+    return artifactService.getStoredArtifact(application, hash);
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ArtifactService.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gate.services;
 
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
 import com.netflix.spinnaker.gate.services.internal.IgorService;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import groovy.transform.CompileStatic;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,6 +58,10 @@ public class ArtifactService {
   public InputStream getArtifactContents(String selectorKey, Map<String, String> artifact)
       throws IOException {
     return clouddriverServiceSelector.select().getArtifactContent(artifact).getBody().in();
+  }
+
+  public Artifact.StoredView getStoredArtifact(String application, String hash) {
+    return clouddriverServiceSelector.select().getStoredArtifact(application, hash);
   }
 
   public List<String> getVersionsOfArtifactForProvider(


### PR DESCRIPTION
This commit adds new endpoints and connections to the various services that require direct retrieval of the artifact, eg deck will now lazily load by calling the gate fetch artifact endpoint.

Depends on https://github.com/spinnaker/clouddriver/pull/5976
