### PR TITLE
fix(core): RetrofitError thrown on login

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/PermissionService.java
@@ -77,7 +77,9 @@ public class PermissionService {
       try {
         AuthenticatedRequest.allowAnonymous(
             () -> {
-              getFiatServiceForLogin().loginUser(userId, null);
+              // TODO(jvz): FiatService::loginUser should have only one parameter as Retrofit no
+              // longer requires this body parameter
+              getFiatServiceForLogin().loginUser(userId, "");
               permissionEvaluator.invalidatePermission(userId);
               return null;
             });


### PR DESCRIPTION
This fixes a regression from when PermissionService was converted from Groovy to Java. Ideally, we'd remove the extra parameter from FiatService directly, but that requires patching Fiat first, something that'll be easier to do when we migrate to the monorepo.

Fixes [#6887](https://github.com/spinnaker/spinnaker/issues/6887).