### PR TITLE
chore(dependency): add explicit dependency of groovy-json in gate-web while upgrading groovy 3.x

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -73,6 +73,7 @@ dependencies {
   testImplementation "com.unboundid:unboundid-ldapsdk"
   testImplementation "io.spinnaker.kork:kork-jedis-test"
   testImplementation "io.spinnaker.kork:kork-test"
+  testImplementation "org.codehaus.groovy:groovy-json"
   testRuntimeOnly "io.spinnaker.kork:kork-retrofit"
 
   // Add each included authz provider as a runtime dependency


### PR DESCRIPTION
With groovy 2.5.15 and spockframework 1.3-groovy-2.5, groovy-json appear as transitive dependency of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/1.3-groovy-2.5) as shown below:
```
$ ./gradlew gate-web:dI --dependency groovy-json --configuration testCompileClasspath

> Task :gate-web:dependencyInsight
org.codehaus.groovy:groovy-json:2.5.15
  Variant compile:
    | Attribute Name                 | Provided | Requested         |
    |--------------------------------|----------|-------------------|
    | org.gradle.status              | release  |                   |
    | org.gradle.category            | library  | library           |
    | org.gradle.libraryelements     | jar      | classes+resources |
    | org.gradle.usage               | java-api | java-api          |
    | org.gradle.dependency.bundling |          | external          |
    | org.gradle.jvm.environment     |          | standard-jvm      |
    | org.gradle.jvm.version         |          | 11                |
   Selection reasons:
      - By constraint
      - Forced

org.codehaus.groovy:groovy-json:2.5.15
\--- io.spinnaker.kork:kork-bom:7.190.0
     \--- testCompileClasspath

org.codehaus.groovy:groovy-json:2.5.4 -> 2.5.15
+--- org.spockframework:spock-core:1.3-groovy-2.5
|    +--- testCompileClasspath (requested org.spockframework:spock-core)
|    +--- io.spinnaker.kork:kork-bom:7.190.0
|    |    \--- testCompileClasspath
|    \--- org.spockframework:spock-spring:1.3-groovy-2.5
|         +--- testCompileClasspath (requested org.spockframework:spock-spring)
|         \--- io.spinnaker.kork:kork-bom:7.190.0 (*)
\--- org.spockframework:spock-spring:1.3-groovy-2.5 (*)
```
While upgrading groovy 3.0.10 and spockframework 2.0-groovy-3.0, groovy-json is not part of [spockframework](https://mvnrepository.com/artifact/org.spockframework/spock-core/2.0-groovy-3.0) and and encounter below error during test compilation:
```
> Task :gate-web:compileTestGroovy FAILED
startup failed:
/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/ApplicationControllerSpec.groovy: 22: unable to resolve class groovy.json.JsonSlurper
 @ line 22, column 1.
   import groovy.json.JsonSlurper
   ^

/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/BuildControllerSpec.groovy: 23: unable to resolve class groovy.json.JsonSlurper
 @ line 23, column 1.
   import groovy.json.JsonSlurper
   ^

/gate/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/EcsClusterControllerSpec.groovy: 22: unable to resolve class groovy.json.JsonSlurper
 @ line 22, column 1.
   import groovy.json.JsonSlurper
   ^

3 errors

```
So, adding explicit dependency of groovy-json in gate-web.gradle