### PR TITLE
feat(web): add a config property that allows front50 to be the source of truth for applications

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/ApplicationConfigurationProperties.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/ApplicationConfigurationProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Salesforce.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "application")
+public class ApplicationConfigurationProperties {
+  /**
+   * defaults to false. When enabled, this will ignore all the applications that are only known to
+   * clouddriver but are missing from front50. This is done so that we can treat front50 as the
+   * source of truth for applications
+   */
+  private boolean useFront50AsSourceOfTruth;
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -73,7 +73,7 @@ import static retrofit.Endpoints.newFixedEndpoint
 @CompileStatic
 @Configuration
 @Slf4j
-@EnableConfigurationProperties([PipelineControllerConfigProperties.class])
+@EnableConfigurationProperties([PipelineControllerConfigProperties, ApplicationConfigurationProperties])
 @Import([PluginsAutoConfiguration, DeckPluginConfiguration, PluginWebConfiguration])
 class GateConfig {
 

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -16,15 +16,17 @@
 
 package com.netflix.spinnaker.gate
 
+import com.netflix.spinnaker.gate.config.ApplicationConfigurationProperties
 import com.netflix.spinnaker.gate.config.Service
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
-import spock.lang.Shared
+import retrofit.RetrofitError
+import retrofit.client.Response
+import retrofit.mime.TypedByteArray
 import spock.lang.Specification
-import spock.lang.Subject
 import spock.lang.Unroll
 
 import java.util.concurrent.Executors
@@ -36,27 +38,31 @@ class ApplicationServiceSpec extends Specification {
     select() >> clouddriver
   }
 
-  @Subject
-  def service = applicationService()
-
   private applicationService() {
-    def service = new ApplicationService()
+    applicationService(new ApplicationConfigurationProperties())
+  }
+
+  private applicationService(ApplicationConfigurationProperties applicationConfigurationProperties) {
     def config = new ServiceConfiguration(services: [front50: new Service()])
-
-    service.serviceConfiguration = config
-    service.front50Service = front50
-    service.clouddriverServiceSelector = clouddriverSelector
-    service.executorService = Executors.newFixedThreadPool(1)
-
+    def service = new ApplicationService(
+      config,
+      clouddriverSelector,
+      front50,
+      Executors.newFixedThreadPool(1),
+      applicationConfigurationProperties
+    )
     return service
   }
 
-  void "should properly aggregate application data from Front50 and Clouddriver"() {
+  void "should properly aggregate application data from Front50 and Clouddriver when useFront50AsSourceOfTruth: #useFront50AsSourceOfTruth"() {
     given:
     def clouddriverApp = [name: name, attributes: [clouddriverName: name, name: "bad"], clusters: [(account): [cluster]]]
     def front50App = [name: name, email: email, owner: owner, accounts: account]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(useFront50AsSourceOfTruth)
 
     when:
+    def service = applicationService(applicationConfigurationProperties)
     def app = service.getApplication(name, true)
 
     then:
@@ -66,6 +72,7 @@ class ApplicationServiceSpec extends Specification {
     app == [name: name, attributes: (clouddriverApp.attributes + front50App), clusters: clouddriverApp.clusters]
 
     where:
+    useFront50AsSourceOfTruth << [true, false]
     name = "foo"
     email = "bar@baz.bz"
     owner = "danw"
@@ -74,12 +81,138 @@ class ApplicationServiceSpec extends Specification {
     providerType = "aws"
   }
 
-  void "should ignore accounts from front50 and only include those from clouddriver clusters"() {
+  @Unroll
+  void "when UseFront50AsSourceOfTruth: #checkFront50 and application exists only in clouddriver"() {
+    given:
+    def clouddriverApp = [name: name, attributes: [clouddriverName: name, name: "bad"], clusters: [(account): [cluster]]]
+    def front50App = [:]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    def app = service.getApplication(name, true)
+
+    then:
+    1 * front50.getApplication(name) >> front50App
+
+    numberOfClouddriverInvocations * clouddriver.getApplication(name) >> clouddriverApp
+
+    assert app == result
+
+    where:
+    checkFront50 | numberOfClouddriverInvocations | result
+    true         | 0                              | null
+    false        | 1                              | [name:"foo", attributes:[clouddriverName:"foo", name:"foo", accounts: "test"], clusters:["test":["cluster1"]]]
+
+    name = "foo"
+    email = "bar@baz.bz"
+    owner = "danw"
+    cluster = "cluster1"
+    account = "test"
+    providerType = "aws"
+  }
+
+  @Unroll
+  void "when UseFront50AsSourceOfTruth: #checkFront50 and application exists only in clouddriver, but front50 throws an exception"() {
+    given:
+    def clouddriverApp = [name: name, attributes: [clouddriverName: name, name: "bad"], clusters: [(account): [cluster]]]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    def app = service.getApplication(name, true)
+
+    then:
+    1 * front50.getApplication(name) >> exception
+
+    numberOfClouddriverInvocations * clouddriver.getApplication(name) >> clouddriverApp
+
+    assert app == result
+
+    where:
+    checkFront50 | numberOfClouddriverInvocations | result | exception
+    true         | 0                              | null   | new Exception("fatal exception")
+    true         | 0                              | null   | retrofit404()
+    false        | 1                              | [name:"foo", attributes:[clouddriverName:"foo", name:"foo", accounts: "test"], clusters:["test":["cluster1"]]] | new Exception("fatal exception")
+    false        | 1                              | [name:"foo", attributes:[clouddriverName:"foo", name:"foo", accounts: "test"], clusters:["test":["cluster1"]]] | retrofit404()
+
+    name = "foo"
+    email = "bar@baz.bz"
+    owner = "danw"
+    cluster = "cluster1"
+    account = "test"
+    providerType = "aws"
+  }
+
+  @Unroll
+  void "when UseFront50AsSourceOfTruth: #checkFront50 and application exists only in front50, but clouddriver throws an exception"() {
+    given:
+    def front50App = [name: name, email: email, owner: owner, accounts: account]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    def app = service.getApplication(name, true)
+
+    then:
+    1 * front50.getApplication(name) >> front50App
+    1 * clouddriver.getApplication(name) >> exception
+
+    assert app == [name: name, attributes:[name: name, email: email, owner: owner, accounts: account], clusters:[:]]
+
+    where:
+    checkFront50 | exception
+    true         | new Exception("fatal exception")
+    true         | retrofit404()
+    false        | new Exception("fatal exception")
+    false        | retrofit404()
+
+    name = "foo"
+    email = "bar@baz.bz"
+    owner = "danw"
+    cluster = "cluster1"
+    account = "test"
+    providerType = "aws"
+  }
+
+  @Unroll
+  void "when UseFront50AsSourceOfTruth: #checkFront50 and both front50 and clouddriver throw an exception"() {
+    given:
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    def app = service.getApplication(name, true)
+
+    then:
+    1 * front50.getApplication(name) >> exception
+    numberOfClouddriverInvocations * clouddriver.getApplication(name) >> exception
+
+    assert app == null
+
+    where:
+    checkFront50 | numberOfClouddriverInvocations | exception
+    true         | 0                              | new Exception("fatal exception")
+    true         | 0                              | retrofit404()
+    false        | 1                              | new Exception("fatal exception")
+    false        | 1                              | retrofit404()
+
+    name = "foo"
+  }
+
+  void "should ignore accounts from front50 and only include those from clouddriver clusters when UseFront50AsSourceOfTruth: #checkFront50"() {
     given:
     def clouddriverApp = [name: name, attributes: [clouddriverName: name, name: "bad"], clusters: [(clouddriverAccount): [cluster]]]
     def front50App = [name: name, email: email, owner: owner, accounts: front50Account]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
 
     when:
+    def service = applicationService()
     def app = service.getApplication(name, true)
 
     then:
@@ -89,6 +222,7 @@ class ApplicationServiceSpec extends Specification {
     app == [name: name, attributes: (clouddriverApp.attributes + front50App + [accounts: [clouddriverAccount].toSet().sort().join(',')]), clusters: clouddriverApp.clusters]
 
     where:
+    checkFront50 << [true, false]
     name = "foo"
     email = "bar@baz.bz"
     owner = "danw"
@@ -101,9 +235,14 @@ class ApplicationServiceSpec extends Specification {
   @Unroll
   void "should return null when application account does not match includedAccounts"() {
     setup:
-    def serviceWithDifferentConfig = applicationService()
     def config = new ServiceConfiguration(services: [front50: new Service(config: [includedAccounts: includedAccount])])
-    serviceWithDifferentConfig.serviceConfiguration = config
+    ApplicationService serviceWithDifferentConfig = new ApplicationService(
+      config,
+      clouddriverSelector,
+      front50,
+      Executors.newFixedThreadPool(1),
+      new ApplicationConfigurationProperties()
+    )
 
     when:
     def app = serviceWithDifferentConfig.getApplication(name, true)
@@ -131,6 +270,7 @@ class ApplicationServiceSpec extends Specification {
 
   void "should return null when no application attributes are available"() {
     when:
+    def service = applicationService()
     def app = service.getApplication(name, true)
 
     then:
@@ -150,6 +290,7 @@ class ApplicationServiceSpec extends Specification {
     def front50App = [name: name.toLowerCase(), email: email]
 
     when:
+    def service = applicationService()
     service.refreshApplicationsCache()
     def apps = service.getAllApplications()
 
@@ -175,6 +316,7 @@ class ApplicationServiceSpec extends Specification {
     def front50App = [name: name.toLowerCase(), email: email, accounts: "test"]
 
     when:
+    def service = applicationService()
     service.refreshApplicationsCache()
     def apps = service.getAllApplications()
 
@@ -194,6 +336,119 @@ class ApplicationServiceSpec extends Specification {
   }
 
   @Unroll
+  def "should properly merge accounts for retrieved apps with clusterNames when useFront50AsSourceOfTruth is #checkFront50"() {
+    given:
+    def clouddriverApp1 = [name: "appname1", attributes: [name: "appname1"], clusterNames: [prod: ["cluster-prod"]]]
+    def clouddriverApp2 = [name: "appname2", attributes: [name: "appname2"], clusterNames: [dev: ["cluster-dev"]]]
+    def front50App = [name: "appname1", email:  "foo@bar.bz", accounts: "test"]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    service.refreshApplicationsCache()
+    def apps = service.getAllApplications()
+
+    then:
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> [clouddriverApp1, clouddriverApp2]
+    1 * front50.getAllApplicationsUnrestricted() >> [front50App]
+
+    assert apps.size() == resultSize
+    assert apps == result
+
+    where:
+    checkFront50 | resultSize | result
+    true         | 1          | [[name:"appname1", email:"foo@bar.bz", accounts:"prod"]]
+    false        | 2          | [[name:"appname1", email:"foo@bar.bz", accounts:"prod"], [name:"appname2", accounts:"dev"]]
+  }
+
+  @Unroll
+  def "should handle front50 returning an exception when useFront50AsSourceOfTruth is #checkFront50"() {
+    given:
+    def clouddriverApp1 = [name: "appname1", attributes: [name: "appname1"], clusterNames: [prod: ["cluster-prod"]]]
+    def clouddriverApp2 = [name: "appname2", attributes: [name: "appname2"], clusterNames: [dev: ["cluster-dev"]]]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    service.refreshApplicationsCache()
+    def apps = service.getAllApplications()
+
+    then:
+    1 * front50.getAllApplicationsUnrestricted() >> exception
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> [clouddriverApp1, clouddriverApp2]
+
+    assert apps.size() == resultSize
+    assert apps == result
+
+    where:
+    checkFront50 | resultSize | result                                                                  | exception
+    true         | 0          | []                                                                      | new Exception("fatal exception")
+    true         | 0          | []                                                                      | retrofit404()
+    false        | 2          | [[name:"appname1", accounts:"prod"], [name:"appname2", accounts:"dev"]] | new Exception("fatal exception")
+    false        | 2          | [[name:"appname1", accounts:"prod"], [name:"appname2", accounts:"dev"]] | retrofit404()
+  }
+
+  @Unroll
+  def "should handle clouddriver returning an exception when useFront50AsSourceOfTruth is #checkFront50"() {
+    given:
+    def front50App = [name: name, email:  email, accounts: account]
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    service.refreshApplicationsCache()
+    def apps = service.getAllApplications()
+
+    then:
+    1 * front50.getAllApplicationsUnrestricted() >> [front50App]
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> exception
+
+    assert apps.size() == 1
+    assert apps == [[name: name, email: email, accounts: account]]
+
+    where:
+    checkFront50 | exception
+    true         | new Exception("fatal exception")
+    true         | retrofit404()
+    false        | new Exception("fatal exception")
+    false        | retrofit404()
+
+    name = "appname1"
+    email = "foo@bar.bz"
+    account = "test"
+  }
+
+  @Unroll
+  def "should handle both front50 and clouddriver returning an exception when useFront50AsSourceOfTruth is #checkFront50"() {
+    given:
+    ApplicationConfigurationProperties applicationConfigurationProperties = new ApplicationConfigurationProperties()
+    applicationConfigurationProperties.setUseFront50AsSourceOfTruth(checkFront50)
+
+    when:
+    def service = applicationService(applicationConfigurationProperties)
+    service.refreshApplicationsCache()
+    def apps = service.getAllApplications()
+
+    then:
+    1 * front50.getAllApplicationsUnrestricted() >> exception
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> exception
+
+    assert apps.size() == 0
+
+    where:
+
+    checkFront50 | exception
+    true         | new Exception("fatal exception")
+    true         | retrofit404()
+    false        | new Exception("fatal exception")
+    false        | retrofit404()
+
+  }
+
+  @Unroll
   void "should merge accounts"() {
     expect:
     ApplicationService.mergeAccounts(accounts1, accounts2) == mergedAccounts
@@ -210,6 +465,7 @@ class ApplicationServiceSpec extends Specification {
   @Unroll
   void "should return pipeline config based on name or id"() {
     when:
+    def service = applicationService()
     def result = service.getPipelineConfigForApplication(app, nameOrId) != null
 
     then:
@@ -229,7 +485,7 @@ class ApplicationServiceSpec extends Specification {
     given:
     def name = 'myApp'
     def serviceWithApplicationsCache = applicationService()
-    serviceWithApplicationsCache.allApplicationsCache.set([
+    serviceWithApplicationsCache.getAllApplicationsCache().set([
         [name: name, email: "cached@email.com"]
     ])
 
@@ -246,5 +502,9 @@ class ApplicationServiceSpec extends Specification {
     }
 
     app.attributes.email == "updated@email.com"
+  }
+
+  def retrofit404(){
+    RetrofitError.httpError("http://localhost", new Response("http://localhost", 404, "Not Found", [], new TypedByteArray("application/json", new byte[0])), null, Map)
   }
 }

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -125,7 +125,7 @@ class ApplicationServiceSpec extends Specification {
     def app = service.getApplication(name, true)
 
     then:
-    1 * front50.getApplication(name) >> exception
+    1 * front50.getApplication(name) >> { throw exception }
 
     numberOfClouddriverInvocations * clouddriver.getApplication(name) >> clouddriverApp
 
@@ -159,7 +159,7 @@ class ApplicationServiceSpec extends Specification {
 
     then:
     1 * front50.getApplication(name) >> front50App
-    1 * clouddriver.getApplication(name) >> exception
+    1 * clouddriver.getApplication(name) >> { throw exception }
 
     assert app == [name: name, attributes:[name: name, email: email, owner: owner, accounts: account], clusters:[:]]
 
@@ -189,8 +189,8 @@ class ApplicationServiceSpec extends Specification {
     def app = service.getApplication(name, true)
 
     then:
-    1 * front50.getApplication(name) >> exception
-    numberOfClouddriverInvocations * clouddriver.getApplication(name) >> exception
+    1 * front50.getApplication(name) >> { throw exception }
+    numberOfClouddriverInvocations * clouddriver.getApplication(name) >> { throw exception }
 
     assert app == null
 
@@ -376,7 +376,7 @@ class ApplicationServiceSpec extends Specification {
     def apps = service.getAllApplications()
 
     then:
-    1 * front50.getAllApplicationsUnrestricted() >> exception
+    1 * front50.getAllApplicationsUnrestricted() >> { throw exception }
     1 * clouddriver.getAllApplicationsUnrestricted(true) >> [clouddriverApp1, clouddriverApp2]
 
     assert apps.size() == resultSize
@@ -404,7 +404,7 @@ class ApplicationServiceSpec extends Specification {
 
     then:
     1 * front50.getAllApplicationsUnrestricted() >> [front50App]
-    1 * clouddriver.getAllApplicationsUnrestricted(true) >> exception
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> { throw exception }
 
     assert apps.size() == 1
     assert apps == [[name: name, email: email, accounts: account]]
@@ -433,8 +433,8 @@ class ApplicationServiceSpec extends Specification {
     def apps = service.getAllApplications()
 
     then:
-    1 * front50.getAllApplicationsUnrestricted() >> exception
-    1 * clouddriver.getAllApplicationsUnrestricted(true) >> exception
+    1 * front50.getAllApplicationsUnrestricted() >> { throw exception }
+    1 * clouddriver.getAllApplicationsUnrestricted(true) >> { throw exception }
 
     assert apps.size() == 0
 


### PR DESCRIPTION
This PR is to address the issue of UI showing synthetic applications created by Spinnaker itself which are unknown to Front50. 

Clouddriver creates these synthetic applications when it is caching resources in a cluster. If the account doesn’t have `onlySpinnakerManaged` set to true, it will create an application using the first part of the manifest name. i.e. a deployment with a name of test-abc will result in an application called test being created.

Through https://github.com/spinnaker/clouddriver/pull/5777, Clouddriver is equipped with discarding caching manifests whose application name(derived from moniker) doesn't exist in front50 but in spite of this, synthetic applications can exist in the following scenarios:
1. When `kubernetes.checkApplicationInFront50` is not enabled in clouddriver
2. If any resources already cached (and created synthetic applications) before enabling `kubernetes.checkApplicationInFront50` in clouddriver.

This PR makes sure that when gate is queried for the applications list, it gets the applications from front50 and clouddriver, and only considers the applications returned from front50 to be the source of truth.

It introduces the following property now in Gate, which when enabled discards all the applications that are obtained from clouddriver which are not known to front50.

```yaml
application.useFront50AsSourceOfTruth: true # defaults to false
```

