### PR TITLE
fix: Fix git trigger issue caused by a misconfig of the object mapper when creating the echo retrofit service

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.gate.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.DefaultServiceEndpoint
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration
 import com.netflix.spinnaker.config.PluginsAutoConfiguration
-import com.netflix.spinnaker.config.ServiceEndpoint
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
@@ -318,9 +318,11 @@ class GateConfig extends RedisHttpSessionConfiguration {
   }
 
   private <T> T buildService(String serviceName, Class<T> type, Endpoint endpoint) {
-    ObjectMapper objectMapper = objectMapperBuilder.build() as ObjectMapper
+    ObjectMapper objectMapper = new ObjectMapper();
     if(serviceName.equals("echo")) {
-      objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+      objectMapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .registerModule(new JavaTimeModule())
     }
     serviceClientProvider.getService(type, new DefaultServiceEndpoint(serviceName, endpoint.url), objectMapper)
   }


### PR DESCRIPTION
Because of the misconfiguration echo was failing with GitEventHandler  : Github Digest mismatch! Pipeline NOT triggered

Github webhook delivery 
![image](https://github.com/spinnaker/spinnaker/assets/105648914/3856cea9-86f5-4e90-aeec-bb6d3c8fb8f2)

Spinnaker pipeline setup

Spinnaker pipeline triggered when the event is received
![image](https://github.com/spinnaker/spinnaker/assets/105648914/c1127d0c-b068-4794-87d4-02e5b89f41bb)
Closes https://github.com/spinnaker/spinnaker/issues/6886
