### PR TITLE
feat(pipelines): add pipelineNameFilter to /{application}/pipelineConfigs endpoint

### DIFF
--- a/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
+++ b/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/Front50Service.java
@@ -42,7 +42,9 @@ public interface Front50Service {
 
   @GET("/pipelines/{app}")
   List<Map> getPipelineConfigsForApplication(
-      @Path("app") String app, @Query("refresh") boolean refresh);
+      @Path("app") String app,
+      @Query("pipelineNameFilter") String pipelineNameFilter,
+      @Query("refresh") boolean refresh);
 
   @GET("/pipelines/{app}/name/{name}")
   Map getPipelineConfigByApplicationAndName(

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/ApplicationController.groovy
@@ -135,8 +135,9 @@ class ApplicationController {
 
   @ApiOperation(value = "Retrieve a list of an application's pipeline configurations", response = List.class)
   @RequestMapping(value = "/{application}/pipelineConfigs", method = RequestMethod.GET)
-  List getPipelineConfigsForApplication(@PathVariable("application") String application) {
-    applicationService.getPipelineConfigsForApplication(application)
+  List getPipelineConfigsForApplication(@PathVariable("application") String application,
+                                        @RequestParam(required = false, value="pipelineNameFilter") String pipelineNameFilter) {
+    applicationService.getPipelineConfigsForApplication(application, pipelineNameFilter)
   }
 
   @ApiOperation(value = "Retrieve a pipeline configuration", response = HashMap.class)

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy
@@ -75,7 +75,7 @@ class PipelineController {
   @ApiOperation(value = "Delete a pipeline definition")
   @DeleteMapping("/{application}/{pipelineName:.+}")
   void deletePipeline(@PathVariable String application, @PathVariable String pipelineName) {
-    List<Map> pipelineConfigs = front50Service.getPipelineConfigsForApplication(application, true)
+    List<Map> pipelineConfigs = front50Service.getPipelineConfigsForApplication(application, null, true)
     if (pipelineConfigs!=null && !pipelineConfigs.isEmpty()){
       Optional<Map> filterResult = pipelineConfigs.stream().filter({ pipeline -> ((String) pipeline.get("name")) != null && ((String) pipeline.get("name")).trim().equalsIgnoreCase(pipelineName) }).findFirst()
       if (filterResult.isPresent()){
@@ -220,7 +220,7 @@ class PipelineController {
       )
     }
 
-    return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"), true)?.find {
+    return front50Service.getPipelineConfigsForApplication((String) pipeline.get("application"), null, true)?.find {
       id == (String) it.get("id")
     }
   }
@@ -259,7 +259,7 @@ class PipelineController {
     String pipelineName = pipelineMap.get("name");
     String application = pipelineMap.get("application");
 
-    List<Map> pipelineConfigs = front50Service.getPipelineConfigsForApplication(application, true)
+    List<Map> pipelineConfigs = front50Service.getPipelineConfigsForApplication(application, null, true)
 
     if (pipelineConfigs!=null && !pipelineConfigs.isEmpty()){
       Optional<Map> filterResult = pipelineConfigs.stream()

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/ApplicationService.groovy
@@ -150,7 +150,11 @@ class ApplicationService {
   }
 
   List<Map> getPipelineConfigsForApplication(String app) {
-    return front50Service.getPipelineConfigsForApplication(app, true)
+    return getPipelineConfigsForApplication(app, null);
+  }
+
+  List<Map> getPipelineConfigsForApplication(String app, String pipelineNameFilter) {
+    return front50Service.getPipelineConfigsForApplication(app, pipelineNameFilter, true)
   }
 
   /**

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/PipelineControllerSpec.groovy
@@ -91,7 +91,7 @@ class PipelineControllerSpec extends Specification {
         ]
       ]
     ]) >> { [id: 'task-id', application: 'application', status: 'SUCCEEDED'] }
-    1 * front50Service.getPipelineConfigsForApplication('application', true) >> []
+    1 * front50Service.getPipelineConfigsForApplication('application', null, true) >> []
   }
 
   def "should propagate pipeline template errors"() {


### PR DESCRIPTION
This plumbs through the new pipelineNameFilter query param to the front50 service call in gate. 
Front50 changes were added as part of https://github.com/spinnaker/front50/pull/1504


