### PR TITLE
refactor(web/test): remove hard-coded port numbers from EchoServiceTest

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -67,6 +67,7 @@ dependencies {
   testImplementation project(":gate-ldap") // TODO: Move system tests to own module
   testImplementation project(":gate-basic")
   testImplementation project(":gate-oauth2")
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
   testImplementation "com.squareup.okhttp:mockwebserver"
 
   testImplementation "com.squareup.retrofit:retrofit-mock"

--- a/gate-web/src/test/resources/application-echo.properties
+++ b/gate-web/src/test/resources/application-echo.properties
@@ -15,30 +15,24 @@
 #
 
 spring.application.name=gate
-services.clouddriver.baseUrl=http://localhost:7002
-services.deck.baseUrl=http://localhost:9000
 
 services.echo.enabled=true
-services.echo.baseUrl=http://localhost:8089
 
 services.fiat.enabled=false
-
-services.fiat.baseUrl=http://localhost:8082
-
-services.front50.baseUrl=http://localhost:8081
+services.fiat.baseUrl=http://nowhere
 
 services.igor.enabled=false
 
 services.kayenta.enabled=false
 
 
-services.orca.baseUrl=http://localhost:8083
+services.orca.baseUrl=http://nowhere
 
 services.mine.enabled=false
 
 services.swabbie.enabled=false
 services.keel.enabled=false
-services.keel.baseUrl=http://localhost:8087
+services.keel.baseUrl=http://nowhere
 
 retrofit.enabled=true
 healthCheckableServices=igor


### PR DESCRIPTION
so the test can pass when these ports are in-use:
```
EchoServiceTest > initializationError FAILED
    java.net.BindException: Address already in use
        at java.base/sun.nio.ch.Net.bind0(Native Method)
        at java.base/sun.nio.ch.Net.bind(Net.java:555)
        at java.base/sun.nio.ch.Net.bind(Net.java:544)
        at java.base/sun.nio.ch.NioSocketImpl.bind(NioSocketImpl.java:648)
        at java.base/java.net.ServerSocket.bind(ServerSocket.java:393)
        at com.squareup.okhttp.mockwebserver.MockWebServer.start(MockWebServer.java:354)
        at com.squareup.okhttp.mockwebserver.MockWebServer.start(MockWebServer.java:337)
        at com.squareup.okhttp.mockwebserver.MockWebServer.start(MockWebServer.java:324)
        at com.netflix.spinnaker.gate.service.EchoServiceTest.setUp(EchoServiceTest.java:57)
```
While we're at it, also convert from
junit4 which com.squareup.okhttp.mockwebserver.MockWebServer uses, to junit5, which wiremock uses.
