### PR TITLE
Pipeline config batch update

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/TaskService.java
@@ -127,6 +127,53 @@ public class TaskService {
     return task;
   }
 
+  public Map bulkCreateAndWaitForCompletion(Map body, int maxPolls, int intervalMs) {
+    log.info("Bulk Creating and waiting for completion: " + body);
+
+    if (body.containsKey("application")) {
+      AuthenticatedRequest.setApplication(body.get("application").toString());
+    }
+
+    Map createResult = create(body);
+    if (createResult.get("ref") == null) {
+      log.warn("No ref field found in create result, returning entire result: " + createResult);
+      return createResult;
+    }
+
+    String taskId = ((String) createResult.get("ref")).split("/")[2];
+    log.info("Create succeeded; polling task for completion: " + taskId);
+
+    LinkedHashMap<String, String> map = new LinkedHashMap<String, String>(1);
+    map.put("id", taskId);
+    Map task = map;
+    for (int i = 0; i < maxPolls; i++) {
+      try {
+        Thread.sleep(intervalMs);
+      } catch (InterruptedException ignored) {
+      }
+
+      task = getTask(taskId);
+      if (new ArrayList<>(Arrays.asList("SUCCEEDED", "TERMINAL"))
+          .contains((String) task.get("status"))) {
+        List<Map<String, String>> bulksaveTasks = (List<Map<String, String>>) task.get("steps");
+        long count = 0;
+        if (bulksaveTasks != null && !bulksaveTasks.isEmpty()) {
+          count =
+              bulksaveTasks.stream()
+                  .filter(
+                      hashmap ->
+                          ("SUCCEEDED".equals((String) hashmap.get("status"))
+                              || "TERMINAL".equals((String) hashmap.get("status"))))
+                  .count();
+        }
+        if (count == 2) {
+          return task;
+        }
+      }
+    }
+    return task;
+  }
+
   public Map createAndWaitForCompletion(Map body, int maxPolls) {
     return createAndWaitForCompletion(body, maxPolls, 1000);
   }
@@ -136,6 +183,10 @@ public class TaskService {
         body,
         taskServiceProperties.getMaxNumberOfPolls(),
         taskServiceProperties.getDefaultIntervalBetweenPolls());
+  }
+
+  public Map bulkCreateAndWaitForCompletion(Map body) {
+    return bulkCreateAndWaitForCompletion(body, 300, 1000);
   }
 
   /** @deprecated This pipeline operation does not belong here. */

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatService
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
+import com.netflix.spinnaker.gate.config.controllers.PipelineControllerConfigProperties
 import com.netflix.spinnaker.gate.converters.JsonHttpMessageConverter
 import com.netflix.spinnaker.gate.converters.YamlHttpMessageConverter
 import com.netflix.spinnaker.gate.filters.RequestLoggingFilter
@@ -51,6 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -71,6 +73,7 @@ import static retrofit.Endpoints.newFixedEndpoint
 @CompileStatic
 @Configuration
 @Slf4j
+@EnableConfigurationProperties([PipelineControllerConfigProperties.class])
 @Import([PluginsAutoConfiguration, DeckPluginConfiguration, PluginWebConfiguration])
 class GateConfig {
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.gate.config.controllers.PipelineControllerConfigProperties
 import com.netflix.spinnaker.gate.filters.ContentCachingFilter
 import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.ResponseHeaderInterceptor
@@ -48,7 +47,7 @@ import javax.servlet.http.HttpServletResponse
 
 @Configuration
 @ComponentScan
-@EnableConfigurationProperties([ResponseHeaderInterceptorConfigurationProperties.class, PipelineControllerConfigProperties.class])
+@EnableConfigurationProperties(ResponseHeaderInterceptorConfigurationProperties.class)
 public class GateWebConfig implements WebMvcConfigurer {
   @Autowired
   Registry registry

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateWebConfig.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.config
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.gate.config.controllers.PipelineControllerConfigProperties
 import com.netflix.spinnaker.gate.filters.ContentCachingFilter
 import com.netflix.spinnaker.gate.interceptors.RequestContextInterceptor
 import com.netflix.spinnaker.gate.interceptors.ResponseHeaderInterceptor
@@ -47,7 +48,7 @@ import javax.servlet.http.HttpServletResponse
 
 @Configuration
 @ComponentScan
-@EnableConfigurationProperties(ResponseHeaderInterceptorConfigurationProperties.class)
+@EnableConfigurationProperties([ResponseHeaderInterceptorConfigurationProperties.class, PipelineControllerConfigProperties.class])
 public class GateWebConfig implements WebMvcConfigurer {
   @Autowired
   Registry registry

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/controllers/PipelineControllerConfigProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/controllers/PipelineControllerConfigProperties.java
@@ -1,0 +1,18 @@
+package com.netflix.spinnaker.gate.config.controllers;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "controller.pipeline")
+public class PipelineControllerConfigProperties {
+
+  /** Holds the configurations to be used for bulk save controller mapping */
+  private BulkSaveConfigProperties bulksave = new BulkSaveConfigProperties();
+
+  @Data
+  public static class BulkSaveConfigProperties {
+    private int maxPollsForTaskCompletion = 300;
+    private int taskCompletionCheckIntervalMs = 2000;
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -125,6 +125,43 @@ class PipelineController {
     }
   }
 
+  @CompileDynamic
+  @ApiOperation(value = "Save an array of pipeline definition")
+  @PostMapping('/bulksave')
+  Map bulksavePipeline(
+    @RequestBody List<Map> pipelineList,
+    @RequestParam(value = "staleCheck", required = false, defaultValue = "false")
+      Boolean staleCheck) {
+
+    def retData = []
+    def operation = [
+      description: "bulk save pipeline",
+      application: "bulk save application",
+      job        : [
+        [
+          type      : "savePipeline",
+          pipeline  : (String) Base64.encoder.encodeToString(objectMapper.writeValueAsString(pipelineList).getBytes("UTF-8")),
+          user      : AuthenticatedRequest.spinnakerUser.orElse("anonymous"),
+          staleCheck: staleCheck,
+          bulksave  : true
+        ]
+      ]
+    ]
+
+    def result = taskService.bulkCreateAndWaitForCompletion(operation)
+    String resultStatus = result.get("status")
+
+    if (!"SUCCEEDED".equalsIgnoreCase(resultStatus)) {
+      String exception = result.variables.find { it.key == "exception" }?.value?.details?.errors?.getAt(0)
+      throw new PipelineException(
+        exception ?: "Pipeline bulk save operation did not succeed: ${result.get("id", "unknown task id")} (status: ${resultStatus})"
+      )
+    } else {
+      retData = result.variables.find { it.key == "bulksave"}?.value
+    }
+    return retData
+  }
+
   @ApiOperation(value = "Rename a pipeline definition")
   @PostMapping('move')
   void renamePipeline(@RequestBody Map renameCommand) {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.config.ErrorConfiguration
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
+import com.netflix.spinnaker.gate.config.controllers.PipelineControllerConfigProperties
 import com.netflix.spinnaker.gate.controllers.ApplicationController
 import com.netflix.spinnaker.gate.controllers.PipelineController
 import com.netflix.spinnaker.gate.services.*
@@ -39,7 +40,7 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import retrofit.RetrofitError
-import retrofit.RestAdapter;
+import retrofit.RestAdapter
 import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 import retrofit.mime.TypedInput
@@ -285,6 +286,11 @@ class FunctionalSpec extends Specification {
         dynamicConfigService,
         fiatClientConfigurationProperties
       )
+    }
+
+    @Bean
+    PipelineControllerConfigProperties pipelineControllerConfigProperties() {
+      new PipelineControllerConfigProperties();
     }
 
     @Override


### PR DESCRIPTION
This is part of: https://github.com/spinnaker/spinnaker/issues/6147.

Adds a new enpdoint, POST /pipelines/bulksave, which can take a list of pipeline configurations to save. The endpoint will return a response that indicates how many of the saves were successful, how many failed, and what the failures are. The structure is
```
[
   "successful_pipelines_count"  : <int>,
   "successful_pipelines"        : <List<String>>,
   "failed_pipelines_count"      : <int>,
   "failed_pipelines"            : <List<Map<String, Object>>> 
]
```

There are a few config knobs which control some bulk save functionality. The gate endpoint invokes an orca asynchronous process to manage saving the pipelines and polls until the orca operations are complete.

```yaml
controller:
  pipeline:
    bulksave:
      # the max number of times gate will poll orca to check for task status
      max-polls-for-task-completion: <int>
      # the interval at which gate will poll orca.
      taskCompletionCheckIntervalMs: <int>
```
See related PRs in front50 and orca
https://github.com/spinnaker/orca/pull/4773, https://github.com/spinnaker/front50/pull/1483