### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY gate-web/build/install/gate /opt/gate
 RUN mkdir -p /opt/gate/plugins && chown -R spinnaker:nogroup /opt/gate/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#10 97.63 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#10 97.71 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 98.12 Segmentation fault (core dumped)
#10 98.17 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 98.55 Segmentation fault (core dumped)
#10 98.56 dpkg: error processing package libc-bin (--configure):
#10 98.56  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/gate/actions/runs/13294117905/job/37121769288?pr=1868

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834