### PR TITLE
chore(web): remove unused code from CleanupService

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/services/CleanupService.java
@@ -54,15 +54,6 @@ public class CleanupService {
     }
   }
 
-  public String restore(String namespace, String resourceId) {
-    try {
-      swabbieService.restore(namespace, resourceId, "");
-    } catch (RetrofitError e) {
-      return Integer.toString(e.getResponse().getStatus());
-    }
-    return "200";
-  }
-
   public List getMarkedList() {
     return swabbieService.getMarkedList(true);
   }


### PR DESCRIPTION
While working on moving from RetrofitError to SpinnakerServerException(and its subclasses), found an unused method that has RetrofitError handling incorrectly done.   Thos PR removes the method.