### PR TITLE
perf(web): Query for individual pipelines

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
@@ -44,6 +44,13 @@ public interface Front50Service {
   List<Map> getPipelineConfigsForApplication(
       @Path("app") String app, @Query("refresh") boolean refresh);
 
+  @GET("/pipelines/{app}/name/{name}")
+  Map getPipelineConfigByApplicationAndName(
+      @Path("app") String app, @Path("name") String name, @Query("refresh") boolean refresh);
+
+  @GET("/pipelines/{id}/get")
+  Map getPipelineConfigById(@Path("id") String id);
+
   @DELETE("/pipelines/{app}/{name}")
   Response deletePipelineConfig(@Path("app") String app, @Path("name") String name);
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.gate.services.PipelineService
 import com.netflix.spinnaker.gate.services.TaskService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.kork.exceptions.HasAdditionalAttributes
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
@@ -324,12 +325,9 @@ class PipelineController {
     AuthenticatedRequest.setApplication(application)
     try {
       pipelineService.trigger(application, pipelineNameOrId, trigger)
+    } catch (SpinnakerException e) {
+      throw e.newInstance(triggerFailureMessage(application, pipelineNameOrId, e));
     } catch (RetrofitError e) {
-      // If spinnakerRetrofitErrorHandler were registered as a "real" error handler, the code here would look something like
-      //
-      // } catch (SpinnakerException e) {
-      //   throw new e.newInstance(triggerFailureMessage(application, pipelineNameOrId, e));
-      // }
       throw spinnakerRetrofitErrorHandler.handleError(e, {
         exception -> triggerFailureMessage(application, pipelineNameOrId, exception) });
     }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -336,7 +336,7 @@ class PipelineController {
   }
 
   private String triggerFailureMessage(String application, String pipelineNameOrId, Throwable e) {
-    String.format("Unable to trigger pipeline (application: %s, pipelineId: %s). Error: %s",
+    String.format("Unable to trigger pipeline (application: %s, pipelineNameOrId: %s). Error: %s",
         value("application", application), value("pipelineId", pipelineNameOrId), e.getMessage())
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -22,11 +22,15 @@ import com.netflix.spinnaker.gate.config.ServiceConfiguration
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerRetrofitErrorHandler
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -53,6 +57,25 @@ class ApplicationService {
   private AtomicReference<List<Map>> allApplicationsCache
   private ApplicationConfigurationProperties applicationConfigurationProperties
 
+  /**
+   * Adjusting the front50Service and other retrofit objects for communicating
+   * with downstream services means changing RetrofitServiceFactory in kork and
+   * so it affects more than gate.  Front50 uses that code to communicate with
+   * echo.  Front50 doesn't currently do any special exception handling when it
+   * calls echo.  Gate does a ton though, and so it would be a big change to
+   * adjust all the catching of RetrofitError into catching
+   * SpinnakerHttpException, etc. as appropriate.
+   *
+   * Even if RetrofitServiceFactory were configurable by service type, so only
+   * gate's Front50Service used SpinnakerRetrofitErrorHandler, it would still be
+   * a big change, affecting gate-iap and gate-oauth2 where there's code that
+   * uses front50Service but checks for RetrofitError.
+   *
+   * To limit the scope of the change to getPipelineConfigForApplication, construct a
+   * spinnakerRetrofitErrorHandler and use it directly.
+   */
+  final SpinnakerRetrofitErrorHandler spinnakerRetrofitErrorHandler
+
   @Autowired
   ApplicationService(
     ServiceConfiguration serviceConfiguration,
@@ -66,6 +89,7 @@ class ApplicationService {
     this.applicationConfigurationProperties = applicationConfigurationProperties
     this.executorService = Executors.newCachedThreadPool()
     this.allApplicationsCache = new AtomicReference<>([])
+    this.spinnakerRetrofitErrorHandler = SpinnakerRetrofitErrorHandler.newInstance()
   }
 
   // used in tests
@@ -156,7 +180,7 @@ class ApplicationService {
    *
    * @param app the application of the pipeline
    * @param pipelineNameOrId the name or id of the pipeline
-   * @return the pipeline configuration, or null if not found
+   * @return the pipeline configuration, or throws an exception if not found
    */
   Map getPipelineConfigForApplication(String app, String pipelineNameOrId) {
     // Since the argument can be a pipeline name or id, handle both cases.
@@ -170,11 +194,23 @@ class ApplicationService {
       log.error("front50 query for a pipeline with name ${pipelineNameOrId} in application ${app} returned a pipeline named ${pipelineConfig.name}")
       // Tempting to return null here, but querying by id might work, so give it a shot.
     } catch (RetrofitError e) {
-      if ((e.getKind() == RetrofitError.Kind.HTTP) && (e.response.status == 404)) {
+      // If spinnakerRetrofitErrorHandler were registered as a "real" error handler, the code here would look something like
+      //
+      // } catch (SpinnakeHttpException e) {
+      //   if (e.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
+      //     ...
+      //   }
+      // }
+      Throwable throwable = spinnakerRetrofitErrorHandler.handleError(e);
+      if (throwable instanceof SpinnakerHttpException && throwable.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
         log.info("front50 returned no pipeline with name ${pipelineNameOrId} in application ${app}")
         // fall through to try querying by id
       } else {
-        throw e
+        // It's a pretty arbitrary choice whether to throw e or throwable here
+        // since PipelineController.invokePipelineConfig handles both.  May as
+        // well throw throwable to avoid converting the RetrofitError to a
+        // Spinnaker*Exception again.
+        throw throwable
       }
     }
 
@@ -187,15 +223,17 @@ class ApplicationService {
       }
       log.error("front50 query for a pipeline with id ${pipelineNameOrId} returned a pipeline with id ${pipelineConfig.id}")
     } catch (RetrofitError e) {
-      if ((e.getKind() == RetrofitError.Kind.HTTP) && (e.response.status == 404)) {
+      Throwable throwable = spinnakerRetrofitErrorHandler.handleError(e);
+      if (throwable instanceof SpinnakerHttpException && throwable.getResponseCode() == HttpStatus.NOT_FOUND.value()) {
         log.info("front50 returned no pipeline with id ${pipelineNameOrId}")
-      } else {
-        throw e
+        throw throwable.newInstance("Pipeline configuration not found (id: ${pipelineNameOrId}): " + throwable.getMessage())
       }
+      throw throwable
     }
 
-    // neither query by app + name nor id turned up a pipeline config
-    return null
+    // If we get here, the query by id returned a pipeline whose id didn't match
+    // what we asked for.
+    throw new NotFoundException("Pipeline configuration not found (id: ${pipelineNameOrId})")
   }
 
   List<Map> getStrategyConfigsForApplication(String app) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/PipelineService.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.gate.services.internal.EchoService
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
 import com.netflix.spinnaker.kork.core.RetrySupport
-import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import de.huxhorn.sulky.ulid.ULID
 import groovy.util.logging.Slf4j
@@ -93,9 +92,6 @@ class PipelineService {
 
   Map trigger(String application, String pipelineNameOrId, Map trigger) {
     def pipelineConfig = applicationService.getPipelineConfigForApplication(application, pipelineNameOrId)
-    if (!pipelineConfig) {
-      throw new NotFoundException("Pipeline configuration not found (id: ${pipelineNameOrId})")
-    }
     pipelineConfig.trigger = trigger
     if (trigger.notifications) {
       if (pipelineConfig.notifications) {

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/ApplicationServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate
 
+import com.google.gson.Gson
 import com.netflix.spinnaker.gate.config.ApplicationConfigurationProperties
 import com.netflix.spinnaker.gate.config.Service
 import com.netflix.spinnaker.gate.config.ServiceConfiguration
@@ -23,8 +24,11 @@ import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import retrofit.RetrofitError
 import retrofit.client.Response
+import retrofit.converter.GsonConverter
 import retrofit.mime.TypedByteArray
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -49,6 +53,10 @@ class ApplicationServiceSpec extends Specification {
       applicationConfigurationProperties
     )
     return service
+  }
+
+  void setup() {
+    println "--------------- Test " + specificationContext.currentIteration.name
   }
 
   void "should properly aggregate application data from Front50 and Clouddriver when useFront50AsSourceOfTruth: #useFront50AsSourceOfTruth"() {
@@ -488,17 +496,18 @@ class ApplicationServiceSpec extends Specification {
     1 * front50.getPipelineConfigById(nameOrId) >> [ id: "by-id", name: "by-name" ]
   }
 
-  void "getPipelineConfigForApplication returns no pipeline config when neither name nor id match"() {
+  void "getPipelineConfigForApplication throws an exception when neither name nor id match"() {
     given:
     def app = "theApp"
     def nameOrId = "not-id"
 
     when:
     def service = applicationService()
-    def result = service.getPipelineConfigForApplication(app, nameOrId)
+    service.getPipelineConfigForApplication(app, nameOrId)
 
     then:
-    result == null
+    def e = thrown SpinnakerHttpException
+    e.responseCode == 404
     1 * front50.getPipelineConfigByApplicationAndName(app, nameOrId, true) >> { throw retrofit404() }
     1 * front50.getPipelineConfigById(nameOrId) >> { throw retrofit404() }
   }
@@ -513,26 +522,26 @@ class ApplicationServiceSpec extends Specification {
     def result = service.getPipelineConfigForApplication(app, nameOrId)
 
     then:
-    result == null
+    result != null
     1 * front50.getPipelineConfigByApplicationAndName(app, nameOrId, true) >> [ id: "arbitrary-id", name: "some-other-name" ]
 
     // The key part of this test is that gate queries front50 by id.  The choice
-    // of id here needs to match the expectation for result (i.e. null or not),
+    // of id here needs to match the expectation for result (i.e. throw an exception or not),
     // but is otherwise arbitrary.
-    1 * front50.getPipelineConfigById(nameOrId) >> [ id: "arbitrary-id", name: "arbitrary-name" ]
+    1 * front50.getPipelineConfigById(nameOrId) >> [ id: nameOrId, name: "arbitrary-name" ]
   }
 
-  void "getPipelineConfigForApplication returns no config when response to query by id doesn't match"() {
+  void "getPipelineConfigForApplication throws an exception when response to query by id doesn't match"() {
     given:
     def app = "theApp"
     def nameOrId = "by-id"
 
     when:
     def service = applicationService()
-    def result = service.getPipelineConfigForApplication(app, nameOrId)
+    service.getPipelineConfigForApplication(app, nameOrId)
 
     then:
-    result == null
+    thrown NotFoundException
     1 * front50.getPipelineConfigByApplicationAndName(app, nameOrId, true) >> { throw retrofit404() }
     1 * front50.getPipelineConfigById(nameOrId) >> [ id: "some-other-id", name: "arbitrary-name" ]
   }
@@ -561,6 +570,6 @@ class ApplicationServiceSpec extends Specification {
   }
 
   def retrofit404(){
-    RetrofitError.httpError("http://localhost", new Response("http://localhost", 404, "Not Found", [], new TypedByteArray("application/json", new byte[0])), null, Map)
+    RetrofitError.httpError("http://localhost", new Response("http://localhost", 404, "Not Found", [], new TypedByteArray("application/json", new byte[0])), new GsonConverter(new Gson()), Map)
   }
 }

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/InvokePipelineConfigTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/InvokePipelineConfigTest.java
@@ -202,7 +202,14 @@ class InvokePipelineConfigTest {
         .perform(invokePipelineConfigRequest())
         .andDo(print())
         .andExpect(status().isNotFound())
-        .andExpect(status().reason("Pipeline configuration not found (id: " + PIPELINE_NAME + ")"))
+        .andExpect(
+            status()
+                .reason(
+                    "Unable to trigger pipeline (application: my-application, pipelineNameOrId: my-pipeline-name). Error: Pipeline configuration not found (id: "
+                        + PIPELINE_NAME
+                        + "): Status: 404, URL: "
+                        + wmFront50.baseUrl()
+                        + "/pipelines/my-pipeline-name/get, Message: message from front50"))
         .andExpect(header().string(REQUEST_ID.getHeader(), SUBMITTED_REQUEST_ID));
 
     verifyFront50PipelinesRequest();

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/InvokePipelineConfigTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/controllers/InvokePipelineConfigTest.java
@@ -210,60 +210,6 @@ class InvokePipelineConfigTest {
   }
 
   @Test
-  void invokePipelineConfig404ResponseFromFront50() throws Exception {
-
-    // Different than a 200 from front50 without the requested info, this test
-    // is about front50 responding with a 404.  Currently, front50's GET
-    // /pipelines/{app} endpoint doesn't generate a 404, but a request to an
-    // endpoint that doesn't exist does.  For example:
-    //
-    // $ curl -s http://localhost:8080/endpointDoesNotExist | python -mjson.tool
-    // {
-    //     "error": "Not Found",
-    //     "message": "No message available",
-    //     "status": 404,
-    //     "timestamp": "2023-04-07T17:51:22.560+00:00"
-    // }
-    //
-    // and
-    //
-    // $ curl -s -i http://localhost:8080/endpointDoesNotExist | head -1
-    // HTTP/1.1 404
-    Map<String, Object> front50Response =
-        Map.of(
-            "error",
-            "Not Found",
-            "message",
-            "message from front50",
-            "status",
-            404,
-            "timestamp",
-            "2023-04-07T17:51:22.560+00:00");
-    String front50ResponseJson = objectMapper.writeValueAsString(front50Response);
-    simulateFront50HttpResponse(HttpStatus.NOT_FOUND, front50ResponseJson);
-
-    // gate's 404 response in this case makes it difficult to distinguish
-    // between a 404 because the endpoint itself doesn't exist and a "real" 404
-    // -- one where all the requests are correct, but front50 doesn't know about
-    // the pipeline.  This seems fairly minor, and callers who want to
-    // distinguish can look at more of the resposne than the status code.
-    webAppMockMvc
-        .perform(invokePipelineConfigRequest())
-        .andDo(print())
-        .andExpect(status().isNotFound())
-        .andExpect(
-            status()
-                .reason(
-                    "Unable to trigger pipeline (application: my-application, pipelineNameOrId: my-pipeline-name). Error: Status: 404, URL: "
-                        + wmFront50.baseUrl()
-                        + "/pipelines/my-application?refresh=true, Message: message from front50"))
-        .andExpect(header().string(REQUEST_ID.getHeader(), SUBMITTED_REQUEST_ID));
-
-    verifyFront50PipelinesRequest();
-    verifyNoOrcaOrchestrateRequest();
-  }
-
-  @Test
   void invokePipelineConfigFront50BadRequest() throws Exception {
 
     // There are two different code paths for generating 400 responses from
@@ -313,7 +259,7 @@ class InvokePipelineConfigTest {
                 .reason(
                     "Unable to trigger pipeline (application: my-application, pipelineNameOrId: my-pipeline-name). Error: Status: 400, URL: "
                         + wmFront50.baseUrl()
-                        + "/pipelines/my-application?refresh=true, Message: message from front50"))
+                        + "/pipelines/my-application/name/my-pipeline-name?refresh=true, Message: message from front50"))
         .andExpect(header().string(REQUEST_ID.getHeader(), SUBMITTED_REQUEST_ID));
 
     verifyFront50PipelinesRequest();
@@ -366,7 +312,7 @@ class InvokePipelineConfigTest {
                 .reason(
                     "Unable to trigger pipeline (application: my-application, pipelineNameOrId: my-pipeline-name). Error: Status: 500, URL: "
                         + wmFront50.baseUrl()
-                        + "/pipelines/my-application?refresh=true, Message: jOOQ; message from front50"))
+                        + "/pipelines/my-application/name/my-pipeline-name?refresh=true, Message: jOOQ; message from front50"))
         .andExpect(header().string(REQUEST_ID.getHeader(), SUBMITTED_REQUEST_ID));
 
     verifyFront50PipelinesRequest();
@@ -501,22 +447,42 @@ class InvokePipelineConfigTest {
   /**
    * Simulate a successful response from front50. The actual response needs to be sufficient for
    * PipelineService.trigger to get far enough to call orca, which means we need a configuration for
-   * the pipeline we're triggering
+   * the pipeline we're triggering.
    */
   private void simulateFront50Success() throws JsonProcessingException {
-    List<Map<String, Object>> pipelineConfigs =
-        List.of(Map.of("id", PIPELINE_ID, "name", PIPELINE_NAME));
-    String pipelineConfigsJson = objectMapper.writeValueAsString(pipelineConfigs);
-    simulateFront50HttpResponse(HttpStatus.OK, pipelineConfigsJson);
+    Map<String, Object> pipelineConfig = Map.of("id", PIPELINE_ID, "name", PIPELINE_NAME);
+    String pipelineConfigJson = objectMapper.writeValueAsString(pipelineConfig);
+    simulateFront50HttpResponse(HttpStatus.OK, pipelineConfigJson);
   }
 
   /**
    * Simulate a response from front50 that doesn't contain a pipeline configuration for the test id
    */
   private void simulateFront50ResponseWithoutPipelineConfig() throws JsonProcessingException {
-    List<Map<String, Object>> pipelineConfigs = Collections.emptyList();
-    String pipelineConfigsJson = objectMapper.writeValueAsString(pipelineConfigs);
-    simulateFront50HttpResponse(HttpStatus.OK, pipelineConfigsJson);
+    // Currently front50 responds with a 404 when it doesn't contain a pipeline
+    // configuration for the given application + nameOrId as well as a query by
+    // pipeline id.
+    Map<String, Object> notFoundResponse =
+        Map.of(
+            "error",
+            "Not Found",
+            "message",
+            "message from front50",
+            "status",
+            404,
+            "timestamp",
+            "2023-04-07T17:51:22.560+00:00");
+    String notFoundResponseJson = objectMapper.writeValueAsString(notFoundResponse);
+    simulateFront50HttpResponse(HttpStatus.NOT_FOUND, notFoundResponseJson);
+
+    // When the query by application + nameOrId responds with 404, gate queries
+    // again by id.  Simulate a 404 response from that query as well.
+    wmFront50.stubFor(
+        WireMock.get(urlPathEqualTo("/pipelines/" + PIPELINE_NAME + "/get"))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.NOT_FOUND.value())
+                    .withBody(notFoundResponseJson)));
   }
 
   /**
@@ -531,8 +497,18 @@ class InvokePipelineConfigTest {
 
   /** Simulate a response from front50 */
   private void simulateFront50Response(ResponseDefinitionBuilder responseDefinitionBuilder) {
+    // This satisfies the queries that
+    // ApplicationService.getPipelineConfigForApplication makes to front50
+    //
+    // The first query is by application and name.  Since these tests use a
+    // pipeline name as the pipelineNameOrId argument to gate's
+    // invokePipelineConfig endpoint, this succeeds, and we can ignore the
+    // second query by pipeline id.
+    //
+    // What's important is that this method produces the desired return value or
+    // exception from ApplicationService.getPipelineConfigForApplication.
     wmFront50.stubFor(
-        WireMock.get(urlPathEqualTo("/pipelines/" + APPLICATION))
+        WireMock.get(urlPathEqualTo("/pipelines/" + APPLICATION + "/name/" + PIPELINE_NAME))
             .withQueryParam("refresh", anythingPattern)
             .willReturn(responseDefinitionBuilder));
   }
@@ -581,7 +557,7 @@ class InvokePipelineConfigTest {
    */
   private void verifyFront50PipelinesRequest() {
     wmFront50.verify(
-        getRequestedFor(urlPathEqualTo("/pipelines/" + APPLICATION))
+        getRequestedFor(urlPathEqualTo("/pipelines/" + APPLICATION + "/name/" + PIPELINE_NAME))
             .withQueryParam("refresh", anythingPattern)
             .withHeader(USER.getHeader(), equalTo(USERNAME)));
   }


### PR DESCRIPTION
- Adjust error message in PipelineController.invokePipelineConfig and use pipeline name instead of id in InvokePipelineConfigTest to reduce diffs when ApplicationService.getPipelineConfigForApplication changes the queries it makes to front50

- Change ApplicationService.getPipelineConfigForApplication to query front50 for individual pipelines instead of querying for all pipelines in an application and then filtering locally.

- Teach ApplicationService.getPipelineConfigForApplication to handle errors with SpinnakerRetrofitErrorHandler to centralize exception handling there / remove the need for callers to check for null