### PR TITLE
refactor(retrofit): remove all com.squareup.okhttp dependencies

### DIFF
--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -25,9 +25,6 @@ dependencies {
   implementation "io.spinnaker.kork:kork-plugins"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
   implementation "com.squareup.retrofit:converter-jackson"
-  implementation "com.squareup.okhttp:okhttp"
-  implementation "com.squareup.okhttp:okhttp-urlconnection"
-  implementation "com.squareup.okhttp:okhttp-apache"
 
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"

--- a/gate-proxy/gate-proxy.gradle
+++ b/gate-proxy/gate-proxy.gradle
@@ -8,7 +8,6 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-web"
   implementation "com.squareup.retrofit:retrofit"
-  implementation "com.squareup.okhttp:okhttp"
   implementation "com.netflix.spectator:spectator-api"
   implementation "com.google.guava:guava"
 }

--- a/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionController.kt
+++ b/gate-proxy/src/main/kotlin/com/netflix/spinnaker/gate/controllers/ApiExtensionController.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.kork.annotations.Alpha
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
-import com.squareup.okhttp.internal.http.HttpMethod
+import okhttp3.internal.http.HttpMethod
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
@@ -74,10 +74,11 @@ class ApiExtensionController @Autowired constructor(private val apiExtensionsPro
 
     if (HttpMethod.permitsRequestBody(httpRequest.method)) {
       try {
-        httpRequest.body = httpServletRequest
-          .reader
-          .lines()
-          .collect(Collectors.joining(System.lineSeparator()))
+        httpRequest.body = if (httpServletRequest.contentLength > 0) {
+          httpServletRequest.reader.readText()
+        } else {
+          ""
+        }
       } catch (e: IOException) {
         throw SpinnakerException("Unable to read request body", e)
       }

--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -21,10 +21,6 @@ dependencies {
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
-  implementation "com.squareup.okhttp:okhttp"
-  implementation "com.squareup.okhttp:okhttp-urlconnection"
-  implementation "com.squareup.okhttp:okhttp-apache"
-
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
 
@@ -69,7 +65,7 @@ dependencies {
   testImplementation project(":gate-basic")
   testImplementation project(":gate-oauth2")
   testImplementation "com.github.tomakehurst:wiremock-jre8-standalone"
-  testImplementation "com.squareup.okhttp:mockwebserver"
+  testImplementation "com.squareup.okhttp3:mockwebserver"
 
   testImplementation "com.squareup.retrofit:retrofit-mock"
   testImplementation "org.springframework.security:spring-security-test"

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/ApplicationControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/ApplicationControllerSpec.groovy
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.gate.services.ApplicationService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
 import com.netflix.spinnaker.gate.services.internal.ClouddriverServiceSelector
 import com.netflix.spinnaker.gate.services.internal.Front50Service
-import com.squareup.okhttp.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/AwsCodeBuildControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/AwsCodeBuildControllerSpec.groovy
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.gate.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.gate.services.internal.IgorService
-import com.squareup.okhttp.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MockMvc

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/BuildControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/BuildControllerSpec.groovy
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.gate.controllers
 
 import com.netflix.spinnaker.gate.services.BuildService
 import com.netflix.spinnaker.gate.services.internal.IgorService
-import com.squareup.okhttp.mockwebserver.MockWebServer
 import groovy.json.JsonSlurper
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MockMvc

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/EcsClusterControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/EcsClusterControllerSpec.groovy
@@ -18,8 +18,8 @@ package com.netflix.spinnaker.gate.controllers
 import com.netflix.spinnaker.gate.services.EcsClusterService
 import com.netflix.spinnaker.gate.controllers.ecs.EcsClusterController
 import com.netflix.spinnaker.gate.services.internal.ClouddriverService
-import com.squareup.okhttp.mockwebserver.MockWebServer
 import groovy.json.JsonSlurper
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MockMvc

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/GoogleCloudBuildControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/GoogleCloudBuildControllerSpec.groovy
@@ -21,8 +21,7 @@ import com.netflix.spinnaker.gate.services.BuildService
 import com.netflix.spinnaker.gate.services.internal.GoogleCloudBuildTrigger
 import com.netflix.spinnaker.gate.services.internal.IgorService
 import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException
-import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerServerException
-import com.squareup.okhttp.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.web.servlet.MockMvc

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/controllers/WebhookControllerSpec.groovy
@@ -21,8 +21,8 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.gate.services.WebhookService
 import com.netflix.spinnaker.gate.services.internal.EchoService
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector
-import com.squareup.okhttp.mockwebserver.MockWebServer
 import io.cloudevents.spring.mvc.CloudEventHttpMessageConverter
+import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse


### PR DESCRIPTION
All references to com.squareup.okhttp will be removed with this PR.

ApiExtensionController needed minor refactoring to fix the following error caused due to kotlin-java conflicts:

```
class java.lang.Object cannot be cast to class java.lang.String (java.lang.Object and java.lang.String are in module java.base of loader 'bootstrap')
  java.lang.ClassCastException: class java.lang.Object cannot be cast to class java.lang.String (java.lang.Object and java.lang.String are in module java.base of loader 'bootstrap')
  at com.netflix.spinnaker.gate.controllers.ApiExtensionController.any(ApiExtensionController.kt:80)
  at com.netflix.spinnaker.gate.controllers.ApiExtensionControllerTest$tests$1$3$2.invoke(ApiExtensionControllerTest.kt:61)
  at com.netflix.spinnaker.gate.controllers.ApiExtensionControllerTest$tests$1$3$2.invoke(ApiExtensionControllerTest.kt:59)
```

Refer https://github.com/spinnaker/kork/pull/1210 for kork PR which completes the removal of okhttp2 dependencies. 
