### PR TITLE
fix(spring/profile): fix the profile property to be processed by spring boot 2.4+

### DIFF
--- a/gate-plugins/src/test/resources/gate-test.yml
+++ b/gate-plugins/src/test/resources/gate-test.yml
@@ -30,7 +30,9 @@ services:
 ---
 
 spring:
-  profiles: test
+  config:
+    activate:
+      on-profile: test
 
 spinnaker:
   extensions:

--- a/gate-web/config/gate.yml
+++ b/gate-web/config/gate.yml
@@ -118,7 +118,9 @@ spring.session.store-type: redis
 ---
 
 spring:
-  profiles: googleOAuth
+  config:
+    activate:
+      on-profile: googleOAuth
 
 security:
   oauth2:
@@ -139,7 +141,9 @@ security:
 ---
 
 spring:
-  profiles: azureOAuth
+  config:
+    activate:
+      on-profile: azureOAuth
 
 security:
   oauth2:
@@ -162,7 +166,9 @@ security:
 ---
 
 spring:
-  profiles: githubOAuth
+  config:
+    activate:
+      on-profile: githubOAuth
 
 security:
   oauth2:

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -37,7 +37,9 @@ slack:
 ---
 
 spring:
-  profiles: alloworigincors
+  config:
+    activate:
+      on-profile: alloworigincors
 
 cors:
   allow-mode: "list"
@@ -48,7 +50,9 @@ cors:
 ---
 
 spring:
-  profiles: regexcors
+  config:
+    activate:
+      on-profile: regexcors
 
 cors:
   allowedOriginsPattern: '^https?://(?:localhost|[^/]+\.somewhere\.net)(?::[1-9]\d*)?/?$'
@@ -57,7 +61,9 @@ cors:
 ---
 
 spring:
-  profiles: test
+  config:
+    activate:
+      on-profile: test
 
 spinnaker:
   extensions:


### PR DESCRIPTION
For spring boot 2.4+, config file processing of profile specific document will consider `spring.config.activate.on-profile` property. As described in this blog: https://spring.io/blog/2020/08/14/config-file-processing-in-spring-boot-2-4
