### PR TITLE
fix(saml): upgrading esapi:2.2.1.0 for CVE-2016-1000031

### DIFF
--- a/gate-saml/gate-saml.gradle
+++ b/gate-saml/gate-saml.gradle
@@ -10,4 +10,8 @@ dependencies{
 
   implementation "org.springframework.security.extensions:spring-security-saml2-core"
   implementation "org.springframework.security.extensions:spring-security-saml-dsl-core"
+
+  constraints {
+    api("org.owasp.esapi:esapi:2.2.1.0")
+  }
 }


### PR DESCRIPTION
We are adding a constraint because there is no fix in `spring-security-saml2-core` for `CVE-2016-1000031`
We are testing locally and we are testing in production before removing the label `do not merge`
We created a docker image, we scanned that image using aquasec, and validated that the CVE is gone
This dependency only exists in gate, that's why we do not add the constrain in kork
related to https://github.com/spinnaker/gate/pull/1694
