### PR TITLE
JRE 17 config for Gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -72,3 +74,28 @@ jobs:
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-unvalidated-ubuntu"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-unvalidated-ubuntu"
+      - name: Build and publish slim JRE 11 container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-java11-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-java11-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11-unvalidated-slim"
+      - name: Build and publish ubuntu JRE 11 container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.ubuntu
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest-java11-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11-unvalidated-ubuntu"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Prepare build variables
@@ -51,3 +53,23 @@ jobs:
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-ubuntu"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-ubuntu"
+      - name: Build slim JRE 11 container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.slim
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-java11"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-java11-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11-slim"
+      - name: Build ubuntu JRE 11 container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.ubuntu
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest-java11-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}-java11-ubuntu"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: |
+            17
+            11
           distribution: 'zulu'
           cache: 'gradle'
       - name: Assemble release info
@@ -108,6 +110,31 @@ jobs:
           tags: |
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-unvalidated-ubuntu"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-${{ steps.build_variables.outputs.VERSION }}-unvalidated-ubuntu"
+      - name: Build and publish slim JRE 11 container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.slim
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-java11-unvalidated"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-java11-unvalidated-slim"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-${{ steps.build_variables.outputs.VERSION }}-java11-unvalidated-slim"
+      - name: Build and publish ubuntu JRE 11 container image
+        # Only run this on repositories in the 'spinnaker' org, not on forks.
+        if: startsWith(github.repository, 'spinnaker/')
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.java11.ubuntu
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-java11-unvalidated-ubuntu"
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.release_info.outputs.RELEASE_VERSION }}-${{ steps.build_variables.outputs.VERSION }}-java11-unvalidated-ubuntu"
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: softprops/action-gh-release@v1

--- a/Dockerfile.java11.slim
+++ b/Dockerfile.java11.slim
@@ -1,7 +1,8 @@
-FROM ubuntu:bionic
+FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget
-RUN adduser --system --uid 10111 --group spinnaker
+RUN apk --no-cache add --update bash openjdk11-jre
+RUN addgroup -S -g 10111 spinnaker
+RUN adduser -S -G spinnaker -u 10111 spinnaker
 COPY gate-web/build/install/gate /opt/gate
 RUN mkdir -p /opt/gate/plugins && chown -R spinnaker:nogroup /opt/gate/plugins
 USER spinnaker

--- a/Dockerfile.java11.ubuntu
+++ b/Dockerfile.java11.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget
+RUN apt-get update && apt-get -y install openjdk-11-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY gate-web/build/install/gate /opt/gate
 RUN mkdir -p /opt/gate/plugins && chown -R spinnaker:nogroup /opt/gate/plugins

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,6 +1,6 @@
 FROM alpine:3.16
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apk --no-cache add --update bash openjdk11-jre
+RUN apk --no-cache add --update bash openjdk17-jre
 RUN addgroup -S -g 10111 spinnaker
 RUN adduser -S -G spinnaker -u 10111 spinnaker
 COPY gate-web/build/install/gate /opt/gate

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,17 @@ allprojects {
     }
   }
 
+  tasks.withType(JavaCompile).configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+      languageVersion = JavaLanguageVersion.of(11)
+    }
+  }
+  tasks.withType(Test).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(17)
+    }
+  }
+
   tasks.withType(JavaExec) {
     if (System.getProperty('DEBUG', 'false') == 'true') {
       jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8184'

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -41,6 +41,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import retrofit.RetrofitError
 import retrofit.RestAdapter;
 import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
 import retrofit.mime.TypedInput
 import spock.lang.Shared
 import spock.lang.Specification
@@ -100,6 +101,7 @@ class FunctionalSpec extends Specification {
     api = new RestAdapter.Builder()
         .setEndpoint("http://localhost:${localPort}")
         .setClient(new OkClient())
+        .setConverter(new JacksonConverter())
         .setLogLevel(RestAdapter.LogLevel.FULL)
         .build()
         .create(Api)

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
@@ -30,6 +30,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.util.NestedServletException
 import retrofit.RestAdapter
 import retrofit.client.OkClient
+import retrofit.converter.JacksonConverter
 import spock.lang.Specification
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -54,6 +55,7 @@ class WebhooksControllerSpec extends Specification {
     EchoService echoService = new RestAdapter.Builder()
       .setEndpoint("http://localhost:${localPort}")
       .setClient(new OkClient())
+      .setConverter(new JacksonConverter())
       .build()
       .create(EchoService)
 


### PR DESCRIPTION
* Add boilerplate to run tests with JRE 17 + build JRE 17 images.
* Add Jackson converters to `RestAdapter`s that don't have one already.
* Refactor a test case to not mock `Files`.