### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
       annotationProcessor "org.projectlombok:lombok"
       testAnnotationProcessor "org.projectlombok:lombok"
 
-      implementation "org.codehaus.groovy:groovy"
+      implementation "org.apache.groovy:groovy"
       implementation "net.logstash.logback:logstash-logback-encoder"
       implementation "org.jetbrains.kotlin:kotlin-reflect"
 

--- a/gate-oauth2/gate-oauth2.gradle
+++ b/gate-oauth2/gate-oauth2.gradle
@@ -4,7 +4,7 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-security"
-  implementation "org.codehaus.groovy:groovy-json"
+  implementation "org.apache.groovy:groovy-json"
   implementation "org.springframework.security.oauth.boot:spring-security-oauth2-autoconfigure"
   implementation "org.springframework.session:spring-session-core"
 }

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation "redis.clients:jedis"
 
   implementation "commons-io:commons-io"
-  implementation "org.codehaus.groovy:groovy-templates"
+  implementation "org.apache.groovy:groovy-templates"
   implementation "org.springframework.session:spring-session-data-redis"
   implementation "de.huxhorn.sulky:de.huxhorn.sulky.ulid"
   implementation "org.apache.commons:commons-lang3"
@@ -76,7 +76,7 @@ dependencies {
   testImplementation "com.unboundid:unboundid-ldapsdk"
   testImplementation "io.spinnaker.kork:kork-jedis-test"
   testImplementation "io.spinnaker.kork:kork-test"
-  testImplementation "org.codehaus.groovy:groovy-json"
+  testImplementation "org.apache.groovy:groovy-json"
   testRuntimeOnly "io.spinnaker.kork:kork-retrofit"
 
   // Add each included authz provider as a runtime dependency


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions.