### PR TITLE
refactor(web/test): replace assert with assertThat and introduce explicit mocks

### DIFF
--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
@@ -1,10 +1,18 @@
 package com.netflix.spinnaker.gate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.fiat.shared.FiatService;
+import com.netflix.spinnaker.gate.services.ApplicationService;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import com.netflix.spinnaker.gate.services.internal.ExtendedFiatService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -14,11 +22,22 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ActiveProfiles("test")
 @TestPropertySource(properties = {"spring.config.location=classpath:gate-test.yml"})
 public class MainSpec {
+  @MockBean private ClouddriverService mockClouddriverService;
 
-  @Autowired ServiceClientProvider serviceClientProvider;
+  @MockBean private ServiceClientProvider serviceClientProvider;
+
+  @MockBean private ApplicationService mockApplicationService;
+
+  @MockBean private PermissionService mockPermissionService;
+
+  @MockBean private FiatService mockFiatService;
+
+  @MockBean private ExtendedFiatService mockExtendedFiatService;
+
+  @MockBean private Front50Service mockFront50Service;
 
   @Test
   public void startupTest() {
-    assert serviceClientProvider != null;
+    assertThat(serviceClientProvider != null);
   }
 }

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ArtifactControllerTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/ArtifactControllerTest.java
@@ -28,9 +28,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
+import com.netflix.spinnaker.gate.services.PermissionService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
+import com.netflix.spinnaker.gate.services.internal.ExtendedFiatService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Map;
@@ -61,6 +67,18 @@ public class ArtifactControllerTest {
   @MockBean private ClouddriverServiceSelector mockClouddriverServiceSelector;
 
   @MockBean private ClouddriverService mockClouddriverService;
+
+  @MockBean private Front50Service mockFront50Service;
+
+  @MockBean private FiatService mocFiatService;
+
+  @MockBean private ExtendedFiatService mockExtendedFiatService;
+
+  @MockBean private PermissionService mockPermissionService;
+
+  @MockBean private ApplicationService mockApplicationService;
+
+  @MockBean private ServiceClientProvider mockServiceClientProvider;
 
   @MockBean private InputStream mockInputStream;
 

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/interceptors/ResponseHeaderInterceptorTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/interceptors/ResponseHeaderInterceptorTest.java
@@ -24,7 +24,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import com.netflix.spinnaker.gate.services.internal.ExtendedFiatService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import com.netflix.spinnaker.kork.common.Header;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
 import java.util.EnumSet;
@@ -34,6 +41,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -51,6 +59,20 @@ public class ResponseHeaderInterceptorTest {
   private static final String TEST_EXECUTION_ID = "Test-Execution-ID";
   private static final String TEST_EXECUTION_TYPE = "Test-Execution-Type";
   private static final String TEST_APPLICATION = "Test-Application";
+
+  @MockBean private ClouddriverService mockClouddriverService;
+
+  @MockBean private ServiceClientProvider mockServiceClientProvider;
+
+  @MockBean private ApplicationService mockApplicationService;
+
+  @MockBean private PermissionService mockPermissionService;
+
+  @MockBean private FiatService mockFiatService;
+
+  @MockBean private ExtendedFiatService mockExtendedFiatService;
+
+  @MockBean private Front50Service mockFront50Service;
 
   @RestController
   @RequestMapping(value = API_BASE)

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/testconfig/GateConfigAuthenticatedRequestFilterTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/testconfig/GateConfigAuthenticatedRequestFilterTest.java
@@ -27,7 +27,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 import ch.qos.logback.classic.Level;
+import com.netflix.spinnaker.fiat.shared.FiatService;
 import com.netflix.spinnaker.gate.Main;
+import com.netflix.spinnaker.gate.services.ApplicationService;
+import com.netflix.spinnaker.gate.services.PermissionService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverService;
+import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector;
+import com.netflix.spinnaker.gate.services.internal.ExtendedFiatService;
+import com.netflix.spinnaker.gate.services.internal.Front50Service;
+import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import com.netflix.spinnaker.kork.common.Header;
 import com.netflix.spinnaker.kork.test.log.MemoryAppender;
 import com.netflix.spinnaker.security.AuthenticatedRequest;
@@ -38,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -60,6 +69,22 @@ public class GateConfigAuthenticatedRequestFilterTest {
 
   private static final String LOG_MESSAGE = " logged in api: ";
   private static final String NULL_VALUE = "null";
+
+  @MockBean private ServiceClientProvider mockServiceClientProvider;
+
+  @MockBean private ClouddriverService mockClouddriverService;
+
+  @MockBean private ClouddriverServiceSelector mockClouddriverServiceSelector;
+
+  @MockBean private ApplicationService mockApplicationService;
+
+  @MockBean private FiatService mockFiatService;
+
+  @MockBean private PermissionService mockPermissionService;
+
+  @MockBean private ExtendedFiatService mockExtendedFiatService;
+
+  @MockBean private Front50Service mockFront50Service;
 
   @RestController
   @RequestMapping(value = API_BASE)


### PR DESCRIPTION
Used assertThat() to cleanup junit4 linkages. Introduced explicit mocks to reduce dependence on `spockframework`/`groovy` transformations used by groovy based test under same package. Test coverage remain same before and after refactor (Tests executed 268).
