### PR TITLE
refactor(web): fix groovy compilation failure due to missing type conversions during upgrade to springboot 2.5.15

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.config.PluginsAutoConfiguration
+import com.netflix.spinnaker.config.ServiceEndpoint
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
@@ -216,7 +217,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
       //     priority: 2
       //     origin: deck
 
-      def defaultSelector = new DefaultServiceSelector(
+      ServiceSelector defaultSelector = new DefaultServiceSelector(
         defaultClouddriverService,
         1,
         null)
@@ -317,7 +318,7 @@ class GateConfig extends RedisHttpSessionConfiguration {
   }
 
   private <T> T buildService(String serviceName, Class<T> type, Endpoint endpoint) {
-    ObjectMapper objectMapper = objectMapperBuilder.build()
+    ObjectMapper objectMapper = objectMapperBuilder.build() as ObjectMapper
     if(serviceName.equals("echo")) {
       objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }


### PR DESCRIPTION
While upgrading springboot 2.5.15, encounter below error in gate-web module:
```
startup failed:
/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy: 231: [Static type checking] - Cannot call com.netflix.spinnaker.kork.web.selector.SelectableService#<init>(java.util.List <com.netflix.spinnaker.kork.web.selector.ServiceSelector>) with arguments [java.util.List <? extends com.netflix.spinnaker.kork.web.selector.ServiceSelector>]
 @ line 231, column 9.
           new SelectableService(selectors + defaultSelector), dynamicConfigService, contextProvider)
           ^

/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy: 322: [Static type checking] - Cannot find matching method java.lang.Object#configure(com.fasterxml.jackson.databind.SerializationFeature, boolean). Please check if the declared type is correct and if the method exists.
 @ line 322, column 7.
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         ^

/gate/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy: 324: [Static type checking] - Cannot find matching method com.netflix.spinnaker.kork.client.ServiceClientProvider#getService(java.lang.Class <T>, com.netflix.spinnaker.config.DefaultServiceEndpoint, T). Please check if the declared type is correct and if the method exists.
 @ line 324, column 5.
       serviceClientProvider.getService(type, new DefaultServiceEndpoint(serviceName, endpoint.url), objectMapper)
       ^

3 errors

> Task :gate-web:compileGroovy FAILED
```
To fix this, explicitly mentioned the type of object reference as `ServiceSelector defaultSelector` and typecasted the object `objectMapperBuilder.build() as ObjectMapper`.