### PR TITLE
chore(dependency): pin graphql-java to avoid version bump during upgrade to spring boot 2.7.x

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -49,6 +49,9 @@ dependencies {
 
   implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1"
   implementation "com.graphql-java-kickstart:graphql-java-tools:6.0.2"
+  implementation ("com.graphql-java:graphql-java:14.0") { // To avoid version bump with spring boot 2.7.x upgrade.
+      force = true					   // Unpin it after adoption of spring-boot-starter-graphql
+   }
 
   implementation "io.springfox:springfox-swagger2"
 


### PR DESCRIPTION
In spring boot 2.7.x, support for spring-graphql project has been introduced with a new starter `spring-boot-starter-graphql`.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#new-spring-graphql-starter

Spring boot 2.7.x bring `com.graphql-java:graphql-java:18.5` as its transitive dependency.

https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.18/spring-boot-dependencies-2.7.18.pom

Since the existing `com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1` and `com.graphql-java-kickstart:graphql-java-tools:6.0.2` use graphql-java:14.0, pinning the graphql-java version to 14.0 till the adoption of new `spring-boot-starter-graphql`.