### PR TITLE
Update PermissionService.java

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
@@ -77,7 +77,7 @@ public class PermissionService {
       try {
         AuthenticatedRequest.allowAnonymous(
             () -> {
-              getFiatServiceForLogin().loginUser(userId, null);
+              getFiatServiceForLogin().loginUser(userId, "");
               permissionEvaluator.invalidatePermission(userId);
               return null;
             });


### PR DESCRIPTION
[fiat login service](https://github.com/spinnaker/fiat/blob/b64c9ea249bd262c84a7421faf071cabdd3fdf77/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatService.java#L103) does not accept `null` as a valid Body param.
Issue was introduced in a [refactor](https://github.com/spinnaker/gate/pull/1663) from `groovy` to `java` file.

Related Issue:
https://github.com/spinnaker/spinnaker/issues/6887