### PR TITLE
refactor(tests): convert junit4 based test cases to junit5 and clean up in gate

### DIFF
--- a/gate-core/src/test/java/com/netflix/spinnaker/gate/services/TaskServiceTest.java
+++ b/gate-core/src/test/java/com/netflix/spinnaker/gate/services/TaskServiceTest.java
@@ -23,14 +23,14 @@ import com.netflix.spinnaker.gate.services.internal.OrcaService;
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {TaskService.class, TaskServiceProperties.class})
 public class TaskServiceTest {
 

--- a/gate-plugins-test/gate-plugins-test.gradle
+++ b/gate-plugins-test/gate-plugins-test.gradle
@@ -10,6 +10,5 @@ dependencies {
   testImplementation("io.spinnaker.kork:kork-plugins")
   testImplementation("io.spinnaker.kork:kork-plugins-tck")
 
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }


### PR DESCRIPTION
Before refactor, total test cases executed were 266. 
After refactor, total test cases executed are 266.
