### PR TITLE
fix(redis): circular dependencies

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
-import com.netflix.spinnaker.gate.config.PostConnectionConfiguringJedisConnectionFactory.ConnectionPostProcessor
 import com.netflix.spinnaker.gate.converters.JsonHttpMessageConverter
 import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
 import com.netflix.spinnaker.gate.filters.RequestLoggingFilter
@@ -124,13 +123,6 @@ class GateConfig extends RedisHttpSessionConfiguration {
   @Bean
   @Primary
   ConfigureRedisAction springBootConfigureRedisAction() {
-    return ConfigureRedisAction.NO_OP
-  }
-
-  @Bean
-  @ConnectionPostProcessor
-  @ConditionalOnProperty("redis.configuration.secure")
-  ConfigureRedisAction connectionPostProcessorConfigureRedisAction() {
     return ConfigureRedisAction.NO_OP
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisConfigSecure.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisConfigSecure.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import com.netflix.spinnaker.gate.config.PostConnectionConfiguringJedisConnectionFactory.ConnectionPostProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+@Configuration
+@ConditionalOnProperty("redis.configuration.secure")
+public class RedisConfigSecure {
+
+  @Bean
+  @ConnectionPostProcessor
+  public ConfigureRedisAction connectionPostProcessorConfigureRedisAction() {
+    return ConfigureRedisAction.NO_OP;
+  }
+}


### PR DESCRIPTION
gate is failing with the following error when you set `redis.configuration.secure=true`

```
***************************
APPLICATION FAILED TO START
***************************

Description:

The dependencies of some of the beans in the application context form a cycle:

┌─────┐
|  gateConfig defined in file [/Users/nemesis/opsmx/source/oss/gate/gate-web/build/classes/groovy/main/com/netflix/spinnaker/gate/config/GateConfig.class]
↑     ↓
|  postConnectionConfiguringJedisConnectionFactory defined in file [/Users/nemesis/opsmx/source/oss/gate/gate-web/build/classes/groovy/main/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.class]
└─────┘
```
