### PR TITLE
refactor(retrofit): replace OkClient with Ok3Client

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PagerDutyConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PagerDutyConfig.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.gate.config
 
+import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.gate.services.PagerDutyService
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Value
@@ -25,7 +26,6 @@ import org.springframework.context.annotation.Configuration
 import retrofit.Endpoint
 import retrofit.RequestInterceptor
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 
 import static retrofit.Endpoints.newFixedEndpoint
@@ -56,7 +56,7 @@ class PagerDutyConfig {
   PagerDutyService pagerDutyService(Endpoint pagerDutyEndpoint) {
     new RestAdapter.Builder()
       .setEndpoint(pagerDutyEndpoint)
-      .setClient(new OkClient())
+      .setClient(new Ok3Client())
       .setConverter(new JacksonConverter())
       .setRequestInterceptor(requestInterceptor)
       .build()

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/FunctionalSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.ErrorConfiguration
 import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
@@ -41,7 +42,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import retrofit.RetrofitError
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 import retrofit.mime.TypedInput
 import spock.lang.Shared
@@ -116,7 +116,7 @@ class FunctionalSpec extends Specification {
     def localPort = ctx.environment.getProperty("local.server.port")
     api = new RestAdapter.Builder()
         .setEndpoint("http://localhost:${localPort}")
-        .setClient(new OkClient())
+        .setClient(new Ok3Client())
         .setConverter(new JacksonConverter())
         .setLogLevel(RestAdapter.LogLevel.FULL)
         .build()

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.gate.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.gate.services.WebhookService
 import com.netflix.spinnaker.gate.services.internal.EchoService
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
@@ -29,7 +30,6 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.util.NestedServletException
 import retrofit.RestAdapter
-import retrofit.client.OkClient
 import retrofit.converter.JacksonConverter
 import spock.lang.Specification
 
@@ -54,7 +54,7 @@ class WebhooksControllerSpec extends Specification {
 
     EchoService echoService = new RestAdapter.Builder()
       .setEndpoint("http://localhost:${localPort}")
-      .setClient(new OkClient())
+      .setClient(new Ok3Client())
       .setConverter(new JacksonConverter())
       .build()
       .create(EchoService)


### PR DESCRIPTION
Moving away from `com.squareup.okhttp.OkHttpClient` to `okhttp3.OkHttpClient` to avoid any unwanted dependency conflicts.

okhttp3.OkHttpClient for retrofit1 is provided by [Ok3Client](https://github.com/JakeWharton/retrofit1-okhttp3-client)