### PR TITLE
fix(test/core): refactor constructor by passing context to HttpSecurity instance updated with spring boot 2.6.x

### DIFF
--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
@@ -18,15 +18,20 @@ package com.netflix.spinnaker.gate.config
 
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatStatus
+import org.springframework.context.ApplicationContext
 import org.springframework.security.config.annotation.ObjectPostProcessor
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.util.matcher.AnyRequestMatcher
+import org.springframework.context.support.GenericApplicationContext
 import spock.lang.Specification
 
 import java.util.stream.Collectors
 
 class AuthConfigTest extends Specification {
+
+  private GenericApplicationContext context = new GenericApplicationContext()
+
   @SuppressWarnings("GroovyAccessibility")
   def "test webhooks are unauthenticated by default"() {
     given:
@@ -44,7 +49,7 @@ class AuthConfigTest extends Specification {
     def httpSecurity = new HttpSecurity(
       Mock(ObjectPostProcessor),
       Mock(AuthenticationManagerBuilder),
-      [:]
+      getSharedObjects()
     )
 
     when:
@@ -79,7 +84,7 @@ class AuthConfigTest extends Specification {
     def httpSecurity = new HttpSecurity(
       Mock(ObjectPostProcessor),
       Mock(AuthenticationManagerBuilder),
-      [:]
+      getSharedObjects()
     )
 
     when:
@@ -94,5 +99,12 @@ class AuthConfigTest extends Specification {
       })
       .collect(Collectors.toList())
     filtered.size() == 1
+  }
+
+  private HashMap<Class<?>, Object> getSharedObjects(){
+    HashMap map = new HashMap<Class<?>, Object>()
+    context.refresh()
+    map.put(ApplicationContext.class, context)
+    return map;
   }
 }


### PR DESCRIPTION
While upgrading spring boot 2.6.15 and spring cloud 2021.0.8, encounter below errors during execution of tests under gate-core modules:
```
Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
java.lang.NullPointerException: Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
	at org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer.<init>(ExpressionUrlAuthorizationConfigurer.java:109)
	at org.springframework.security.config.annotation.web.builders.HttpSecurity.authorizeRequests(HttpSecurity.java:1265)
	at com.netflix.spinnaker.gate.config.AuthConfig.configure(AuthConfig.java:76)
	at com.netflix.spinnaker.gate.config.AuthConfigTest.test webhooks are unauthenticated by default(AuthConfigTest.groovy:51)

Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
java.lang.NullPointerException: Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
	at org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer.<init>(ExpressionUrlAuthorizationConfigurer.java:109)
	at org.springframework.security.config.annotation.web.builders.HttpSecurity.authorizeRequests(HttpSecurity.java:1265)
	at com.netflix.spinnaker.gate.config.AuthConfig.configure(AuthConfig.java:76)
	at com.netflix.spinnaker.gate.config.AuthConfigTest.test webhooks can be configured to be authenticated(AuthConfigTest.groovy:86)
```
As per the reference given [here](https://stackoverflow.com/questions/71322261/nullpointerexception-at-org-springframework-security-config-annotation-web-confi), the implementation of spring-security-config got changed from 5.5.x to 5.6.x and it must require the ApplicationContext object. So, in order to fix this issue added a map containing ApplicationContext.class and its object to the constructor.