### PR TITLE
fix(swagger): ensure byteArrayHttpMessageConverter is the first converter to render swagger UI

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/CloudEventHandlerConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/CloudEventHandlerConfiguration.java
@@ -28,17 +28,16 @@ public class CloudEventHandlerConfiguration implements WebMvcConfigurer {
 
   @Override
   public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-    converters.add(0, byteArrayHttpMessageConverter());
+    converters.add(
+        0,
+        new ByteArrayHttpMessageConverter()); // adding ByteArrayHttpMessageConverter as the first
+    // element to avoid Swagger decode issues. See:
+    // https://github.com/springdoc/springdoc-openapi/issues/2143
     converters.add(cloudEventHttpMessageConverter());
   }
 
   @Bean
   public CloudEventHttpMessageConverter cloudEventHttpMessageConverter() {
     return new CloudEventHttpMessageConverter();
-  }
-
-  @Bean
-  public ByteArrayHttpMessageConverter byteArrayHttpMessageConverter() {
-    return new ByteArrayHttpMessageConverter();
   }
 }

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/CloudEventHandlerConfiguration.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/CloudEventHandlerConfiguration.java
@@ -19,6 +19,7 @@ import io.cloudevents.spring.mvc.CloudEventHttpMessageConverter;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -27,11 +28,17 @@ public class CloudEventHandlerConfiguration implements WebMvcConfigurer {
 
   @Override
   public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+    converters.add(0, byteArrayHttpMessageConverter());
     converters.add(cloudEventHttpMessageConverter());
   }
 
   @Bean
   public CloudEventHttpMessageConverter cloudEventHttpMessageConverter() {
     return new CloudEventHttpMessageConverter();
+  }
+
+  @Bean
+  public ByteArrayHttpMessageConverter byteArrayHttpMessageConverter() {
+    return new ByteArrayHttpMessageConverter();
   }
 }

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gate.config;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.netflix.spinnaker.gate.Main;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = Main.class)
+@ActiveProfiles("swaggertest")
+@TestPropertySource(properties = {"spring.config.location=classpath:gate-test.yml"})
+public class GateSwaggerConfigTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  private static final String OPENAPI_API_PATH = "/v3/api-docs";
+
+  @Test
+  void TestSwaggerEndpointIsOk() throws Exception {
+    mockMvc
+        .perform(get(OPENAPI_API_PATH))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.openapi", startsWith("3."))) // validates we use version 3.x.x from kork
+        .andExpect(jsonPath("$.info.title", is("Spinnaker Test")));
+  }
+}

--- a/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
+++ b/gate-web/src/test/java/com/netflix/spinnaker/gate/config/GateSwaggerConfigTest.java
@@ -43,7 +43,7 @@ public class GateSwaggerConfigTest {
   private static final String OPENAPI_API_PATH = "/v3/api-docs";
 
   @Test
-  void TestSwaggerEndpointIsOk() throws Exception {
+  void TestSwaggerDocsIsNotMalformed() throws Exception {
     mockMvc
         .perform(get(OPENAPI_API_PATH))
         .andDo(print())

--- a/gate-web/src/test/resources/gate-test.yml
+++ b/gate-web/src/test/resources/gate-test.yml
@@ -72,3 +72,18 @@ spinnaker:
       front50:
         enabled: true
         url: https://front50.net
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: swaggertest
+
+swagger:
+  enabled: true
+  title: Spinnaker Test
+  description:
+  contact:
+  patterns:
+    - /test


### PR DESCRIPTION
Starting in 1.36.x Swagger UI in Gate fails on loading the swagger ui with the follow:
![Screenshot 2025-02-07 at 15 12 49](https://github.com/user-attachments/assets/e0abdcb9-76d1-4b97-9155-6226f81d914e)

the main issue is that the JSON from swagger-ui is encoded in base64.

After some investigation I found this error was reported in the following Github issue: https://github.com/springdoc/springdoc-openapi/issues/2143

In a few words, the ByteArrayHttpMessageConverter is responsible on deserialize the swagger JSON but it needs to be at the beginning of the converters. My fix just creates a ByteArrayHttpMessageConverter bean at set it as the first messageConverters. 
