### PR TITLE
refactor(test): fix scope of setup method while upgrading junit to 5.9.0

### DIFF
--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/interceptors/ResponseHeaderInterceptorTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/interceptors/ResponseHeaderInterceptorTest.java
@@ -84,7 +84,7 @@ public class ResponseHeaderInterceptorTest {
   private MockMvc mockMvc;
 
   @BeforeEach
-  private void setup() {
+  void setup() {
     AuthenticatedRequest.clear();
   }
 
@@ -100,7 +100,7 @@ public class ResponseHeaderInterceptorTest {
     @Autowired private WebApplicationContext webApplicationContext;
 
     @BeforeEach
-    private void setup() {
+    void setup() {
       mockMvc = webAppContextSetup(webApplicationContext).build();
     }
 
@@ -171,7 +171,7 @@ public class ResponseHeaderInterceptorTest {
     @Autowired private WebApplicationContext webApplicationContext;
 
     @BeforeEach
-    private void setup() {
+    void setup() {
       mockMvc = webAppContextSetup(webApplicationContext).build();
     }
 
@@ -211,7 +211,7 @@ public class ResponseHeaderInterceptorTest {
     @Autowired private WebApplicationContext webApplicationContext;
 
     @BeforeEach
-    private void setup() {
+    void setup() {
       mockMvc = webAppContextSetup(webApplicationContext).build();
     }
 


### PR DESCRIPTION
While upgrading junit to 5.9.0, encountered below error during test execution of gate-web module:
```
@BeforeEach method 'private void com.netflix.spinnaker.gate.interceptors.ResponseHeaderInterceptorTest.setup()' must not be private.
org.junit.platform.commons.JUnitException: @BeforeEach method 'private void com.netflix.spinnaker.gate.interceptors.ResponseHeaderInterceptorTest.setup()' must not be private.
        at org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.assertNonPrivate(LifecycleMethodUtils.java:104)
        at org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.lambda$findMethodsAndAssertNonStaticAndNonPrivate$2(LifecycleMethodUtils.java:74)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1092)
        at org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findMethodsAndAssertNonStaticAndNonPrivate(LifecycleMethodUtils.java:72)
        at org.junit.jupiter.engine.descriptor.LifecycleMethodUtils.findBeforeEachMethods(LifecycleMethodUtils.java:50)
        at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.registerBeforeEachMethodAdapters(ClassBasedTestDescriptor.java:478)
        at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.prepare(ClassBasedTestDescriptor.java:174)
        at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.prepare(ClassBasedTestDescriptor.java:84)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$2(NodeTestTask.java:123)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:123)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:90)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
        at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
        at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
        at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```
The root cause of this issue is breaking change brought in 5.9.0 to private lifecycle methods (annotated with `@BeforeAll`, `@AfterAll`, `@BeforeEach`, or `@AfterEach`) leading to an exception. 
https://junit.org/junit5/docs/5.9.0/release-notes/index.html#deprecations-and-breaking-changes-2 
To fix this issue changed the scope of setup method from private to generic.
